### PR TITLE
Remove KAVA from the beta section

### DIFF
--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -1177,7 +1177,7 @@ export const EmbedChainInfos: ChainInfo[] = [
       high: 0.25,
     },
     coinType: 459,
-    beta: true,
+    beta: false,
   },
   {
     rpc: IXO_RPC_ENDPOINT,


### PR DESCRIPTION
Kava's chain upgrade was completed so the chain should no longer be listed under the beta section.
@Thunnini

I also have a possibly unrelated question related to a recent deploy from keplr. Our users got prompted with the [Bip44 modal ](https://github.com/chainapsis/keplr-wallet/blob/2229367b58076fc6426bf956bd1215d6ab0deb3c/packages/extension/src/pages/main/bip44-select-modal.tsx#L111) and picked the incorrect address (the one generated by the 118 coin type instead of kava's 459 coin type. As a result they have a different kava address.  How are users able to get that radio select modal to load back up so they can choose the other address? I've played around in the UI, but can't seem to get it to re-prompt.