### PR TITLE
URGENT - Increase kava gas price step

### DIFF
--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -1170,7 +1170,7 @@ export const EmbedChainInfos: ChainInfo[] = [
         coinDecimals: 6,
         coinGeckoId: "kava",
       },
-    ], 
+    ],
     gasPriceStep: {
       low: 0.05,
       average: 0.1,

--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -1170,10 +1170,10 @@ export const EmbedChainInfos: ChainInfo[] = [
         coinDecimals: 6,
         coinGeckoId: "kava",
       },
-    ],
+    ], 
     gasPriceStep: {
-      low: 0.001,
-      average: 0.005,
+      low: 0.05,
+      average: 0.1,
       high: 0.25,
     },
     coinType: 459,


### PR DESCRIPTION
Due to high network activity, Kava users have been seeing their transactions fail using the previous low and average gas price. 
@Thunnini 