### PR TITLE
new kava chain id

### DIFF
--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -1099,7 +1099,7 @@ export const EmbedChainInfos: ChainInfo[] = [
     rpcConfig: KAVA_RPC_CONFIG,
     rest: KAVA_REST_ENDPOINT,
     restConfig: KAVA_REST_CONFIG,
-    chainId: "kava-9",
+    chainId: "kava_2222-10",
     chainName: "Kava",
     stakeCurrency: {
       coinDenom: "KAVA",


### PR DESCRIPTION
@Thunnini  Kava did a mainnet upgrade today and this is the new chainId for transactions.

Can we also have the beta: true tag removed. I'm happy to add that to this PR now that launch is completed.