### PR TITLE
Ethereum Keys - Fix coin type check on broadcast

### DIFF
--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -450,7 +450,7 @@ export class AccountSetBase<MsgOpts, Queries> {
       true
     );
 
-    const coinType = this.chainGetter.getChain(this.chainId).coinType;
+    const coinType = this.chainGetter.getChain(this.chainId).bip44.coinType;
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const keplr = (await this.getKeplr())!;


### PR DESCRIPTION
Solves the below due to not properly getting `coinType`

![image](https://user-images.githubusercontent.com/11379797/156871466-23f01740-2d03-4c42-aadf-c3181497c01e.png)

