### PR TITLE
update Kava chainId for mainnet upgrade

### DIFF
--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -1087,7 +1087,7 @@ export const EmbedChainInfos: ChainInfo[] = [
     rpcConfig: KAVA_RPC_CONFIG,
     rest: KAVA_REST_ENDPOINT,
     restConfig: KAVA_REST_CONFIG,
-    chainId: "kava-8",
+    chainId: "kava-9",
     chainName: "Kava",
     stakeCurrency: {
       coinDenom: "KAVA",


### PR DESCRIPTION
Kava-Labs is upgrading our mainnet today. (release is almost complete at the time of writing this).

Previous Chain ID: `kava-8`
New Chain ID: `kava-9`

I will follow up with a comment on here once the update is complete so this can be reviewed and merged
