### PR TITLE
Allow zero gas for offline signing

### DIFF
--- a/packages/hooks/src/tx/gas.ts
+++ b/packages/hooks/src/tx/gas.ts
@@ -30,8 +30,8 @@ export class GasConfig extends TxChainSetter implements IGasConfig {
   }
 
   getError(): Error | undefined {
-    if (this.gas <= 0) {
-      return new Error("Gas should be greater than 0");
+    if (this.gas < 0) {
+      return new Error("Gas cannot be negative");
     }
     return;
   }


### PR DESCRIPTION
I've been looking into the offline signing and the signed typed data and have found ADR36, which seems to be in Draft but coming along.

Broadly, this means people can use the Keplr wallet to sign arbitrary messages. This is common in web3 wallet logins, like is mentioned for the [Sign-in with Ethereum](https://github.com/ethereum/EIPs/blob/9a9c5d0abdaf5ce5c5dd6dc88c6d8db1b130e95b/EIPS/eip-4361.md#technical-decisions) initiative.

If you look at the [**Decisions** section of ADR36](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-036-arbitrary-signature.md#decision), we'll see:

>fee gas must be equal to 0

Since there is no interaction with the blockchain, this makes sense. It's just using the private key to sign something (typically some salt or something unique and time-locked) and use normal cryptography methods to verify the signer and so on.

When I try attaching 0 gas I get:

<img width="361" alt="Screen Shot 2021-11-20 at 8 19 57 AM" src="https://user-images.githubusercontent.com/1042667/143731585-d438dc1f-b0f4-473e-a500-44b92c045e1f.png">

`input.fee.error.unknown`

I tracked it down starting here:
https://github.com/chainapsis/keplr-extension/blob/5295e9b866f01459b7809b54b6cf9c146b115721/packages/extension/src/components/form/fee-buttons/fee-buttons.tsx#L153-L168

and then I believe the culprit is here:
https://github.com/chainapsis/keplr-extension/blob/5295e9b866f01459b7809b54b6cf9c146b115721/packages/hooks/src/tx/gas.ts#L32-L35

I tried to follow the directions in the README to build a local extension, but was unable to get it built.

For now I'm attaching 1 gas and it works. Seems like whether it's ADR36 or another standard, we'll need to allow zero gas for offline signing, hence this tiny, itty-bitty PR.