### PR TITLE
Implement `KeplrError` and replace error instances in `@keplr-wallet/background`

### DIFF
--- a/packages/background/src/chains/handler.ts
+++ b/packages/background/src/chains/handler.ts
@@ -1,4 +1,10 @@
-import { Env, Handler, InternalHandler, Message } from "@keplr-wallet/router";
+import {
+  Env,
+  Handler,
+  InternalHandler,
+  KeplrError,
+  Message,
+} from "@keplr-wallet/router";
 import { ChainsService } from "./service";
 import {
   GetChainInfosMsg,
@@ -25,7 +31,7 @@ export const getHandler: (service: ChainsService) => Handler = (service) => {
           msg as RemoveSuggestedChainInfoMsg
         );
       default:
-        throw new Error("Unknown msg type");
+        throw new KeplrError("chains", 110, "Unknown msg type");
     }
   };
 };

--- a/packages/background/src/chains/messages.ts
+++ b/packages/background/src/chains/messages.ts
@@ -1,4 +1,4 @@
-import { Message } from "@keplr-wallet/router";
+import { KeplrError, Message } from "@keplr-wallet/router";
 import { ChainInfoWithEmbed } from "./types";
 import { ChainInfo } from "@keplr-wallet/types";
 import { ROUTE } from "./constants";
@@ -34,7 +34,7 @@ export class SuggestChainInfoMsg extends Message<void> {
 
   validateBasic(): void {
     if (!this.chainInfo) {
-      throw new Error("chain info not set");
+      throw new KeplrError("chains", 100, "Chain info not set");
     }
   }
 
@@ -62,7 +62,7 @@ export class RemoveSuggestedChainInfoMsg extends Message<ChainInfoWithEmbed[]> {
 
   validateBasic(): void {
     if (!this.chainId) {
-      throw new Error("Chain id not set");
+      throw new KeplrError("chains", 101, "Chain id not set");
     }
   }
 

--- a/packages/background/src/chains/service.ts
+++ b/packages/background/src/chains/service.ts
@@ -6,7 +6,7 @@ import { ChainInfo } from "@keplr-wallet/types";
 import { KVStore, Debouncer } from "@keplr-wallet/common";
 import { ChainUpdaterService } from "../updater";
 import { InteractionService } from "../interaction";
-import { Env } from "@keplr-wallet/router";
+import { Env, KeplrError } from "@keplr-wallet/router";
 import { SuggestChainInfoMsg } from "./messages";
 import { ChainIdHelper } from "@keplr-wallet/cosmos";
 
@@ -103,7 +103,11 @@ export class ChainsService {
     });
 
     if (!chainInfo) {
-      throw new Error(`There is no chain info for ${chainId}`);
+      throw new KeplrError(
+        "chains",
+        411,
+        `There is no chain info for ${chainId}`
+      );
     }
     return chainInfo;
   }
@@ -112,7 +116,11 @@ export class ChainsService {
     const chainInfo = await this.getChainInfo(chainId);
 
     if (!chainInfo) {
-      throw new Error(`There is no chain info for ${chainId}`);
+      throw new KeplrError(
+        "chains",
+        411,
+        `There is no chain info for ${chainId}`
+      );
     }
 
     return chainInfo.bip44.coinType;
@@ -153,7 +161,7 @@ export class ChainsService {
 
   async addChainInfo(chainInfo: ChainInfo): Promise<void> {
     if (await this.hasChainInfo(chainInfo.chainId)) {
-      throw new Error("Same chain is already registered");
+      throw new KeplrError("chains", 121, "Same chain is already registered");
     }
 
     const savedChainInfos =
@@ -168,11 +176,11 @@ export class ChainsService {
 
   async removeChainInfo(chainId: string): Promise<void> {
     if (!(await this.hasChainInfo(chainId))) {
-      throw new Error("Chain is not registered");
+      throw new KeplrError("chains", 120, "Chain is not registered");
     }
 
     if ((await this.getChainInfo(chainId)).embeded) {
-      throw new Error("Can't remove the embedded chain");
+      throw new KeplrError("chains", 122, "Can't remove the embedded chain");
     }
 
     const savedChainInfos =

--- a/packages/background/src/chains/types.ts
+++ b/packages/background/src/chains/types.ts
@@ -1,3 +1,4 @@
+import { KeplrError } from "@keplr-wallet/router";
 import {
   Bech32Config,
   ChainInfo,
@@ -116,7 +117,11 @@ export const ChainInfoSchema = Joi.object<ChainInfo>({
     .unique()
     .custom((value: string[]) => {
       if (value.indexOf("cosmwasm") >= 0 && value.indexOf("secretwasm") >= 0) {
-        throw new Error("cosmwasm and secretwasm are not compatible");
+        throw new KeplrError(
+          "chains",
+          430,
+          "cosmwasm and secretwasm are not compatible"
+        );
       }
 
       return value;

--- a/packages/background/src/interaction/foreground/handler.ts
+++ b/packages/background/src/interaction/foreground/handler.ts
@@ -1,4 +1,10 @@
-import { Env, Handler, InternalHandler, Message } from "@keplr-wallet/router";
+import {
+  Env,
+  Handler,
+  InternalHandler,
+  KeplrError,
+  Message,
+} from "@keplr-wallet/router";
 import { PushEventDataMsg, PushInteractionDataMsg } from "./messages";
 import { InteractionForegroundService } from "./service";
 
@@ -15,7 +21,7 @@ export const getHandler: (service: InteractionForegroundService) => Handler = (
       case PushEventDataMsg:
         return handlePushEventDataMsg(service)(env, msg as PushEventDataMsg);
       default:
-        throw new Error("Unknown msg type");
+        throw new KeplrError("interaction", 110, "Unknown msg type");
     }
   };
 };

--- a/packages/background/src/interaction/foreground/messages.ts
+++ b/packages/background/src/interaction/foreground/messages.ts
@@ -1,4 +1,4 @@
-import { Message } from "@keplr-wallet/router";
+import { KeplrError, Message } from "@keplr-wallet/router";
 import { ROUTE } from "./constants";
 import { InteractionWaitingData } from "../types";
 
@@ -13,7 +13,7 @@ export class PushInteractionDataMsg extends Message<void> {
 
   validateBasic(): void {
     if (!this.data.type) {
-      throw new Error("Type should not be empty");
+      throw new KeplrError("interaction", 101, "Type should not be empty");
     }
   }
 
@@ -39,7 +39,7 @@ export class PushEventDataMsg extends Message<void> {
 
   validateBasic(): void {
     if (!this.data.type) {
-      throw new Error("Type should not be empty");
+      throw new KeplrError("interaction", 101, "Type should not be empty");
     }
   }
 

--- a/packages/background/src/interaction/handler.ts
+++ b/packages/background/src/interaction/handler.ts
@@ -1,4 +1,10 @@
-import { Env, Handler, InternalHandler, Message } from "@keplr-wallet/router";
+import {
+  Env,
+  Handler,
+  InternalHandler,
+  KeplrError,
+  Message,
+} from "@keplr-wallet/router";
 import { ApproveInteractionMsg, RejectInteractionMsg } from "./messages";
 import { InteractionService } from "./service";
 
@@ -18,7 +24,7 @@ export const getHandler: (service: InteractionService) => Handler = (
           msg as RejectInteractionMsg
         );
       default:
-        throw new Error("Unknown msg type");
+        throw new KeplrError("interaction", 100, "Unknown msg type");
     }
   };
 };

--- a/packages/background/src/interaction/service.ts
+++ b/packages/background/src/interaction/service.ts
@@ -5,6 +5,7 @@ import { InteractionWaitingData } from "./types";
 import {
   Env,
   FnRequestInteractionOptions,
+  KeplrError,
   MessageRequester,
 } from "@keplr-wallet/router";
 import { PushEventDataMsg, PushInteractionDataMsg } from "./foreground";
@@ -28,7 +29,7 @@ export class InteractionService {
   // And, don't ensure that the event is delivered successfully, just ignore the any errors.
   dispatchEvent(port: string, type: string, data: unknown) {
     if (!type) {
-      throw new Error("Type should not be empty");
+      throw new KeplrError("interaction", 101, "Type should not be empty");
     }
 
     const msg = new PushEventDataMsg({
@@ -49,7 +50,7 @@ export class InteractionService {
     options?: FnRequestInteractionOptions
   ): Promise<unknown> {
     if (!type) {
-      throw new Error("Type should not be empty");
+      throw new KeplrError("interaction", 101, "Type should not be empty");
     }
 
     // TODO: Add timeout?
@@ -68,7 +69,7 @@ export class InteractionService {
 
   protected async wait(id: string, fn: () => void): Promise<unknown> {
     if (this.resolverMap.has(id)) {
-      throw new Error("Id is aleady in use");
+      throw new KeplrError("interaction", 100, "Id is aleady in use");
     }
 
     return new Promise<unknown>((resolve, reject) => {
@@ -121,7 +122,7 @@ export class InteractionService {
     };
 
     if (this.waitingMap.has(id)) {
-      throw new Error("Id is aleady in use");
+      throw new KeplrError("interaction", 100, "Id is aleady in use");
     }
 
     this.waitingMap.set(id, interactionWaitingData);

--- a/packages/background/src/keyring/crypto.ts
+++ b/packages/background/src/keyring/crypto.ts
@@ -9,6 +9,7 @@ import { Hash, RNG } from "@keplr-wallet/crypto";
 import pbkdf2 from "pbkdf2";
 
 import { Buffer } from "buffer/";
+import { KeplrError } from "@keplr-wallet/router";
 
 /**
  * This is similar to ethereum's key store.
@@ -84,7 +85,7 @@ export class Crypto {
             );
           });
         default:
-          throw new Error("Unknown kdf");
+          throw new KeplrError("keyring", 220, "Unknown kdf");
       }
     })();
     const buf = Buffer.from(text);
@@ -153,7 +154,7 @@ export class Crypto {
             );
           });
         default:
-          throw new Error("Unknown kdf");
+          throw new KeplrError("keyring", 220, "Unknown kdf");
       }
     })();
 
@@ -168,7 +169,7 @@ export class Crypto {
       ])
     );
     if (!Buffer.from(mac).equals(Buffer.from(keyStore.crypto.mac, "hex"))) {
-      throw new Error("Unmatched mac");
+      throw new KeplrError("keyring", 222, "Unmatched mac");
     }
 
     return Buffer.from(

--- a/packages/background/src/keyring/handler.ts
+++ b/packages/background/src/keyring/handler.ts
@@ -1,4 +1,10 @@
-import { Env, Handler, InternalHandler, Message } from "@keplr-wallet/router";
+import {
+  Env,
+  Handler,
+  InternalHandler,
+  KeplrError,
+  Message,
+} from "@keplr-wallet/router";
 import {
   CreateMnemonicKeyMsg,
   CreatePrivateKeyMsg,
@@ -110,7 +116,7 @@ export const getHandler: (service: KeyRingService) => Handler = (
           msg as ExportKeyRingDatasMsg
         );
       default:
-        throw new Error("Unknown msg type");
+        throw new KeplrError("keyring", 221, "Unknown msg type");
     }
   };
 };

--- a/packages/background/src/keyring/keyring.ts
+++ b/packages/background/src/keyring/keyring.ts
@@ -9,7 +9,7 @@ import { KVStore } from "@keplr-wallet/common";
 import { LedgerService } from "../ledger";
 import { BIP44HDPath, CommonCrypto, ExportKeyRingData } from "./types";
 import { ChainInfo } from "@keplr-wallet/types";
-import { Env } from "@keplr-wallet/router";
+import { Env, KeplrError } from "@keplr-wallet/router";
 
 import { Buffer } from "buffer/";
 import { ChainIdHelper } from "@keplr-wallet/cosmos";
@@ -90,7 +90,7 @@ export class KeyRing {
     }
 
     if (type !== "mnemonic" && type !== "privateKey" && type !== "ledger") {
-      throw new Error("Invalid type of key store");
+      throw new KeplrError("keyring", 132, "Invalid type of key store");
     }
 
     return type;
@@ -190,7 +190,7 @@ export class KeyRing {
     defaultCoinType: number
   ): number {
     if (!this.keyStore) {
-      throw new Error("Key Store is empty");
+      throw new KeplrError("keyring", 130, "Key store is empty");
     }
 
     return this.keyStore.coinTypeForChain
@@ -215,7 +215,11 @@ export class KeyRing {
     multiKeyStoreInfo: MultiKeyStoreInfoWithSelected;
   }> {
     if (this.status !== KeyRingStatus.EMPTY) {
-      throw new Error("Key ring is not loaded or not empty");
+      throw new KeplrError(
+        "keyring",
+        142,
+        "Key ring is not loaded or not empty"
+      );
     }
 
     this.mnemonicMasterSeed = Mnemonic.generateMasterSeedFromMnemonic(mnemonic);
@@ -249,7 +253,11 @@ export class KeyRing {
     multiKeyStoreInfo: MultiKeyStoreInfoWithSelected;
   }> {
     if (this.status !== KeyRingStatus.EMPTY) {
-      throw new Error("Key ring is not loaded or not empty");
+      throw new KeplrError(
+        "keyring",
+        142,
+        "Key ring is not loaded or not empty"
+      );
     }
 
     this.privateKey = privateKey;
@@ -283,7 +291,11 @@ export class KeyRing {
     multiKeyStoreInfo: MultiKeyStoreInfoWithSelected;
   }> {
     if (this.status !== KeyRingStatus.EMPTY) {
-      throw new Error("Key ring is not loaded or not empty");
+      throw new KeplrError(
+        "keyring",
+        142,
+        "Key ring is not loaded or not empty"
+      );
     }
 
     // Get public key first
@@ -316,7 +328,7 @@ export class KeyRing {
 
   public lock() {
     if (this.status !== KeyRingStatus.UNLOCKED) {
-      throw new Error("Key ring is not unlocked");
+      throw new KeplrError("keyring", 143, "Key ring is not unlocked");
     }
 
     this.mnemonicMasterSeed = undefined;
@@ -327,7 +339,7 @@ export class KeyRing {
 
   public async unlock(password: string) {
     if (!this.keyStore || this.type === "none") {
-      throw new Error("Key ring not initialized");
+      throw new KeplrError("keyring", 144, "Key ring not initialized");
     }
 
     if (this.type === "mnemonic") {
@@ -353,7 +365,7 @@ export class KeyRing {
         "hex"
       );
     } else {
-      throw new Error("Unexpected type of keyring");
+      throw new KeplrError("keyring", 145, "Unexpected type of keyring");
     }
 
     this.password = password;
@@ -373,7 +385,7 @@ export class KeyRing {
     }
     const multiKeyStore = await this.kvStore.get<KeyStore[]>(KeyMultiStoreKey);
     if (!multiKeyStore) {
-      // Restore the multi keystore if key store exist but multi key store is empty.
+      // Restore the multi keystore if key store exist 13t multi Key store is empty.
       // This case will occur if extension is updated from the prior version that doesn't support the multi key store.
       // This line ensures the backward compatibility.
       if (keyStore) {
@@ -438,7 +450,7 @@ export class KeyRing {
 
   public isKeyStoreCoinTypeSet(chainId: string): boolean {
     if (!this.keyStore) {
-      throw new Error("Empty key store");
+      throw new KeplrError("keyring", 130, "Key store is empty");
     }
 
     return (
@@ -451,7 +463,7 @@ export class KeyRing {
 
   public async setKeyStoreCoinType(chainId: string, coinType: number) {
     if (!this.keyStore) {
-      throw new Error("Empty key store");
+      throw new KeplrError("keyring", 130, "Key store is empty");
     }
 
     if (
@@ -460,7 +472,7 @@ export class KeyRing {
         ChainIdHelper.parse(chainId).identifier
       ] !== undefined
     ) {
-      throw new Error("Coin type already set");
+      throw new KeplrError("keyring", 110, "Coin type already set");
     }
 
     this.keyStore.coinTypeForChain = {
@@ -493,17 +505,17 @@ export class KeyRing {
     keyStoreChanged: boolean;
   }> {
     if (this.status !== KeyRingStatus.UNLOCKED) {
-      throw new Error("Key ring is not unlocked");
+      throw new KeplrError("keyring", 143, "Key ring is not unlocked");
     }
 
     if (this.password !== password) {
-      throw new Error("Invalid password");
+      throw new KeplrError("keyring", 121, "Invalid password");
     }
 
     const keyStore = this.multiKeyStore[index];
 
     if (!keyStore) {
-      throw new Error("Empty key store");
+      throw new KeplrError("keyring", 130, "Key store is empty");
     }
 
     const multiKeyStore = this.multiKeyStore
@@ -552,13 +564,13 @@ export class KeyRing {
     name: string
   ): Promise<MultiKeyStoreInfoWithSelected> {
     if (this.status !== KeyRingStatus.UNLOCKED) {
-      throw new Error("Key ring is not unlocked");
+      throw new KeplrError("keyring", 143, "Key ring is not unlocked");
     }
 
     const keyStore = this.multiKeyStore[index];
 
     if (!keyStore) {
-      throw new Error("Empty key store");
+      throw new KeplrError("keyring", 130, "Key store is empty");
     }
 
     keyStore.meta = { ...keyStore.meta, name: name };
@@ -576,20 +588,22 @@ export class KeyRing {
 
   private loadKey(coinType: number): Key {
     if (this.status !== KeyRingStatus.UNLOCKED) {
-      throw new Error("Key ring is not unlocked");
+      throw new KeplrError("keyring", 143, "Key ring is not unlocked");
     }
 
     if (!this.keyStore) {
-      throw new Error("Key Store is empty");
+      throw new KeplrError("keyring", 130, "Key store is empty");
     }
 
     if (this.keyStore.type === "ledger") {
       if (!this.ledgerPublicKey) {
-        throw new Error("Ledger public key not set");
+        throw new KeplrError("keyring", 150, "Ledger public key not set");
       }
 
       if (coinType === 60) {
-        throw new Error(
+        throw new KeplrError(
+          "keyring",
+          152,
           "Ledger is not compatible with this coinType right now"
         );
       }
@@ -635,7 +649,7 @@ export class KeyRing {
       this.type === "none" ||
       !this.keyStore
     ) {
-      throw new Error("Key ring is not unlocked");
+      throw new KeplrError("keyring", 143, "Key ring is not unlocked");
     }
 
     const bip44HDPath = KeyRing.getKeyStoreBIP44Path(this.keyStore);
@@ -648,7 +662,9 @@ export class KeyRing {
       }
 
       if (!this.mnemonicMasterSeed) {
-        throw new Error(
+        throw new KeplrError(
+          "keyring",
+          133,
           "Key store type is mnemonic and it is unlocked. But, mnemonic is not loaded unexpectedly"
         );
       }
@@ -664,14 +680,16 @@ export class KeyRing {
       // If key store type is private key, path will be ignored.
 
       if (!this.privateKey) {
-        throw new Error(
+        throw new KeplrError(
+          "keyring",
+          134,
           "Key store type is private key and it is unlocked. But, private key is not loaded unexpectedly"
         );
       }
 
       return new PrivKeySecp256k1(this.privateKey);
     } else {
-      throw new Error("Unexpected type of keyring");
+      throw new KeplrError("keyring", 145, "Unexpected type of keyring");
     }
   }
 
@@ -682,11 +700,11 @@ export class KeyRing {
     message: Uint8Array
   ): Promise<Uint8Array> {
     if (this.status !== KeyRingStatus.UNLOCKED) {
-      throw new Error("Key ring is not unlocked");
+      throw new KeplrError("keyring", 143, "Key ring is not unlocked");
     }
 
     if (!this.keyStore) {
-      throw new Error("Key Store is empty");
+      throw new KeplrError("keyring", 130, "Key store is empty");
     }
 
     // Sign with Evmos/Ethereum
@@ -699,7 +717,11 @@ export class KeyRing {
       const pubKey = this.ledgerPublicKey;
 
       if (!pubKey) {
-        throw new Error("Ledger public key is not initialized");
+        throw new KeplrError(
+          "keyring",
+          151,
+          "Ledger public key is not initialized"
+        );
       }
 
       return await this.ledgerKeeper.sign(
@@ -722,20 +744,26 @@ export class KeyRing {
     message: Uint8Array
   ): Promise<Uint8Array> {
     if (this.status !== KeyRingStatus.UNLOCKED) {
-      throw new Error("Key ring is not unlocked");
+      throw new KeplrError("keyring", 143, "Key ring is not unlocked");
     }
 
     if (!this.keyStore) {
-      throw new Error("Key Store is empty");
+      throw new KeplrError("keyring", 130, "Key store is empty");
     }
 
     if (this.keyStore.type === "ledger") {
       // TODO: Ethereum Ledger Integration
-      throw new Error("Ethereum signing with Ledger is not yet supported");
+      throw new KeplrError(
+        "keyring",
+        112,
+        "Ethereum signing with Ledger is not yet supported"
+      );
     } else {
       const coinType = this.computeKeyStoreCoinType(chainId, defaultCoinType);
       if (coinType !== 60) {
-        throw new Error(
+        throw new KeplrError(
+          "keyring",
+          111,
           "Invalid coin type passed in to Ethereum signing (expected 60)"
         );
       }
@@ -758,17 +786,17 @@ export class KeyRing {
   // Show private key or mnemonic key if password is valid.
   public async showKeyRing(index: number, password: string): Promise<string> {
     if (this.status !== KeyRingStatus.UNLOCKED) {
-      throw new Error("Key ring is not unlocked");
+      throw new KeplrError("keyring", 143, "Key ring is not unlocked");
     }
 
     if (this.password !== password) {
-      throw new Error("Invalid password");
+      throw new KeplrError("keyring", 121, "Invalid password");
     }
 
     const keyStore = this.multiKeyStore[index];
 
     if (!keyStore) {
-      throw new Error("Empty key store");
+      throw new KeplrError("keyring", 130, "Key store is empty");
     }
 
     if (keyStore.type === "mnemonic") {
@@ -797,7 +825,11 @@ export class KeyRing {
     multiKeyStoreInfo: MultiKeyStoreInfoWithSelected;
   }> {
     if (this.status !== KeyRingStatus.UNLOCKED || this.password == "") {
-      throw new Error("Key ring is locked or not initialized");
+      throw new KeplrError(
+        "keyring",
+        141,
+        "Key ring is locked or not initialized"
+      );
     }
 
     const keyStore = await KeyRing.CreateMnemonicKeyStore(
@@ -825,7 +857,11 @@ export class KeyRing {
     multiKeyStoreInfo: MultiKeyStoreInfoWithSelected;
   }> {
     if (this.status !== KeyRingStatus.UNLOCKED || this.password == "") {
-      throw new Error("Key ring is locked or not initialized");
+      throw new KeplrError(
+        "keyring",
+        141,
+        "Key ring is locked or not initialized"
+      );
     }
 
     const keyStore = await KeyRing.CreatePrivateKeyStore(
@@ -853,7 +889,11 @@ export class KeyRing {
     multiKeyStoreInfo: MultiKeyStoreInfoWithSelected;
   }> {
     if (this.status !== KeyRingStatus.UNLOCKED || this.password == "") {
-      throw new Error("Key ring is locked or not initialized");
+      throw new KeplrError(
+        "keyring",
+        141,
+        "Key ring is locked or not initialized"
+      );
     }
 
     // Get public key first
@@ -883,12 +923,16 @@ export class KeyRing {
     multiKeyStoreInfo: MultiKeyStoreInfoWithSelected;
   }> {
     if (this.status !== KeyRingStatus.UNLOCKED || this.password == "") {
-      throw new Error("Key ring is locked or not initialized");
+      throw new KeplrError(
+        "keyring",
+        141,
+        "Key ring is locked or not initialized"
+      );
     }
 
     const keyStore = this.multiKeyStore[index];
     if (!keyStore) {
-      throw new Error("Invalid keystore");
+      throw new KeplrError("keyring", 120, "Invalid keystore");
     }
 
     this.keyStore = keyStore;
@@ -923,7 +967,7 @@ export class KeyRing {
 
   checkPassword(password: string): boolean {
     if (!this.password) {
-      throw new Error("Keyring is locked");
+      throw new KeplrError("keyring", 100, "Keyring is locked");
     }
 
     return this.password === password;
@@ -931,11 +975,11 @@ export class KeyRing {
 
   async exportKeyRingDatas(password: string): Promise<ExportKeyRingData[]> {
     if (!this.password) {
-      throw new Error("Keyring is locked");
+      throw new KeplrError("keyring", 100, "Keyring is locked");
     }
 
     if (this.password !== password) {
-      throw new Error("Invalid password");
+      throw new KeplrError("keyring", 121, "Invalid password");
     }
 
     const result: ExportKeyRingData[] = [];
@@ -1063,7 +1107,7 @@ export class KeyRing {
   private static getKeyStoreId(keyStore: KeyStore): string {
     const id = keyStore.meta?.__id__;
     if (!id) {
-      throw new Error("Key store's id is empty");
+      throw new KeplrError("keyring", 131, "Key store's id is empty");
     }
 
     return id;
@@ -1083,21 +1127,21 @@ export class KeyRing {
 
   public static validateBIP44Path(bip44Path: BIP44HDPath): void {
     if (!Number.isInteger(bip44Path.account) || bip44Path.account < 0) {
-      throw new Error("Invalid account in hd path");
+      throw new KeplrError("keyring", 100, "Invalid account in hd path");
     }
 
     if (
       !Number.isInteger(bip44Path.change) ||
       !(bip44Path.change === 0 || bip44Path.change === 1)
     ) {
-      throw new Error("Invalid change in hd path");
+      throw new KeplrError("keyring", 102, "Invalid change in hd path");
     }
 
     if (
       !Number.isInteger(bip44Path.addressIndex) ||
       bip44Path.addressIndex < 0
     ) {
-      throw new Error("Invalid address index in hd path");
+      throw new KeplrError("keyring", 101, "Invalid address index in hd path");
     }
   }
 

--- a/packages/background/src/keyring/messages.ts
+++ b/packages/background/src/keyring/messages.ts
@@ -1,4 +1,4 @@
-import { Message } from "@keplr-wallet/router";
+import { KeplrError, Message } from "@keplr-wallet/router";
 import { ROUTE } from "./constants";
 import {
   KeyRing,
@@ -57,11 +57,11 @@ export class DeleteKeyRingMsg extends Message<{
 
   validateBasic(): void {
     if (!Number.isInteger(this.index)) {
-      throw new Error("Invalid index");
+      throw new KeplrError("keyring", 201, "Invalid index");
     }
 
     if (!this.password) {
-      throw new Error("password not set");
+      throw new KeplrError("keyring", 274, "password not set");
     }
   }
 
@@ -87,11 +87,11 @@ export class UpdateNameKeyRingMsg extends Message<{
 
   validateBasic(): void {
     if (!Number.isInteger(this.index)) {
-      throw new Error("Invalid index");
+      throw new KeplrError("keyring", 201, "Invalid index");
     }
 
     if (!this.name) {
-      throw new Error("name not set");
+      throw new KeplrError("keyring", 273, "name not set");
     }
   }
 
@@ -115,11 +115,11 @@ export class ShowKeyRingMsg extends Message<string> {
 
   validateBasic(): void {
     if (!Number.isInteger(this.index)) {
-      throw new Error("Invalid index");
+      throw new KeplrError("keyring", 201, "Invalid index");
     }
 
     if (!this.password) {
-      throw new Error("password not set");
+      throw new KeplrError("keyring", 274, "password not set");
     }
   }
 
@@ -156,15 +156,15 @@ export class CreateMnemonicKeyMsg extends Message<{
       this.kdf !== "sha256" &&
       this.kdf !== "pbkdf2"
     ) {
-      throw new Error("Invalid kdf");
+      throw new KeplrError("keyring", 202, "Invalid kdf");
     }
 
     if (!this.mnemonic) {
-      throw new Error("mnemonic not set");
+      throw new KeplrError("keyring", 272, "mnemonic not set");
     }
 
     if (!this.password) {
-      throw new Error("password not set");
+      throw new KeplrError("keyring", 274, "password not set");
     }
 
     // Validate mnemonic.
@@ -212,11 +212,11 @@ export class AddMnemonicKeyMsg extends Message<{
       this.kdf !== "sha256" &&
       this.kdf !== "pbkdf2"
     ) {
-      throw new Error("Invalid kdf");
+      throw new KeplrError("keyring", 202, "Invalid kdf");
     }
 
     if (!this.mnemonic) {
-      throw new Error("mnemonic not set");
+      throw new KeplrError("keyring", 272, "mnemonic not set");
     }
 
     // Validate mnemonic.
@@ -265,19 +265,19 @@ export class CreatePrivateKeyMsg extends Message<{
       this.kdf !== "sha256" &&
       this.kdf !== "pbkdf2"
     ) {
-      throw new Error("Invalid kdf");
+      throw new KeplrError("keyring", 202, "Invalid kdf");
     }
 
     if (!this.privateKey || this.privateKey.length === 0) {
-      throw new Error("private key not set");
+      throw new KeplrError("keyring", 275, "private key not set");
     }
 
     if (this.privateKey.length !== 32) {
-      throw new Error("invalid length of private key");
+      throw new KeplrError("keyring", 260, "invalid length of private key");
     }
 
     if (!this.password) {
-      throw new Error("password not set");
+      throw new KeplrError("keyring", 274, "password not set");
     }
   }
 
@@ -313,11 +313,11 @@ export class CreateLedgerKeyMsg extends Message<{
       this.kdf !== "sha256" &&
       this.kdf !== "pbkdf2"
     ) {
-      throw new Error("Invalid kdf");
+      throw new KeplrError("keyring", 202, "Invalid kdf");
     }
 
     if (!this.password) {
-      throw new Error("password not set");
+      throw new KeplrError("keyring", 274, "password not set");
     }
 
     KeyRing.validateBIP44Path(this.bip44HDPath);
@@ -353,15 +353,15 @@ export class AddPrivateKeyMsg extends Message<{
       this.kdf !== "sha256" &&
       this.kdf !== "pbkdf2"
     ) {
-      throw new Error("Invalid kdf");
+      throw new KeplrError("keyring", 202, "Invalid kdf");
     }
 
     if (!this.privateKey || this.privateKey.length === 0) {
-      throw new Error("private key not set");
+      throw new KeplrError("keyring", 275, "private key not set");
     }
 
     if (this.privateKey.length !== 32) {
-      throw new Error("invalid length of private key");
+      throw new KeplrError("keyring", 260, "invalid length of private key");
     }
   }
 
@@ -395,7 +395,7 @@ export class AddLedgerKeyMsg extends Message<{
       this.kdf !== "sha256" &&
       this.kdf !== "pbkdf2"
     ) {
-      throw new Error("Invalid kdf");
+      throw new KeplrError("keyring", 202, "Invalid kdf");
     }
 
     KeyRing.validateBIP44Path(this.bip44HDPath);
@@ -443,7 +443,7 @@ export class UnlockKeyRingMsg extends Message<{ status: KeyRingStatus }> {
 
   validateBasic(): void {
     if (!this.password) {
-      throw new Error("password not set");
+      throw new KeplrError("keyring", 274, "password not set");
     }
   }
 
@@ -467,7 +467,7 @@ export class GetKeyMsg extends Message<Key> {
 
   validateBasic(): void {
     if (!this.chainId) {
-      throw new Error("chain id not set");
+      throw new KeplrError("keyring", 270, "chain id not set");
     }
   }
 
@@ -503,11 +503,11 @@ export class RequestSignAminoMsg extends Message<AminoSignResponse> {
 
   validateBasic(): void {
     if (!this.chainId) {
-      throw new Error("chain id not set");
+      throw new KeplrError("keyring", 270, "chain id not set");
     }
 
     if (!this.signer) {
-      throw new Error("signer not set");
+      throw new KeplrError("keyring", 230, "signer not set");
     }
 
     // Validate bech32 address.
@@ -517,18 +517,20 @@ export class RequestSignAminoMsg extends Message<AminoSignResponse> {
     // ADR-36 sign doc doesn't have the chain id
     if (!checkAndValidateADR36AminoSignDoc(this.signDoc)) {
       if (this.signDoc.chain_id !== this.chainId) {
-        throw new Error(
+        throw new KeplrError(
+          "keyring",
+          234,
           "Chain id in the message is not matched with the requested chain id"
         );
       }
     } else {
       if (this.signDoc.msgs[0].value.signer !== this.signer) {
-        throw new Error("Unmatched signer in sign doc");
+        throw new KeplrError("keyring", 233, "Unmatched signer in sign doc");
       }
     }
 
     if (!this.signOptions) {
-      throw new Error("Sign options are null");
+      throw new KeplrError("keyring", 235, "Sign options are null");
     }
   }
 
@@ -561,15 +563,15 @@ export class RequestVerifyADR36AminoSignDoc extends Message<boolean> {
 
   validateBasic(): void {
     if (!this.chainId) {
-      throw new Error("chain id not set");
+      throw new KeplrError("keyring", 270, "chain id not set");
     }
 
     if (!this.signer) {
-      throw new Error("signer not set");
+      throw new KeplrError("keyring", 230, "signer not set");
     }
 
     if (!this.signature) {
-      throw new Error("Signature not set");
+      throw new KeplrError("keyring", 271, "Signature not set");
     }
 
     // Validate bech32 address.
@@ -618,11 +620,11 @@ export class RequestSignDirectMsg extends Message<{
 
   validateBasic(): void {
     if (!this.chainId) {
-      throw new Error("chain id not set");
+      throw new KeplrError("keyring", 270, "chain id not set");
     }
 
     if (!this.signer) {
-      throw new Error("signer not set");
+      throw new KeplrError("keyring", 230, "signer not set");
     }
 
     // Validate bech32 address.
@@ -636,13 +638,15 @@ export class RequestSignDirectMsg extends Message<{
     });
 
     if (signDoc.chainId !== this.chainId) {
-      throw new Error(
+      throw new KeplrError(
+        "keyring",
+        234,
         "Chain id in the message is not matched with the requested chain id"
       );
     }
 
     if (!this.signOptions) {
-      throw new Error("Sign options are null");
+      throw new KeplrError("keyring", 235, "Sign options are null");
     }
   }
 
@@ -696,11 +700,11 @@ export class ChangeKeyRingMsg extends Message<{
 
   validateBasic(): void {
     if (this.index < 0) {
-      throw new Error("Index is negative");
+      throw new KeplrError("keyring", 200, "Index is negative");
     }
 
     if (!Number.isInteger(this.index)) {
-      throw new Error("Invalid index");
+      throw new KeplrError("keyring", 201, "Invalid index");
     }
   }
 
@@ -731,11 +735,11 @@ export class GetIsKeyStoreCoinTypeSetMsg extends Message<
 
   validateBasic(): void {
     if (!this.chainId) {
-      throw new Error("chain id not set");
+      throw new KeplrError("keyring", 270, "chain id not set");
     }
 
     if (this.paths.length === 0) {
-      throw new Error("empty bip44 path list");
+      throw new KeplrError("keyring", 250, "empty bip44 path list");
     }
   }
 
@@ -762,15 +766,15 @@ export class SetKeyStoreCoinTypeMsg extends Message<KeyRingStatus> {
 
   validateBasic(): void {
     if (!this.chainId) {
-      throw new Error("chain id not set");
+      throw new KeplrError("keyring", 270, "chain id not set");
     }
 
     if (this.coinType < 0) {
-      throw new Error("coin type can not be negative");
+      throw new KeplrError("keyring", 240, "coin type can not be negative");
     }
 
     if (!Number.isInteger(this.coinType)) {
-      throw new Error("coin type should be integer");
+      throw new KeplrError("keyring", 241, "coin type should be integer");
     }
   }
 
@@ -794,7 +798,7 @@ export class CheckPasswordMsg extends Message<boolean> {
 
   validateBasic(): void {
     if (!this.password) {
-      throw new Error("password not set");
+      throw new KeplrError("keyring", 274, "password not set");
     }
   }
 
@@ -818,7 +822,7 @@ export class ExportKeyRingDatasMsg extends Message<ExportKeyRingData[]> {
 
   validateBasic(): void {
     if (!this.password) {
-      throw new Error("password not set");
+      throw new KeplrError("keyring", 274, "password not set");
     }
   }
 

--- a/packages/background/src/ledger/handler.ts
+++ b/packages/background/src/ledger/handler.ts
@@ -1,4 +1,10 @@
-import { Env, Handler, InternalHandler, Message } from "@keplr-wallet/router";
+import {
+  Env,
+  Handler,
+  InternalHandler,
+  KeplrError,
+  Message,
+} from "@keplr-wallet/router";
 import { LedgerGetWebHIDFlagMsg, LedgerSetWebHIDFlagMsg } from "./messages";
 import { LedgerService } from "./service";
 
@@ -18,7 +24,7 @@ export const getHandler: (service: LedgerService) => Handler = (
           msg as LedgerSetWebHIDFlagMsg
         );
       default:
-        throw new Error("Unknown msg type");
+        throw new KeplrError("ledger", 111, "Unknown msg type");
     }
   };
 };

--- a/packages/background/src/ledger/ledger.ts
+++ b/packages/background/src/ledger/ledger.ts
@@ -5,6 +5,7 @@ const CosmosApp: any = require("ledger-cosmos-js").default;
 import TransportWebHID from "@ledgerhq/hw-transport-webhid";
 import TransportWebUSB from "@ledgerhq/hw-transport-webusb";
 import { signatureImport } from "secp256k1";
+import { KeplrError } from "@keplr-wallet/router";
 
 export enum LedgerInitErrorOn {
   Transport,
@@ -46,7 +47,7 @@ export class Ledger {
       // However, it is almost same as that the device is not unlocked to user-side.
       // So, handle this case as initializing failed in `Transport`.
       if (versionResponse.deviceLocked) {
-        throw new Error("Device is on screen saver");
+        throw new KeplrError("ledger", 102, "Device is on screen saver");
       }
 
       return ledger;
@@ -71,7 +72,7 @@ export class Ledger {
     testMode: boolean;
   }> {
     if (!this.cosmosApp) {
-      throw new Error("Cosmos App not initialized");
+      throw new KeplrError("ledger", 100, "Cosmos App not initialized");
     }
 
     const result = await this.cosmosApp.getVersion();
@@ -91,7 +92,7 @@ export class Ledger {
 
   async getPublicKey(path: number[]): Promise<Uint8Array> {
     if (!this.cosmosApp) {
-      throw new Error("Cosmos App not initialized");
+      throw new KeplrError("ledger", 100, "Cosmos App not initialized");
     }
 
     const result = await this.cosmosApp.publicKey(path);
@@ -104,7 +105,7 @@ export class Ledger {
 
   async sign(path: number[], message: Uint8Array): Promise<Uint8Array> {
     if (!this.cosmosApp) {
-      throw new Error("Cosmos App not initialized");
+      throw new KeplrError("ledger", 100, "Cosmos App not initialized");
     }
 
     const result = await this.cosmosApp.sign(path, message);

--- a/packages/background/src/ledger/ledger.ts
+++ b/packages/background/src/ledger/ledger.ts
@@ -71,7 +71,7 @@ export class Ledger {
     testMode: boolean;
   }> {
     if (!this.cosmosApp) {
-      throw new Error("Comsos App not initialized");
+      throw new Error("Cosmos App not initialized");
     }
 
     const result = await this.cosmosApp.getVersion();
@@ -91,7 +91,7 @@ export class Ledger {
 
   async getPublicKey(path: number[]): Promise<Uint8Array> {
     if (!this.cosmosApp) {
-      throw new Error("Comsos App not initialized");
+      throw new Error("Cosmos App not initialized");
     }
 
     const result = await this.cosmosApp.publicKey(path);
@@ -104,7 +104,7 @@ export class Ledger {
 
   async sign(path: number[], message: Uint8Array): Promise<Uint8Array> {
     if (!this.cosmosApp) {
-      throw new Error("Comsos App not initialized");
+      throw new Error("Cosmos App not initialized");
     }
 
     const result = await this.cosmosApp.sign(path, message);

--- a/packages/background/src/ledger/messages.ts
+++ b/packages/background/src/ledger/messages.ts
@@ -1,4 +1,4 @@
-import { Message } from "@keplr-wallet/router";
+import { KeplrError, Message } from "@keplr-wallet/router";
 import { ROUTE } from "./constants";
 
 export class LedgerGetWebHIDFlagMsg extends Message<boolean> {
@@ -34,7 +34,7 @@ export class LedgerSetWebHIDFlagMsg extends Message<void> {
 
   validateBasic(): void {
     if (this.flag == null) {
-      throw new Error("Flag is null");
+      throw new KeplrError("ledger", 101, "Flag is null");
     }
   }
 

--- a/packages/background/src/ledger/service.ts
+++ b/packages/background/src/ledger/service.ts
@@ -5,7 +5,7 @@ import { Ledger, LedgerWebHIDIniter, LedgerWebUSBIniter } from "./ledger";
 
 import delay from "delay";
 
-import { APP_PORT, Env } from "@keplr-wallet/router";
+import { APP_PORT, Env, KeplrError } from "@keplr-wallet/router";
 import { BIP44HDPath } from "../keyring";
 import { KVStore } from "@keplr-wallet/common";
 import { InteractionService } from "../interaction";
@@ -81,7 +81,7 @@ export class LedgerService {
           Buffer.from(expectedPubKey).toString("hex") !==
           Buffer.from(pubKey).toString("hex")
         ) {
-          throw new Error("Unmatched public key");
+          throw new KeplrError("ledger", 110, "Unmatched public key");
         }
         // Cosmos App on Ledger doesn't support the coin type other than 118.
         const signature = await ledger.sign(
@@ -167,7 +167,7 @@ export class LedgerService {
       try {
         const transportIniter = this.options.transportIniters[mode];
         if (!transportIniter) {
-          throw new Error(`Unknown mode: ${mode}`);
+          throw new KeplrError("ledger", 112, `Unknown mode: ${mode}`);
         }
 
         const ledger = await Ledger.init(transportIniter, initArgs);
@@ -204,7 +204,7 @@ export class LedgerService {
                 | undefined;
 
               if (response?.abort) {
-                throw new Error("Ledger init aborted");
+                throw new KeplrError("ledger", 120, "Ledger init aborted");
               }
 
               if (response?.initArgs) {
@@ -233,7 +233,7 @@ export class LedgerService {
                   event: "init-aborted",
                   mode,
                 });
-                throw new Error("Ledger init timeout");
+                throw new KeplrError("ledger", 121, "Ledger init timeout");
               }
             })()
           );
@@ -274,7 +274,7 @@ export class LedgerService {
       }
 
       if (!find) {
-        throw new Error("Ledger init aborted");
+        throw new KeplrError("ledger", 120, "Ledger init aborted");
       }
 
       await delay(1000);

--- a/packages/background/src/permission/handler.ts
+++ b/packages/background/src/permission/handler.ts
@@ -5,7 +5,13 @@ import {
   GetPermissionOriginsMsg,
   RemovePermissionOrigin,
 } from "./messages";
-import { Env, Handler, InternalHandler, Message } from "@keplr-wallet/router";
+import {
+  Env,
+  Handler,
+  InternalHandler,
+  KeplrError,
+  Message,
+} from "@keplr-wallet/router";
 import { PermissionService } from "./service";
 
 export const getHandler: (service: PermissionService) => Handler = (
@@ -36,7 +42,7 @@ export const getHandler: (service: PermissionService) => Handler = (
           msg as RemovePermissionOrigin
         );
       default:
-        throw new Error("Unknown msg type");
+        throw new KeplrError("permission", 120, "Unknown msg type");
     }
   };
 };

--- a/packages/background/src/permission/messages.ts
+++ b/packages/background/src/permission/messages.ts
@@ -1,4 +1,4 @@
-import { Message } from "@keplr-wallet/router";
+import { KeplrError, Message } from "@keplr-wallet/router";
 import { ROUTE } from "./constants";
 
 export class EnableAccessMsg extends Message<void> {
@@ -12,7 +12,7 @@ export class EnableAccessMsg extends Message<void> {
 
   validateBasic(): void {
     if (!this.chainIds || this.chainIds.length === 0) {
-      throw new Error("chain id not set");
+      throw new KeplrError("permission", 100, "chain id not set");
     }
   }
 
@@ -43,11 +43,11 @@ export class GetPermissionOriginsMsg extends Message<string[]> {
 
   validateBasic(): void {
     if (!this.chainId) {
-      throw new Error("chain id not set");
+      throw new KeplrError("permission", 100, "chain id not set");
     }
 
     if (!this.permissionType) {
-      throw new Error("empty permission type");
+      throw new KeplrError("permission", 110, "empty permission type");
     }
   }
 
@@ -74,11 +74,11 @@ export class GetOriginPermittedChainsMsg extends Message<string[]> {
 
   validateBasic(): void {
     if (!this.permissionOrigin) {
-      throw new Error("origin not set");
+      throw new KeplrError("permission", 101, "origin not set");
     }
 
     if (!this.permissionType) {
-      throw new Error("empty permission type");
+      throw new KeplrError("permission", 110, "empty permission type");
     }
   }
 
@@ -106,15 +106,15 @@ export class AddPermissionOrigin extends Message<void> {
 
   validateBasic(): void {
     if (!this.chainId) {
-      throw new Error("chain id not set");
+      throw new KeplrError("permission", 100, "chain id not set");
     }
 
     if (!this.permissionType) {
-      throw new Error("empty permission type");
+      throw new KeplrError("permission", 110, "empty permission type");
     }
 
     if (!this.permissionOrigin) {
-      throw new Error("empty permission origin");
+      throw new KeplrError("permission", 111, "empty permission origin");
     }
   }
 
@@ -142,15 +142,15 @@ export class RemovePermissionOrigin extends Message<void> {
 
   validateBasic(): void {
     if (!this.chainId) {
-      throw new Error("chain id not set");
+      throw new KeplrError("permission", 100, "chain id not set");
     }
 
     if (!this.permissionType) {
-      throw new Error("empty permission type");
+      throw new KeplrError("permission", 110, "empty permission type");
     }
 
     if (!this.permissionOrigin) {
-      throw new Error("empty permission origin");
+      throw new KeplrError("permission", 111, "empty permission origin");
     }
   }
 

--- a/packages/background/src/permission/service.ts
+++ b/packages/background/src/permission/service.ts
@@ -2,7 +2,7 @@ import { delay, inject, singleton } from "tsyringe";
 import { TYPES } from "../types";
 
 import { InteractionService } from "../interaction";
-import { Env } from "@keplr-wallet/router";
+import { Env, KeplrError } from "@keplr-wallet/router";
 import {
   getBasicAccessPermissionType,
   INTERACTION_TYPE_PERMISSION,
@@ -132,7 +132,7 @@ export class PermissionService {
     }
 
     if (!this.hasPermisson(chainId, type, origin)) {
-      throw new Error(`${origin} is not permitted`);
+      throw new KeplrError("permission", 130, `${origin} is not permitted`);
     }
   }
 

--- a/packages/background/src/secret-wasm/handler.ts
+++ b/packages/background/src/secret-wasm/handler.ts
@@ -1,4 +1,10 @@
-import { Env, Handler, InternalHandler, Message } from "@keplr-wallet/router";
+import {
+  Env,
+  Handler,
+  InternalHandler,
+  KeplrError,
+  Message,
+} from "@keplr-wallet/router";
 import {
   GetPubkeyMsg,
   GetTxEncryptionKeyMsg,
@@ -24,7 +30,7 @@ export const getHandler: (service: SecretWasmService) => Handler = (
           msg as GetTxEncryptionKeyMsg
         );
       default:
-        throw new Error("Unknown msg type");
+        throw new KeplrError("secret-wasm", 120, "Unknown msg type");
     }
   };
 };

--- a/packages/background/src/secret-wasm/messages.ts
+++ b/packages/background/src/secret-wasm/messages.ts
@@ -1,4 +1,4 @@
-import { Message } from "@keplr-wallet/router";
+import { KeplrError, Message } from "@keplr-wallet/router";
 import { ROUTE } from "./constants";
 
 export class GetPubkeyMsg extends Message<Uint8Array> {
@@ -12,7 +12,7 @@ export class GetPubkeyMsg extends Message<Uint8Array> {
 
   validateBasic(): void {
     if (!this.chainId) {
-      throw new Error("chain id not set");
+      throw new KeplrError("secret-wasm", 100, "chain id not set");
     }
   }
 
@@ -45,15 +45,15 @@ export class ReqeustEncryptMsg extends Message<Uint8Array> {
 
   validateBasic(): void {
     if (!this.chainId) {
-      throw new Error("chain id not set");
+      throw new KeplrError("secret-wasm", 100, "chain id not set");
     }
 
     if (!this.contractCodeHash) {
-      throw new Error("contract code hash not set");
+      throw new KeplrError("secret-wasm", 103, "contract code hash not set");
     }
 
     if (!this.msg) {
-      throw new Error("msg not set");
+      throw new KeplrError("secret-wasm", 101, "msg not set");
     }
   }
 
@@ -85,15 +85,15 @@ export class RequestDecryptMsg extends Message<Uint8Array> {
 
   validateBasic(): void {
     if (!this.chainId) {
-      throw new Error("chain id not set");
+      throw new KeplrError("secret-wasm", 100, "chain id not set");
     }
 
     if (!this.cipherText || this.cipherText.length === 0) {
-      throw new Error("ciphertext not set");
+      throw new KeplrError("secret-wasm", 102, "ciphertext not set");
     }
 
     if (!this.nonce || this.nonce.length === 0) {
-      throw new Error("nonce not set");
+      throw new KeplrError("secret-wasm", 110, "nonce not set");
     }
   }
 
@@ -124,12 +124,12 @@ export class GetTxEncryptionKeyMsg extends Message<Uint8Array> {
 
   validateBasic(): void {
     if (!this.chainId) {
-      throw new Error("chain id not set");
+      throw new KeplrError("secret-wasm", 100, "chain id not set");
     }
 
     if (!this.nonce) {
       // Nonce of zero length is permitted.
-      throw new Error("nonce is null");
+      throw new KeplrError("secret-wasm", 111, "nonce is null");
     }
   }
 

--- a/packages/background/src/secret-wasm/service.ts
+++ b/packages/background/src/secret-wasm/service.ts
@@ -9,7 +9,7 @@ import { Hash } from "@keplr-wallet/crypto";
 import { KVStore, Debouncer } from "@keplr-wallet/common";
 import { ChainInfo } from "@keplr-wallet/types";
 import { Bech32Address } from "@keplr-wallet/cosmos";
-import { Env } from "@keplr-wallet/router";
+import { Env, KeplrError } from "@keplr-wallet/router";
 
 import { Buffer } from "buffer/";
 
@@ -48,7 +48,7 @@ export class SecretWasmService {
 
     const keyRingType = await this.keyRingService.getKeyRingType();
     if (keyRingType === "none") {
-      throw new Error("Key ring is not initialized");
+      throw new KeplrError("secret-wasm", 130, "Key ring is not initialized");
     }
 
     const seed = await this.getSeed(env, chainInfo);
@@ -66,7 +66,7 @@ export class SecretWasmService {
 
     const keyRingType = await this.keyRingService.getKeyRingType();
     if (keyRingType === "none") {
-      throw new Error("Key ring is not initialized");
+      throw new KeplrError("secret-wasm", 130, "Key ring is not initialized");
     }
 
     const seed = await this.getSeed(env, chainInfo);
@@ -86,7 +86,7 @@ export class SecretWasmService {
 
     const keyRingType = await this.keyRingService.getKeyRingType();
     if (keyRingType === "none") {
-      throw new Error("Key ring is not initialized");
+      throw new KeplrError("secret-wasm", 130, "Key ring is not initialized");
     }
 
     // XXX: Keplr should generate the seed deterministically according to the account.
@@ -110,7 +110,7 @@ export class SecretWasmService {
 
     const keyRingType = await this.keyRingService.getKeyRingType();
     if (keyRingType === "none") {
-      throw new Error("Key ring is not initialized");
+      throw new KeplrError("secret-wasm", 130, "Key ring is not initialized");
     }
 
     // XXX: Keplr should generate the seed deterministically according to the account.

--- a/packages/background/src/tokens/handler.ts
+++ b/packages/background/src/tokens/handler.ts
@@ -1,4 +1,10 @@
-import { Env, Handler, InternalHandler, Message } from "@keplr-wallet/router";
+import {
+  Env,
+  Handler,
+  InternalHandler,
+  KeplrError,
+  Message,
+} from "@keplr-wallet/router";
 import { TokensService } from "./service";
 import {
   AddTokenMsg,
@@ -25,7 +31,7 @@ export const getHandler: (service: TokensService) => Handler = (service) => {
           msg as GetSecret20ViewingKey
         );
       default:
-        throw new Error("Unknown msg type");
+        throw new KeplrError("tokens", 120, "Unknown msg type");
     }
   };
 };

--- a/packages/background/src/tokens/messages.ts
+++ b/packages/background/src/tokens/messages.ts
@@ -1,4 +1,4 @@
-import { Message } from "@keplr-wallet/router";
+import { KeplrError, Message } from "@keplr-wallet/router";
 import { ROUTE } from "./constants";
 import { AppCurrency } from "@keplr-wallet/types";
 
@@ -13,7 +13,7 @@ export class GetTokensMsg extends Message<AppCurrency[]> {
 
   validateBasic(): void {
     if (!this.chainId) {
-      throw new Error("Chain id is empty");
+      throw new KeplrError("tokens", 100, "Chain id is empty");
     }
   }
 
@@ -45,11 +45,11 @@ export class SuggestTokenMsg extends Message<void> {
 
   validateBasic(): void {
     if (!this.chainId) {
-      throw new Error("Chain id is empty");
+      throw new KeplrError("tokens", 100, "Chain id is empty");
     }
 
     if (!this.contractAddress) {
-      throw new Error("Contract address is empty");
+      throw new KeplrError("tokens", 101, "Contract address is empty");
     }
   }
 
@@ -76,7 +76,7 @@ export class AddTokenMsg extends Message<void> {
 
   validateBasic(): void {
     if (!this.chainId) {
-      throw new Error("Chain id is empty");
+      throw new KeplrError("tokens", 100, "Chain id is empty");
     }
   }
 
@@ -103,7 +103,7 @@ export class RemoveTokenMsg extends Message<void> {
 
   validateBasic(): void {
     if (!this.chainId) {
-      throw new Error("Chain id is empty");
+      throw new KeplrError("tokens", 100, "Chain id is empty");
     }
   }
 
@@ -130,11 +130,11 @@ export class GetSecret20ViewingKey extends Message<string> {
 
   validateBasic(): void {
     if (!this.chainId) {
-      throw new Error("Chain id is empty");
+      throw new KeplrError("tokens", 100, "Chain id is empty");
     }
 
     if (!this.contractAddress) {
-      throw new Error("Contract address is empty");
+      throw new KeplrError("tokens", 101, "Contract address is empty");
     }
   }
 

--- a/packages/background/src/tokens/service.ts
+++ b/packages/background/src/tokens/service.ts
@@ -1,7 +1,7 @@
 import { delay, inject, singleton } from "tsyringe";
 import { TYPES } from "../types";
 
-import { Env } from "@keplr-wallet/router";
+import { Env, KeplrError } from "@keplr-wallet/router";
 import {
   ChainInfo,
   AppCurrency,
@@ -292,7 +292,7 @@ export class TokensService {
       }
     }
 
-    throw new Error("There is no matched secret20");
+    throw new KeplrError("tokens", 111, "There is no matched secret20");
   }
 
   async checkOrGrantSecret20ViewingKeyPermission(
@@ -339,7 +339,7 @@ export class TokensService {
           );
           break;
         default:
-          throw new Error("Unknown type of currency");
+          throw new KeplrError("tokens", 110, "Unknown type of currency");
       }
     } else {
       currency = await CurrencySchema.validateAsync(currency);

--- a/packages/background/src/tx/handler.ts
+++ b/packages/background/src/tx/handler.ts
@@ -1,4 +1,10 @@
-import { Env, Handler, InternalHandler, Message } from "@keplr-wallet/router";
+import {
+  Env,
+  Handler,
+  InternalHandler,
+  KeplrError,
+  Message,
+} from "@keplr-wallet/router";
 import { SendTxMsg } from "./messages";
 import { BackgroundTxService } from "./service";
 
@@ -10,7 +16,7 @@ export const getHandler: (service: BackgroundTxService) => Handler = (
       case SendTxMsg:
         return handleSendTxMsg(service)(env, msg as SendTxMsg);
       default:
-        throw new Error("Unknown msg type");
+        throw new KeplrError("tx", 110, "Unknown msg type");
     }
   };
 };

--- a/packages/background/src/tx/messages.ts
+++ b/packages/background/src/tx/messages.ts
@@ -1,4 +1,4 @@
-import { Message } from "@keplr-wallet/router";
+import { KeplrError, Message } from "@keplr-wallet/router";
 import { ROUTE } from "./constants";
 
 // Return the tx hash
@@ -17,18 +17,18 @@ export class SendTxMsg extends Message<Uint8Array> {
 
   validateBasic(): void {
     if (!this.chainId) {
-      throw new Error("chain id is empty");
+      throw new KeplrError("tx", 100, "chain id is empty");
     }
 
     if (!this.tx) {
-      throw new Error("tx is empty");
+      throw new KeplrError("tx", 101, "tx is empty");
     }
 
     if (
       !this.mode ||
       (this.mode !== "sync" && this.mode !== "async" && this.mode !== "block")
     ) {
-      throw new Error("invalid mode");
+      throw new KeplrError("tx", 120, "invalid mode");
     }
   }
 

--- a/packages/background/src/updater/handler.ts
+++ b/packages/background/src/updater/handler.ts
@@ -1,4 +1,10 @@
-import { Env, Handler, InternalHandler, Message } from "@keplr-wallet/router";
+import {
+  Env,
+  Handler,
+  InternalHandler,
+  KeplrError,
+  Message,
+} from "@keplr-wallet/router";
 import { ChainUpdaterService } from "./service";
 import { TryUpdateChainMsg } from "./messages";
 
@@ -10,7 +16,7 @@ export const getHandler: (service: ChainUpdaterService) => Handler = (
       case TryUpdateChainMsg:
         return handleTryUpdateChainMsg(service)(env, msg as TryUpdateChainMsg);
       default:
-        throw new Error("Unknown msg type");
+        throw new KeplrError("updater", 110, "Unknown msg type");
     }
   };
 };

--- a/packages/background/src/updater/messages.ts
+++ b/packages/background/src/updater/messages.ts
@@ -1,4 +1,4 @@
-import { Message } from "@keplr-wallet/router";
+import { KeplrError, Message } from "@keplr-wallet/router";
 import { ROUTE } from "./constants";
 
 export class TryUpdateChainMsg extends Message<void> {
@@ -12,7 +12,7 @@ export class TryUpdateChainMsg extends Message<void> {
 
   validateBasic(): void {
     if (!this.chainId) {
-      throw new Error("Empty chain id");
+      throw new KeplrError("updater", 100, "Empty chain id");
     }
   }
 

--- a/packages/extension/src/pages/main/account.tsx
+++ b/packages/extension/src/pages/main/account.tsx
@@ -61,6 +61,7 @@ export const AccountView: FunctionComponent = observer(() => {
         <ToolTip
           tooltip={(() => {
             if (
+              accountInfo.rejectionReason &&
               accountInfo.rejectionReason instanceof KeplrError &&
               accountInfo.rejectionReason.module === "keyring" &&
               accountInfo.rejectionReason.code === 152

--- a/packages/extension/src/pages/main/account.tsx
+++ b/packages/extension/src/pages/main/account.tsx
@@ -38,7 +38,7 @@ export const AccountView: FunctionComponent = observer(() => {
         });
       }
     },
-    [accountInfo.walletStatus, accountInfo.bech32Address, notification, intl]
+    [accountInfo.walletStatus, notification, intl]
   );
 
   return (

--- a/packages/extension/src/pages/main/account.tsx
+++ b/packages/extension/src/pages/main/account.tsx
@@ -10,6 +10,7 @@ import { useNotification } from "../../components/notification";
 import { ToolTip } from "../../components/tooltip";
 import { useIntl } from "react-intl";
 import { WalletStatus } from "@keplr-wallet/stores";
+import { KeplrError } from "@keplr-wallet/router";
 
 export const AccountView: FunctionComponent = observer(() => {
   const { accountStore, chainStore } = useStore();
@@ -60,9 +61,9 @@ export const AccountView: FunctionComponent = observer(() => {
         <ToolTip
           tooltip={(() => {
             if (
-              accountInfo.rejectionReason &&
-              accountInfo.rejectionReason.message ===
-                "Ledger is not compatible with this coinType right now"
+              accountInfo.rejectionReason instanceof KeplrError &&
+              accountInfo.rejectionReason.module === "keyring" &&
+              accountInfo.rejectionReason.code === 152
             ) {
               return "Ledger is not supported for this chain";
             }

--- a/packages/extension/src/pages/setting/keyring/change/name.tsx
+++ b/packages/extension/src/pages/setting/keyring/change/name.tsx
@@ -10,6 +10,7 @@ import { useStore } from "../../../../stores";
 import { observer } from "mobx-react-lite";
 
 import styleName from "./name.module.scss";
+import { KeplrError } from "@keplr-wallet/router";
 
 interface FormData {
   name: string;
@@ -32,7 +33,7 @@ export const ChangeNamePage: FunctionComponent = observer(() => {
 
   useEffect(() => {
     if (parseInt(match.params.index).toString() !== match.params.index) {
-      throw new Error("Invalid index");
+      throw new KeplrError("keyring", 201, "Invalid index");
     }
   }, [match.params.index]);
 

--- a/packages/router-extension/src/requester/extension.ts
+++ b/packages/router-extension/src/requester/extension.ts
@@ -2,6 +2,7 @@ import {
   MessageRequester,
   Message,
   JSONUint8Array,
+  KeplrError,
 } from "@keplr-wallet/router";
 import { getKeplrExtensionRouterId } from "../utils";
 
@@ -34,7 +35,15 @@ export class InExtensionMessageRequester implements MessageRequester {
     }
 
     if (result.error) {
-      throw new Error(result.error);
+      if (typeof result.error === "string") {
+        throw new Error(result.error);
+      } else {
+        throw new KeplrError(
+          result.error.module,
+          result.error.code,
+          result.error.message
+        );
+      }
     }
 
     return result.return;
@@ -69,7 +78,15 @@ export class InExtensionMessageRequester implements MessageRequester {
     }
 
     if (result.error) {
-      throw new Error(result.error);
+      if (typeof result.error === "string") {
+        throw new Error(result.error);
+      } else {
+        throw new KeplrError(
+          result.error.module,
+          result.error.code,
+          result.error.message
+        );
+      }
     }
 
     return result.return;

--- a/packages/router-extension/src/router/extension.ts
+++ b/packages/router-extension/src/router/extension.ts
@@ -3,6 +3,7 @@ import {
   MessageSender,
   Result,
   EnvProducer,
+  KeplrError,
 } from "@keplr-wallet/router";
 import { getKeplrExtensionRouterId } from "../utils";
 
@@ -75,7 +76,15 @@ export class ExtensionRouter extends Router {
       console.log(
         `Failed to process msg ${message.type}: ${e?.message || e?.toString()}`
       );
-      if (e) {
+      if (e instanceof KeplrError) {
+        return Promise.resolve({
+          error: {
+            code: e.code,
+            module: e.module,
+            message: e.message || e.toString(),
+          },
+        });
+      } else if (e) {
         return Promise.resolve({
           error: e.message || e.toString(),
         });

--- a/packages/router-mock/src/requester/index.ts
+++ b/packages/router-mock/src/requester/index.ts
@@ -3,6 +3,7 @@ import {
   Message,
   JSONUint8Array,
   Result,
+  KeplrError,
 } from "@keplr-wallet/router";
 import { MockRouter } from "../router";
 
@@ -42,7 +43,15 @@ export class MockMessageRequester implements MessageRequester {
     }
 
     if (result.error) {
-      throw new Error(result.error);
+      if (typeof result.error === "string") {
+        throw new Error(result.error);
+      } else {
+        throw new KeplrError(
+          result.error.module,
+          result.error.code,
+          result.error.message
+        );
+      }
     }
 
     return result.return;

--- a/packages/router/src/error.ts
+++ b/packages/router/src/error.ts
@@ -1,0 +1,12 @@
+export class KeplrError extends Error {
+  module: string;
+  code: number;
+
+  constructor(module: string, code: number, message?: string) {
+    super(message);
+    this.module = module;
+    this.code = code;
+
+    Object.setPrototypeOf(this, KeplrError.prototype);
+  }
+}

--- a/packages/router/src/error.ts
+++ b/packages/router/src/error.ts
@@ -1,6 +1,6 @@
 export class KeplrError extends Error {
-  module: string;
-  code: number;
+  public readonly module: string;
+  public readonly code: number;
 
   constructor(module: string, code: number, message?: string) {
     super(message);

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -2,6 +2,7 @@ export * from "./router";
 export * from "./handler";
 export * from "./interfaces";
 export * from "./types";
+export * from "./error";
 export * from "./message";
 export * from "./constant";
 export * from "./encoding";

--- a/packages/router/src/interfaces.ts
+++ b/packages/router/src/interfaces.ts
@@ -1,4 +1,4 @@
 export interface Result {
-  error?: string;
+  error?: string | { module: string; code: number; message: string };
   return?: any;
 }

--- a/packages/router/src/interfaces.ts
+++ b/packages/router/src/interfaces.ts
@@ -1,4 +1,8 @@
 export interface Result {
+  /**
+   * NOTE: If `error` is of type `{ module:string; code: number; message: string }`,
+   * it should be considered and processed as `KeplrError`.
+   */
   error?: string | { module: string; code: number; message: string };
   return?: any;
 }

--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -4,7 +4,6 @@ import { ChainGetter } from "../common";
 import { DenomHelper, toGenerator } from "@keplr-wallet/common";
 import { StdFee } from "@cosmjs/launchpad";
 import { evmosToEth } from "@hanchon/ethermint-address-converter";
-import { KeplrError } from "@keplr-wallet/router";
 
 export enum WalletStatus {
   NotInit = "NotInit",
@@ -269,7 +268,7 @@ export class AccountSetBase {
     return this._walletStatus;
   }
 
-  get rejectionReason(): Error | KeplrError | undefined {
+  get rejectionReason(): Error | undefined {
     return this._rejectionReason;
   }
 

--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -4,6 +4,7 @@ import { ChainGetter } from "../common";
 import { DenomHelper, toGenerator } from "@keplr-wallet/common";
 import { StdFee } from "@cosmjs/launchpad";
 import { evmosToEth } from "@hanchon/ethermint-address-converter";
+import { KeplrError } from "@keplr-wallet/router";
 
 export enum WalletStatus {
   NotInit = "NotInit",
@@ -268,7 +269,7 @@ export class AccountSetBase {
     return this._walletStatus;
   }
 
-  get rejectionReason(): Error | undefined {
+  get rejectionReason(): Error | KeplrError | undefined {
     return this._rejectionReason;
   }
 


### PR DESCRIPTION
- Closes #367 

<details>
  <summary>Complete table of error messages by each module</summary>

## Error messages

### Keyring
| module | code | message |
|:---:|:---:|:---|
| `keyring` | 100 | Invalid account in hd path |
| `keyring` | 101 | Invalid address index in hd path |
| `keyring` | 102 | Invalid change in hd path |
| `keyring` | 110 | Coin type already set |
| `keyring` | 111 | Invalid coin type passed in to Ethereum signing (expected 60) |
| `keyring` | 112 | Ethereum signing with Ledger is not yet supported |
| `keyring` | 120 | Invalid keystore |
| `keyring` | 121 | Invalid password |
| `keyring` | 130 | Key Store is empty (merged with `Empty key store`) |
| `keyring` | 131 | Key store's id is empty |
| `keyring` | 132 | Invalid type of key store |
| `keyring` | 133 | Key store type is mnemonic and it is unlocked. But, mnemonic is not loaded unexpectedly |
| `keyring` | 134 | Key store type is private key and it is unlocked. But, private key is not loaded unexpectedly |
| `keyring` | 140 | Key ring is locked (merged with `Keyring is locked`) |
| `keyring` | 141 | Key ring is locked or not initialized |
| `keyring` | 142 | Key ring is not loaded or not empty |
| `keyring` | 143 | Key ring is not unlocked |
| `keyring` | 144 | Key ring not initialized |
| `keyring` | 145 | Unexpected type of keyring |
| `keyring` | 150 | Ledger public key not set |
| `keyring` | 151 | Ledger public key is not initialized |
| `keyring` | 152 | Ledger is not compatible with this coinType right now |
| `keyring` | 200 | Index is negative |
| `keyring` | 201 | Invalid index |
| `keyring` | 202 | Invalid kdf |
| `keyring` | 210 | Pub key unmatched |
| `keyring` | 211 | `Unsupported type of pub key: ${signature.pub_key.type}` |
| `keyring` | 220 | Unknown kdf |
| `keyring` | 221 | Unknown msg type |
| `keyring` | 222 | Unmatched mac |
| `keyring` | 230 | signer not set |
| `keyring` | 231 | Signer mismatched |
| `keyring` | 232 | Unmatched signer in new sign doc |
| `keyring` | 233 | Unmatched signer in sign doc |
| `keyring` | 234 | Chain id in the message is not matched with the requested chain id |
| `keyring` | 235 | Sign options are null |
| `keyring` | 236 | Sign doc is not for ADR-36. But, "isADR36WithString" option is defined |
| `keyring` | 237 | Signing request was for ADR-36. But, accidentally, new sign doc is not for ADR-3 |
| `keyring` | 240 | coin type can not be negative |
| `keyring` | 241 | coin type should be integer |
| `keyring` | 250 | empty bip44 path list |
| `keyring` | 260 | invalid length of private key |
| `keyring` | 261 | key doesn't exist |
| `keyring` | 270 | chain id not set |
| `keyring` | 271 | Signature not set |
| `keyring` | 272 | mnemonic not set |
| `keyring` | 273 | name not set |
| `keyring` | 274 | password not set |
| `keyring` | 275 | private key not set |

### ledger
| module | code | message |
|:---:|:---:|:---|
| `ledger` | 100 | Cosmos App not initialized |
| `ledger` | 101 | Flag is null |
| `ledger` | 102 | Device is on screen saver |
| `ledger` | 110 | Unmatched public key |
| `ledger` | 111 | Unknown msg type |
| `ledger` | 112 | `Unknown mode: ${mode}` |
| `ledger` | 120 | Ledger init aborted |
| `ledger` | 121 | Ledger init timeout |

### chains
| module | code | message |
|:---:|:---:|:---|
| `chains` | 100 | Chain info not set |
| `chains` | 101 | Chain id not set |
| `chains` | 110 | Unknown msg type |
| `chains` | 111 | `There is no chain info for ${chainId}` |
| `chains` | 120 | Chain is not registered |
| `chains` | 121 | Same chain is already registered |
| `chains` | 122 | Can't remove the embedded chain |
| `chains` | 130 | cosmwasm and secretwasm are not compatible |

### interaction
| module | code | message |
|:---:|:---:|:---|
| `interaction` | 100 | Id is aleady in use |
| `interaction` | 101 | Type should not be empty |
| `interaction` | 110 | Unknown msg type |

### permission
| module | code | message |
|:---:|:---:|:---|
| `permission` | 100 | chain id not set |
| `permission` | 101 | origin not set |
| `permission` | 110 | empty permission type |
| `permission` | 111 | empty permission origin |
| `permission` | 120 | Unknown msg type |
| `permission` | 130 | `${origin} is not permitted` |

### tokens
| module | code | message |
|:---:|:---:|:---|
| `tokens` | 100 | Chain id is empty |
| `tokens` | 101 | Contract address is empty |
| `tokens` | 110 | Unknown type of currency |
| `tokens` | 111 | There is no matched secret20 |
| `tokens` | 120 | Unknown msg type |

### updater
| module | code | message |
|:---:|:---:|:---|
| `updater` | 100 | Empty chain id |
| `updater` | 110 | Unknown msg type |

### tx
| module | code | message |
|:---:|:---:|:---|
| `tx` | 100 | chain id is empty |
| `tx` | 101 | tx is empty |
| `tx` | 110 | Unknown msg type |
| `tx` | 120 | invalid mode |

### secret-wasm
| module | code | message |
|:---:|:---:|:---|
| `secret-wasm` | 100 | chain id not set |
| `secret-wasm` | 101 | msg not set |
| `secret-wasm` | 102 | ciphertext not set |
| `secret-wasm` | 103 | contract code hash not set |
| `secret-wasm` | 110 | nonce not set |
| `secret-wasm` | 111 | nonce is null |
| `secret-wasm` | 120 | Unknown msg type |
| `secret-wasm` | 130 | Key ring is not initialized |

</details>