### PR TITLE
add rizon extension config

### DIFF
--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -75,6 +75,10 @@ import {
   AGORIC_RPC_CONFIG,
   AGORIC_REST_ENDPOINT,
   AGORIC_REST_CONFIG,
+  RIZON_RPC_ENDPOINT,
+  RIZON_RPC_CONFIG,
+  RIZON_REST_ENDPOINT,
+  RIZON_REST_CONFIG,
 } from "./config.var";
 
 export const EmbedChainInfos: ChainInfo[] = [
@@ -1223,6 +1227,49 @@ export const EmbedChainInfos: ChainInfo[] = [
       high: 0.04 * Math.pow(10, 12),
     },
     beta: true,
+  },
+  {
+    rpc: RIZON_RPC_ENDPOINT,
+    rpcConfig: RIZON_RPC_CONFIG,
+    rest: RIZON_REST_ENDPOINT,
+    restConfig: RIZON_REST_CONFIG,
+    chainId: "titan-1",
+    chainName: "RIZON",
+    stakeCurrency: {
+      coinDenom: "ATOLO",
+      coinMinimalDenom: "uatolo",
+      coinDecimals: 6,
+      coinGeckoId: "rizon",
+    },
+    walletUrl:
+      process.env.NODE_ENV === "production"
+        ? "https://wallet.cosmostation.io/rizon"
+        : "http://localhost:8080/#/rizon/stake",
+    walletUrlForStaking:
+      process.env.NODE_ENV === "production"
+        ? "https://wallet.cosmostation.io/rizon"
+        : "http://localhost:8080/#/rizon/stake",
+    bip44: {
+      coinType: 118,
+    },
+    bech32Config: Bech32Address.defaultBech32Config("rizon"),
+    currencies: [
+      {
+        coinDenom: "ATOLO",
+        coinMinimalDenom: "uatolo",
+        coinDecimals: 6,
+        coinGeckoId: "rizon",
+      },
+    ],
+    feeCurrencies: [
+      {
+        coinDenom: "ATOLO",
+        coinMinimalDenom: "uatolo",
+        coinDecimals: 6,
+        coinGeckoId: "rizon",
+      },
+    ],
+    features: ["stargate", "ibc-transfer"],
   },
 ];
 

--- a/packages/extension/src/config.var.example.ts
+++ b/packages/extension/src/config.var.example.ts
@@ -113,4 +113,9 @@ export const AGORIC_RPC_CONFIG: AxiosRequestConfig | undefined = undefined;
 export const AGORIC_REST_ENDPOINT = "";
 export const AGORIC_REST_CONFIG: AxiosRequestConfig | undefined = undefined;
 
+export const RIZON_RPC_ENDPOINT = "";
+export const RIZON_RPC_CONFIG: AxiosRequestConfig | undefined = undefined;
+export const RIZON_REST_ENDPOINT = "";
+export const RIZON_REST_CONFIG: AxiosRequestConfig | undefined = undefined;
+
 export const PRIVILEGED_ORIGINS: string[] = [];


### PR DESCRIPTION
- Add rizon to extension/src/config.ts
- Add rizon to extension/src/config.var.example.ts

The mainnet rpc/rest endpoint url is as follows:
```typescript
export const RIZON_RPC_ENDPOINT = "http://seed-1.mainnet.rizon.world:26657";
export const RIZON_RPC_CONFIG: AxiosRequestConfig | undefined = undefined;
export const RIZON_REST_ENDPOINT = "http://seed-1.mainnet.rizon.world:1317";
export const RIZON_REST_CONFIG: AxiosRequestConfig | undefined = undefined;
```