### PR TITLE
Fix stargaze inline video playback

### DIFF
--- a/packages/mobile/src/screens/web/webpages/stargaze.tsx
+++ b/packages/mobile/src/screens/web/webpages/stargaze.tsx
@@ -7,6 +7,7 @@ export const StargazeWebpageScreen: FunctionComponent = () => {
       name="Stargaze"
       source={{ uri: "https://app.stargaze.zone" }}
       originWhitelist={["https://app.stargaze.zone"]}
+      allowsInlineMediaPlayback={true}
     />
   );
 };


### PR DESCRIPTION
Adds support for the stargaze webview to respect `playsinline` attributes on embedded videos.