### PR TITLE
Include community tax in staking APR

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Official Releases
 
-> NOTE: We do not accept native integrations to the official releases through pull requests. Please feel free to check out Keplr's [suggest chain](https://docs.keplr.app/api/suggest-chain.html) feature for permissionless intergrations to your chain.
+> NOTE: We do not accept native integrations to the official releases through pull requests. Please feel free to check out Keplr's [suggest chain](https://docs.keplr.app/api/suggest-chain.html) feature for permissionless integrations to your chain.
 
 You can find the latest versions of the official managed releases on these links:
 - [Browser Extension](https://chrome.google.com/webstore/detail/keplr/dmkamcknogkgcdfhhbddcghachkejeap)

--- a/packages/stores/src/query/cosmos/distribution/index.ts
+++ b/packages/stores/src/query/cosmos/distribution/index.ts
@@ -1,0 +1,1 @@
+export * from "./params";

--- a/packages/stores/src/query/cosmos/distribution/params.ts
+++ b/packages/stores/src/query/cosmos/distribution/params.ts
@@ -1,0 +1,10 @@
+import { ObservableChainQuery } from "../../chain-query";
+import { DistributionParams } from "./types";
+import { KVStore } from "@keplr-wallet/common";
+import { ChainGetter } from "../../../common";
+
+export class ObservableQueryDistributionParams extends ObservableChainQuery<DistributionParams> {
+  constructor(kvStore: KVStore, chainId: string, chainGetter: ChainGetter) {
+    super(kvStore, chainId, chainGetter, "/distribution/parameters");
+  }
+}

--- a/packages/stores/src/query/cosmos/distribution/types.ts
+++ b/packages/stores/src/query/cosmos/distribution/types.ts
@@ -1,0 +1,8 @@
+export type DistributionParams = {
+  height: string;
+  result: {
+    community_tax: string;
+    base_proposer_reward: string;
+    bonus_proposer_reward: string;
+  };
+};

--- a/packages/stores/src/query/cosmos/queries.ts
+++ b/packages/stores/src/query/cosmos/queries.ts
@@ -34,6 +34,7 @@ import {
   ObservableQueryOsmosisEpochs,
   ObservableQueryOsmosisMintParmas,
 } from "./supply/osmosis";
+import { ObservableQueryDistributionParams } from "./distribution";
 
 export interface HasCosmosQueries {
   cosmos: CosmosQueries;
@@ -135,7 +136,8 @@ export class CosmosQueries {
         chainGetter,
         osmosisMintParams
       ),
-      osmosisMintParams
+      osmosisMintParams,
+      new ObservableQueryDistributionParams(kvStore, chainId, chainGetter)
     );
     this.queryRewards = new ObservableQueryRewards(
       kvStore,


### PR DESCRIPTION
The earning rate for staking doesn't take into account inflation coins sent to the community pool. There's a community tax taken off newly minted coins before distribution to delegators.

Most chains have a small community tax rate (2%) so the difference isn't noticable. But recently kava changed to 80% which was throwing off the rate.

This PR adds an observable to fetch the community tax from the distribution module, and includes it in the rate calculation.
If the query fails it falls back to the the current calculation.

Changes introduced:

| chain       | current | new    |
|-------------|---------|--------|
| cosmos      | 15.46   | 15.15  |
| osmosis     | 72.41   | 72.41  |
| secret      | 24.57   | 24.08  |
| akash       | 33.31   | 32.64  |
| crypto      | 14.85   | 14.85  |
| starname    | 17.09   | 17.09  |
| sifchain    | 248.9   | 248.89 |
| certik      | 24.24   | 24.24  |
| irisnet     | 10.92   | 10.7   |
| regen       | 26.72   | 26.19  |
| persistence | 36.74   | 36.01  |
| sentinel    | 60.40   | 59.2   |
| kava        | 163.2   | 32.64  |
| ixo         | 49.76   | 48.76  |
| juno        | 103.56  | 101.49 |