### PR TITLE
Scale evmos gas-prices

### DIFF
--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -1677,9 +1677,9 @@ export const EmbedChainInfos: ChainInfo[] = [
       },
     ],
     gasPriceStep: {
-      low: 0.005,
-      average: 0.025,
-      high: 0.04,
+      low: 5000000000,
+      average: 25000000000,
+      high: 40000000000,
     },
     features: ["ibc-transfer", "stargate", "no-legacy-stdTx", "ibc-go"],
     beta: true,


### PR DESCRIPTION
Evmos has 18 decimals and not 6 like other cosmos chains.

gas-prices `0.025` should be `25000000000`, etc

![image](https://user-images.githubusercontent.com/14926587/156025980-2fec1c5f-64d6-486a-a424-cbb5f5e268c0.png)

> Crypto.com Cronos uses `5000000000000basecro` as gas-prices