### PR TITLE
fix: Do not overflow container when requesting access to multiple chains

### DIFF
--- a/packages/extension/src/pages/access/style.module.scss
+++ b/packages/extension/src/pages/access/style.module.scss
@@ -11,7 +11,7 @@
   .paragraph {
     text-align: center;
     padding: 0 24px;
-    overflow-y: scroll;
+    overflow-y: auto;
     margin-bottom: 0rem;
     border: 1px solid black;
   }

--- a/packages/extension/src/pages/access/style.module.scss
+++ b/packages/extension/src/pages/access/style.module.scss
@@ -11,6 +11,9 @@
   .paragraph {
     text-align: center;
     padding: 0 24px;
+    overflow-y: scroll;
+    margin-bottom: 0rem;
+    border: 1px solid black;
   }
 
   .permission {


### PR DESCRIPTION
Issue:
![image](https://user-images.githubusercontent.com/6826762/159252956-b9623726-edb8-4a2b-bd05-203a531e89c3.png)

Changes:
- `overflow-y:  auto` to not overflow 
- `margin-bottom: 0rem` to gain some additional space (don't think it affects anything visually)
- `border: 1px solid black` to draw attention to what is being approved/this being a container. I think it's important when it IS scrollable