### PR TITLE
Update cosmwasm REST query path

### DIFF
--- a/packages/stores/src/query/cosmwasm/contract-query.ts
+++ b/packages/stores/src/query/cosmwasm/contract-query.ts
@@ -30,7 +30,7 @@ export class ObservableCosmwasmContractChainQuery<
     const msg = JSON.stringify(obj);
     const query = Buffer.from(msg).toString("base64");
 
-    return `/wasm/v1/contract/${contractAddress}/smart/${query}`;
+    return `/cosmwasm/wasm/v1/contract/${contractAddress}/smart/${query}`;
   }
 
   // eslint-disable-next-line @typescript-eslint/ban-types


### PR DESCRIPTION
Update cosmwasm query path, reference [v0.24 CHANGELOG](https://github.com/CosmWasm/wasmd/blob/v0.24.0/CHANGELOG.md#v0240-2022-03-09)

Juno will updated to wasm v0.24 in the next software-upgrade.