### PR TITLE
remove beta tag from kava chain (revert)

### DIFF
--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -1177,7 +1177,7 @@ export const EmbedChainInfos: ChainInfo[] = [
       high: 0.25,
     },
     coinType: 459,
-    beta: true,
+    beta: false,
   },
   {
     rpc: IXO_RPC_ENDPOINT,


### PR DESCRIPTION
@Thunnini I work at Kava Labs. Looking for some clarity on [this commit](https://github.com/chainapsis/keplr-wallet/commit/91cc48044d1f2b176c51af72d40021211d60a3f3). Not sure why Kava chain was moved to the Beta section. It was previously not Beta and none of the other devs here are sure why it would have changed.