### PR TITLE
bump regen low gas price from 0.01 to 0.015 so it matches min default rpc node price

### DIFF
--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -996,6 +996,11 @@ export const EmbedChainInfos: ChainInfo[] = [
         coinGeckoId: "regen",
       },
     ],
+    gasPriceStep: {
+      low: 0.015,
+      average: 0.025,
+      high: 0.04,
+    },
     features: ["ibc-go", "ibc-transfer", "ibc-go"],
   },
   {


### PR DESCRIPTION
Update Regen 'low' gas price to 0.015uregen to match the default RPC node min-gas-price (i.e. make 'low' a usable option for regen).

Resolves #405 