### PR TITLE
Extension Terra support

### DIFF
--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -1272,6 +1272,63 @@ export const EmbedChainInfos: ChainInfo[] = [
     },
     beta: true,
   },
+  {
+    rpc: "https://rpc-columbus.keplr.app",
+    rest: "https://lcd-columbus.keplr.app",
+    chainId: "columbus-5",
+    chainName: "Terra",
+    stakeCurrency: {
+      coinDenom: "LUNA",
+      coinMinimalDenom: "uluna",
+      coinDecimals: 6,
+      coinGeckoId: "terra-luna",
+    },
+    bip44: {
+      coinType: 330,
+    },
+    bech32Config: Bech32Address.defaultBech32Config("terra"),
+    currencies: [
+      {
+        coinDenom: "LUNA",
+        coinMinimalDenom: "uluna",
+        coinDecimals: 6,
+        coinGeckoId: "terra-luna",
+      },
+      {
+        coinDenom: "UST",
+        coinMinimalDenom: "uusd",
+        coinDecimals: 6,
+        coinGeckoId: "terrausd",
+      },
+      {
+        coinDenom: "KRT",
+        coinMinimalDenom: "ukrw",
+        coinDecimals: 6,
+        coinGeckoId: "terrakrw",
+      },
+    ],
+    feeCurrencies: [
+      {
+        coinDenom: "LUNA",
+        coinMinimalDenom: "uluna",
+        coinDecimals: 6,
+        coinGeckoId: "terra-luna",
+      },
+      {
+        coinDenom: "UST",
+        coinMinimalDenom: "uusd",
+        coinDecimals: 6,
+        coinGeckoId: "terrausd",
+      },
+    ],
+    gasPriceStep: {
+      low: 0.015,
+      average: 0.015,
+      high: 0.015,
+    },
+    features: ["stargate", "ibc-transfer", "no-legacy-stdTx"],
+    hideInUI: true,
+  },
 ];
 
 // The origins that are able to pass any permission that external webpages can have.


### PR DESCRIPTION
Hello, I'm a Kava developer and we are currently in the process of adding IBC support to [Kava](https://kava.io). We'd like to include Keplr Terra LUNA support. We used this config to enable support with experimental suggest chain, but it would be better if this was included in Keplr itself.

I simply used the existing terra config from the keplr mobile config.ts and put it in extension's config.ts. 

This config works for me when I use experimental suggest chain