### PR TITLE
Update Low and Average Fees for Kava

### DIFF
--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -1172,8 +1172,8 @@ export const EmbedChainInfos: ChainInfo[] = [
       },
     ],
     gasPriceStep: {
-      low: 0,
-      average: 0.001,
+      low: 0.001,
+      average: 0.005,
       high: 0.25,
     },
     coinType: 459,


### PR DESCRIPTION
## What Changes
@Thunnini After the Kava-10 upgrade on May 25th, few (if any) validators are accepting zero fee transactions. This results in users' transactions getting stuck in mempool. This update will prevent that from occurring. 