### PR TITLE
Fix Safari issues

### DIFF
--- a/packages/common/src/kv-store/extension.ts
+++ b/packages/common/src/kv-store/extension.ts
@@ -3,11 +3,15 @@ import { KVStoreProvider } from "./interface";
 
 const ExtensionKVStoreProvider: KVStoreProvider = {
   get:
-    typeof browser !== "undefined"
+    typeof browser !== "undefined" &&
+    typeof browser.storage !== "undefined" &&
+    typeof browser.storage.local !== "undefined"
       ? browser.storage.local.get
       : (undefined as any),
   set:
-    typeof browser !== "undefined"
+    typeof browser !== "undefined" &&
+    typeof browser.storage !== "undefined" &&
+    typeof browser.storage.local !== "undefined"
       ? browser.storage.local.set
       : (undefined as any),
 };


### PR DESCRIPTION
When including `@keplr-wallet/stores` in an app run on Safari, the following error prevents webpack'd JavaScript to load:

```
TypeError: undefined is not an object (evaluating 'browser.storage.local')
```

<img width="861" alt="Screen Shot 2022-05-11 at 11 26 16 PM" src="https://user-images.githubusercontent.com/6721426/168005670-102306e9-e258-4054-ae8b-1a293efe7bc9.png">

This is because `browser` exists in Safari, but it does *not* have a `storage` property, so the check is not rigorous enough.