### PR TITLE
Update EVMOS min-gas-price

### DIFF
--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -1744,7 +1744,7 @@ export const EmbedChainInfos: ChainInfo[] = [
       },
     ],
     gasPriceStep: {
-      low: 10000000000,
+      low: 25000000000,
       average: 25000000000,
       high: 40000000000,
     },


### PR DESCRIPTION
the next [Evmos upgrade](https://www.mintscan.io/evmos/proposals/29) will force the min-gas-prices:  `25000000000aevmos`