### PR TITLE
Disable ledger accounts for Ethereum chains

### DIFF
--- a/packages/background/src/keyring/keyring.ts
+++ b/packages/background/src/keyring/keyring.ts
@@ -585,6 +585,12 @@ export class KeyRing {
         throw new Error("Ledger public key not set");
       }
 
+      if (coinType === 60) {
+        throw new Error(
+          "Ledger is not compatible with this coinType right now"
+        );
+      }
+
       const pubKey = new PubKeySecp256k1(this.ledgerPublicKey);
 
       return {

--- a/packages/extension/src/pages/main/account.module.scss
+++ b/packages/extension/src/pages/main/account.module.scss
@@ -24,3 +24,12 @@
 
   cursor: pointer;
 }
+
+.unsupported-key-message {
+  margin-top: 2px;
+
+  font-size: 12px;
+  color: #474747;
+
+  text-align: center;
+}

--- a/packages/extension/src/pages/main/account.module.scss
+++ b/packages/extension/src/pages/main/account.module.scss
@@ -25,11 +25,13 @@
   cursor: pointer;
 }
 
-.unsupported-key-message {
-  margin-top: 2px;
+:global(.popper) {
+  font-size: 14px;
+  min-width: 140px;
+  text-align: center;
+}
 
-  font-size: 12px;
-  color: #474747;
-
+.unsupported-key-icon {
+  width: 100%;
   text-align: center;
 }

--- a/packages/extension/src/pages/main/account.tsx
+++ b/packages/extension/src/pages/main/account.tsx
@@ -50,13 +50,13 @@ export const AccountView: FunctionComponent = observer(() => {
               intl.formatMessage({
                 id: "setting.keyring.unnamed-account",
               })
-            : accountInfo.walletStatus === WalletStatus.Rejected
-            ? "Unsupported Key"
+            : accountInfo.isWalletRejectedWithError
+            ? "Unable to Load Key"
             : "Loading..."}
         </div>
         <div style={{ flex: 1 }} />
       </div>
-      {accountInfo.walletStatus === WalletStatus.Rejected && (
+      {accountInfo.isWalletRejectedWithError && (
         <ToolTip
           tooltip="Could not load public key for this device"
           theme="dark"

--- a/packages/extension/src/pages/main/account.tsx
+++ b/packages/extension/src/pages/main/account.tsx
@@ -49,6 +49,8 @@ export const AccountView: FunctionComponent = observer(() => {
               intl.formatMessage({
                 id: "setting.keyring.unnamed-account",
               })
+            : WalletStatus.Rejected
+            ? "Key Rejected"
             : "Loading..."}
         </div>
         <div style={{ flex: 1 }} />

--- a/packages/extension/src/pages/main/account.tsx
+++ b/packages/extension/src/pages/main/account.tsx
@@ -49,27 +49,34 @@ export const AccountView: FunctionComponent = observer(() => {
               intl.formatMessage({
                 id: "setting.keyring.unnamed-account",
               })
-            : WalletStatus.Rejected
-            ? "Key Rejected"
+            : accountInfo.walletStatus === WalletStatus.Rejected
+            ? "Unsupported Key"
             : "Loading..."}
         </div>
         <div style={{ flex: 1 }} />
       </div>
-      <div className={styleAccount.containerAccount}>
-        <div style={{ flex: 1 }} />
-        <div
-          className={styleAccount.address}
-          onClick={() => copyAddress(accountInfo.bech32Address)}
-        >
-          <Address maxCharacters={22} lineBreakBeforePrefix={false}>
-            {accountInfo.walletStatus === WalletStatus.Loaded &&
-            accountInfo.bech32Address
-              ? accountInfo.bech32Address
-              : "..."}
-          </Address>
+      {accountInfo.walletStatus === WalletStatus.Rejected && (
+        <div className={styleAccount.unsupportedKeyMessage}>
+          This keytype is currently not supported
         </div>
-        <div style={{ flex: 1 }} />
-      </div>
+      )}
+      {accountInfo.walletStatus !== WalletStatus.Rejected && (
+        <div className={styleAccount.containerAccount}>
+          <div style={{ flex: 1 }} />
+          <div
+            className={styleAccount.address}
+            onClick={() => copyAddress(accountInfo.bech32Address)}
+          >
+            <Address maxCharacters={22} lineBreakBeforePrefix={false}>
+              {accountInfo.walletStatus === WalletStatus.Loaded &&
+              accountInfo.bech32Address
+                ? accountInfo.bech32Address
+                : "..."}
+            </Address>
+          </div>
+          <div style={{ flex: 1 }} />
+        </div>
+      )}
       {accountInfo.hasEvmosHexAddress && (
         <div
           className={styleAccount.containerAccount}

--- a/packages/extension/src/pages/main/account.tsx
+++ b/packages/extension/src/pages/main/account.tsx
@@ -7,6 +7,7 @@ import styleAccount from "./account.module.scss";
 import { observer } from "mobx-react-lite";
 import { useStore } from "../../stores";
 import { useNotification } from "../../components/notification";
+import { ToolTip } from "../../components/tooltip";
 import { useIntl } from "react-intl";
 import { WalletStatus } from "@keplr-wallet/stores";
 
@@ -56,9 +57,18 @@ export const AccountView: FunctionComponent = observer(() => {
         <div style={{ flex: 1 }} />
       </div>
       {accountInfo.walletStatus === WalletStatus.Rejected && (
-        <div className={styleAccount.unsupportedKeyMessage}>
-          This keytype is currently not supported
-        </div>
+        <ToolTip
+          tooltip="Could not load public key for this device"
+          theme="dark"
+          trigger="hover"
+          options={{
+            placement: "top",
+          }}
+        >
+          <i
+            className={`fas fa-exclamation-triangle text-danger ${styleAccount.unsupportedKeyIcon}`}
+          />
+        </ToolTip>
       )}
       {accountInfo.walletStatus !== WalletStatus.Rejected && (
         <div className={styleAccount.containerAccount}>

--- a/packages/extension/src/pages/main/index.tsx
+++ b/packages/extension/src/pages/main/index.tsx
@@ -23,6 +23,7 @@ import { ChainUpdaterService } from "@keplr-wallet/background";
 import { IBCTransferView } from "./ibc-transfer";
 import { DenomHelper } from "@keplr-wallet/common";
 import { Dec } from "@keplr-wallet/unit";
+import { WalletStatus } from "@keplr-wallet/stores";
 
 export const MainPage: FunctionComponent = observer(() => {
   const history = useHistory();
@@ -119,7 +120,9 @@ export const MainPage: FunctionComponent = observer(() => {
           <div className={style.containerAccountInner}>
             <AccountView />
             <AssetView />
-            <TxButtonView />
+            {accountInfo.walletStatus !== WalletStatus.Rejected && (
+              <TxButtonView />
+            )}
           </div>
         </CardBody>
       </Card>

--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -220,13 +220,23 @@ export class AccountSetBase<MsgOpts, Queries> {
       return;
     }
 
-    const key = yield* toGenerator(keplr.getKey(this.chainId));
-    this._bech32Address = key.bech32Address;
-    this._name = key.name;
-    this.pubKey = key.pubKey;
+    try {
+      const key = yield* toGenerator(keplr.getKey(this.chainId));
+      this._bech32Address = key.bech32Address;
+      this._name = key.name;
+      this.pubKey = key.pubKey;
 
-    // Set the wallet status as loaded after getting all necessary infos.
-    this._walletStatus = WalletStatus.Loaded;
+      // Set the wallet status as loaded after getting all necessary infos.
+      this._walletStatus = WalletStatus.Loaded;
+    } catch {
+      // Caught error loading key
+      // Reset properties, and set status to Rejected
+      this._bech32Address = "";
+      this._name = "";
+      this.pubKey = new Uint8Array(0);
+
+      this._walletStatus = WalletStatus.Rejected;
+    }
   }
 
   @action

--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -86,6 +86,9 @@ export class AccountSetBase<MsgOpts, Queries> {
   protected _walletStatus: WalletStatus = WalletStatus.NotInit;
 
   @observable
+  protected _walletRejectionError: Error | undefined;
+
+  @observable
   protected _name: string = "";
 
   @observable
@@ -204,6 +207,9 @@ export class AccountSetBase<MsgOpts, Queries> {
     // Set wallet status as loading whenever try to init.
     this._walletStatus = WalletStatus.Loading;
 
+    // Reset previous rejection error message
+    this._walletRejectionError = undefined;
+
     const keplr = yield* toGenerator(this.getKeplr());
     if (!keplr) {
       this._walletStatus = WalletStatus.NotExist;
@@ -228,7 +234,7 @@ export class AccountSetBase<MsgOpts, Queries> {
 
       // Set the wallet status as loaded after getting all necessary infos.
       this._walletStatus = WalletStatus.Loaded;
-    } catch {
+    } catch (error: any) {
       // Caught error loading key
       // Reset properties, and set status to Rejected
       this._bech32Address = "";
@@ -236,6 +242,7 @@ export class AccountSetBase<MsgOpts, Queries> {
       this.pubKey = new Uint8Array(0);
 
       this._walletStatus = WalletStatus.Rejected;
+      this._walletRejectionError = error as Error;
     }
   }
 
@@ -537,6 +544,13 @@ export class AccountSetBase<MsgOpts, Queries> {
 
   get walletStatus(): WalletStatus {
     return this._walletStatus;
+  }
+
+  get isWalletRejectedWithError(): boolean {
+    return (
+      this.walletStatus === WalletStatus.Rejected &&
+      this._walletRejectionError !== undefined
+    );
   }
 
   get name(): string {


### PR DESCRIPTION
Since Ledgers on Keplr are hard-coded to use the `coinType = 118`, we must disable them on Evmos to prevent users from using invalid address and getting funds stuck.

![simulator](https://user-images.githubusercontent.com/11379797/159143567-2296e6c4-8d7f-4881-b145-054df75aaec5.gif)

