### PR TITLE
emit event on chain change

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Browser extension's build output is placed in `packages/extension/prod`, and you
 
 This repo contains submodules that are not open sourced and are only available through the Chainapsis’ official Keplr Browser Extension release. However, all primary features of the extension will work without the closed sourced submodules.
 
-Source code for moblie app is also placed in `packages/mobile`.
+Source code for mobile app is also placed in `packages/mobile`.
 
 ### Example
 Refer to the [Keplr Example repository](https://github.com/chainapsis/keplr-example) for examples of how to integrate Keplr signing support for your web interface/application.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -257,3 +257,13 @@ window.addEventListener("keplr_keystorechange", () => {
     console.log("Key store in Keplr is changed. You may need to refetch the account info.")
 })
 ```
+
+### Change Chain Event
+
+Similarly, when the user switches the network from the extension menu, the webpage might need to be made aware of the currently selected chain. Keplr emits a `keplr_chainchange` event to the webpage's window each time the user selects a new chain from the extension. You can request the currently selected chain based on this event listener.
+```javascript
+window.addEventListener("keplr_chainchange", (e) => {
+    console.log("Keplr chain updated. Currently selected chainId:", (e as CustomEvent).detail);
+});
+```
+

--- a/packages/background/src/chains/handler.ts
+++ b/packages/background/src/chains/handler.ts
@@ -10,6 +10,7 @@ import {
   GetChainInfosMsg,
   RemoveSuggestedChainInfoMsg,
   SuggestChainInfoMsg,
+  ChangeChainMsg,
 } from "./messages";
 import { ChainInfo } from "@keplr-wallet/types";
 
@@ -30,6 +31,8 @@ export const getHandler: (service: ChainsService) => Handler = (service) => {
           env,
           msg as RemoveSuggestedChainInfoMsg
         );
+      case ChangeChainMsg:
+        return handleChangeChainMsg(service)(env, msg as ChangeChainMsg);
       default:
         throw new KeplrError("chains", 110, "Unknown msg type");
     }
@@ -70,5 +73,13 @@ const handleRemoveSuggestedChainInfoMsg: (
   return async (_, msg) => {
     await service.removeChainInfo(msg.chainId);
     return await service.getChainInfos();
+  };
+};
+
+const handleChangeChainMsg: (
+  service: ChainsService
+) => InternalHandler<ChangeChainMsg> = (service) => {
+  return async (_, msg) => {
+    service.changeChain(msg.chainInfo);
   };
 };

--- a/packages/background/src/chains/init.ts
+++ b/packages/background/src/chains/init.ts
@@ -1,5 +1,6 @@
 import { Router } from "@keplr-wallet/router";
 import {
+  ChangeChainMsg,
   GetChainInfosMsg,
   SuggestChainInfoMsg,
   RemoveSuggestedChainInfoMsg,
@@ -12,6 +13,7 @@ export function init(router: Router, service: ChainsService): void {
   router.registerMessage(GetChainInfosMsg);
   router.registerMessage(SuggestChainInfoMsg);
   router.registerMessage(RemoveSuggestedChainInfoMsg);
+  router.registerMessage(ChangeChainMsg);
 
   router.addHandler(ROUTE, getHandler(service));
 }

--- a/packages/background/src/chains/messages.ts
+++ b/packages/background/src/chains/messages.ts
@@ -74,3 +74,31 @@ export class RemoveSuggestedChainInfoMsg extends Message<ChainInfoWithEmbed[]> {
     return RemoveSuggestedChainInfoMsg.type();
   }
 }
+
+export class ChangeChainMsg extends Message<void> {
+  public static type() {
+    return "change-chain";
+  }
+
+  constructor(public readonly chainInfo: ChainInfo) {
+    super();
+  }
+
+  validateBasic(): void {
+    if (!this.chainInfo) {
+      throw new Error("chain info not set");
+    }
+  }
+
+  approveExternal(): boolean {
+    return true;
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return ChangeChainMsg.type();
+  }
+}

--- a/packages/background/src/chains/service.ts
+++ b/packages/background/src/chains/service.ts
@@ -6,7 +6,7 @@ import { ChainInfo } from "@keplr-wallet/types";
 import { KVStore, Debouncer } from "@keplr-wallet/common";
 import { ChainUpdaterService } from "../updater";
 import { InteractionService } from "../interaction";
-import { Env, KeplrError } from "@keplr-wallet/router";
+import { Env, KeplrError, WEBPAGE_PORT } from "@keplr-wallet/router";
 import { SuggestChainInfoMsg } from "./messages";
 import { ChainIdHelper } from "@keplr-wallet/cosmos";
 
@@ -207,5 +207,13 @@ export class ChainsService {
 
   addChainRemovedHandler(handler: ChainRemovedHandler) {
     this.onChainRemovedHandlers.push(handler);
+  }
+
+  changeChain(chainInfo: ChainInfo): void {
+    this.interactionKeeper.dispatchEvent(
+      WEBPAGE_PORT,
+      "chain-changed",
+      chainInfo
+    );
   }
 }

--- a/packages/extension/src/content-scripts/events.ts
+++ b/packages/extension/src/content-scripts/events.ts
@@ -31,16 +31,23 @@ class PushEventDataMsg extends Message<void> {
 
 export function initEvents(router: Router) {
   router.registerMessage(PushEventDataMsg);
-
   router.addHandler("interaction-foreground", (_, msg) => {
-    switch (msg.constructor) {
-      case PushEventDataMsg:
-        if ((msg as PushEventDataMsg).data.type === "keystore-changed") {
+    if (msg.constructor === PushEventDataMsg) {
+      switch ((msg as PushEventDataMsg).data.type) {
+        case "keystore-changed":
           window.dispatchEvent(new Event("keplr_keystorechange"));
-        }
-        return;
-      default:
-        throw new Error("Unknown msg type");
+          return;
+        case "chain-changed":
+          const { chainId } = (msg as PushEventDataMsg).data.data as any;
+          window.dispatchEvent(
+            new CustomEvent("keplr_chainchange", {
+              detail: chainId,
+            })
+          );
+          return;
+      }
+    } else {
+      throw new Error("Unknown msg type");
     }
   });
 }

--- a/packages/extension/src/layouts/header/chain-list.tsx
+++ b/packages/extension/src/layouts/header/chain-list.tsx
@@ -34,6 +34,7 @@ const ChainElement: FunctionComponent<{
           });
           chainStore.selectChain(chainInfo.chainId);
           chainStore.saveLastViewChainId();
+          chainStore.changeChain(chainInfo);
         }
       }}
     >

--- a/packages/extension/src/stores/chain/index.tsx
+++ b/packages/extension/src/stores/chain/index.tsx
@@ -8,6 +8,7 @@ import {
 import { ChainInfo } from "@keplr-wallet/types";
 import {
   ChainInfoWithEmbed,
+  ChangeChainMsg,
   SetPersistentMemoryMsg,
   GetPersistentMemoryMsg,
   GetChainInfosMsg,
@@ -131,5 +132,11 @@ export class ChainStore extends BaseChainStore<ChainInfoWithEmbed> {
     const msg = new TryUpdateChainMsg(chainId);
     yield this.requester.sendMessage(BACKGROUND_PORT, msg);
     yield this.getChainInfosFromBackground();
+  }
+
+  @flow
+  *changeChain(chainInfo: ChainInfo) {
+    const msg = new ChangeChainMsg(chainInfo);
+    yield* toGenerator(this.requester.sendMessage(BACKGROUND_PORT, msg));
   }
 }


### PR DESCRIPTION
When the user switches the network from the extension menu, the webpage might need to be made aware of the currently selected chain. With the changes introduced in this PR, Keplr emits a `keplr_chainchange` event to the webpage's window each time the user selects a new chain from the extension. You can request the currently selected chain based on this event listener.
```javascript
window.addEventListener("keplr_chainchange", (e) => {
    console.log("Keplr chain updated. Currently selected chainId:", (e as CustomEvent).detail);
});
```