### PR TITLE
Implement the tx simulation for estimating gas

### DIFF
--- a/packages/extension/src/components/form/fee-buttons/fee-buttons.module.scss
+++ b/packages/extension/src/components/form/fee-buttons/fee-buttons.module.scss
@@ -3,6 +3,8 @@
 
   .button {
     flex: 1;
+    padding-left: 0;
+    padding-right: 0;
 
     box-shadow: 0 1px 3px rgba(50, 50, 93, 0.15), 0 1px 0 rgba(0, 0, 0, 0.02);
     &:not(:global(.btn-primary)) {

--- a/packages/extension/src/components/form/fee-buttons/fee-buttons.tsx
+++ b/packages/extension/src/components/form/fee-buttons/fee-buttons.tsx
@@ -21,6 +21,7 @@ import { observer } from "mobx-react-lite";
 import {
   IFeeConfig,
   IGasConfig,
+  IGasSimulator,
   InsufficientFeeError,
   NotLoadedFeeError,
 } from "@keplr-wallet/hooks";
@@ -29,6 +30,7 @@ import { useLanguage } from "../../../languages";
 import { useIntl } from "react-intl";
 import { GasInput } from "../gas-input";
 import { action, makeObservable, observable } from "mobx";
+import { GasContainer } from "../gas-form";
 
 export interface FeeButtonsProps {
   feeConfig: IFeeConfig;
@@ -44,6 +46,7 @@ export interface FeeButtonsProps {
   };
 
   gasLabel?: string;
+  gasSimulator?: IGasSimulator;
 }
 
 class FeeButtonState {
@@ -72,6 +75,7 @@ export const FeeButtons: FunctionComponent<FeeButtonsProps> = observer(
     label,
     feeSelectLabels = { low: "Low", average: "Average", high: "High" },
     gasLabel,
+    gasSimulator,
   }) => {
     // This may be not the good way to handle the states across the components.
     // But, rather than using the context API with boilerplate code, just use the mobx state to simplify the logic.
@@ -89,7 +93,15 @@ export const FeeButtons: FunctionComponent<FeeButtonsProps> = observer(
           />
         ) : null}
         {feeButtonState.isGasInputOpen || !feeConfig.feeCurrency ? (
-          <GasInput label={gasLabel} gasConfig={gasConfig} />
+          gasSimulator ? (
+            <GasContainer
+              label={gasLabel}
+              gasConfig={gasConfig}
+              gasSimulator={gasSimulator}
+            />
+          ) : (
+            <GasInput label={gasLabel} gasConfig={gasConfig} />
+          )
         ) : null}
       </React.Fragment>
     );

--- a/packages/extension/src/components/form/fee-buttons/fee-buttons.tsx
+++ b/packages/extension/src/components/form/fee-buttons/fee-buttons.tsx
@@ -90,6 +90,7 @@ export const FeeButtons: FunctionComponent<FeeButtonsProps> = observer(
             label={label}
             feeSelectLabels={feeSelectLabels}
             feeButtonState={feeButtonState}
+            gasSimulator={gasSimulator}
           />
         ) : null}
         {feeButtonState.isGasInputOpen || !feeConfig.feeCurrency ? (
@@ -111,7 +112,7 @@ export const FeeButtons: FunctionComponent<FeeButtonsProps> = observer(
 export const FeeButtonsInner: FunctionComponent<
   Pick<
     FeeButtonsProps,
-    "feeConfig" | "priceStore" | "label" | "feeSelectLabels"
+    "feeConfig" | "priceStore" | "label" | "feeSelectLabels" | "gasSimulator"
   > & { feeButtonState: FeeButtonState }
 > = observer(
   ({
@@ -120,6 +121,7 @@ export const FeeButtonsInner: FunctionComponent<
     label,
     feeSelectLabels = { low: "Low", average: "Average", high: "High" },
     feeButtonState,
+    gasSimulator,
   }) => {
     useEffect(() => {
       if (feeConfig.feeCurrency && !feeConfig.fee) {
@@ -181,6 +183,10 @@ export const FeeButtonsInner: FunctionComponent<
         }
       }
     })();
+
+    if (gasSimulator && gasSimulator.isSimulating) {
+      isFeeLoading = true;
+    }
 
     return (
       <FormGroup style={{ position: "relative" }}>

--- a/packages/extension/src/components/form/gas-form/auto.module.scss
+++ b/packages/extension/src/components/form/gas-form/auto.module.scss
@@ -4,5 +4,10 @@
 
   .gasAdjustmentContainer {
     display: flex;
+
+    .multiply-icon {
+      margin: 0 8px;
+      margin-top: 42px;
+    }
   }
 }

--- a/packages/extension/src/components/form/gas-form/auto.module.scss
+++ b/packages/extension/src/components/form/gas-form/auto.module.scss
@@ -1,0 +1,8 @@
+.container {
+  display: flex;
+  flex-direction: column;
+
+  .gasAdjustmentContainer {
+    display: flex;
+  }
+}

--- a/packages/extension/src/components/form/gas-form/auto.tsx
+++ b/packages/extension/src/components/form/gas-form/auto.tsx
@@ -2,7 +2,8 @@ import React, { FunctionComponent } from "react";
 import { observer } from "mobx-react-lite";
 import styleAuto from "./auto.module.scss";
 import { Input } from "../input";
-import { IGasConfig, IGasSimulator } from "@keplr-wallet/hooks";
+import { IGasConfig, IGasSimulator, GasSimulator } from "@keplr-wallet/hooks";
+import { Alert } from "reactstrap";
 
 const MultiplyIcon: FunctionComponent<{
   size: number;
@@ -34,6 +35,13 @@ export const GasAutoContainer: FunctionComponent<{
 }> = observer(({ gasConfig, gasSimulator }) => {
   return (
     <div className={styleAuto.container}>
+      {gasSimulator instanceof GasSimulator &&
+      gasSimulator.outdatedCosmosSdk ? (
+        <Alert color="warning">
+          Gas estimation is not supported, because this chain uses outdated
+          cosmos-sdk
+        </Alert>
+      ) : null}
       <div className={styleAuto.gasAdjustmentContainer}>
         <Input
           label="Gas Adjustment"

--- a/packages/extension/src/components/form/gas-form/auto.tsx
+++ b/packages/extension/src/components/form/gas-form/auto.tsx
@@ -3,7 +3,6 @@ import { observer } from "mobx-react-lite";
 import styleAuto from "./auto.module.scss";
 import { Input } from "../input";
 import { IGasConfig, IGasSimulator } from "@keplr-wallet/hooks";
-import { Alert } from "reactstrap";
 
 const MultiplyIcon: FunctionComponent<{
   size: number;
@@ -31,18 +30,10 @@ const MultiplyIcon: FunctionComponent<{
 export const GasAutoContainer: FunctionComponent<{
   gasConfig: IGasConfig;
 
-  gasSimulator: IGasSimulator & {
-    outdatedCosmosSdk?: boolean;
-  };
+  gasSimulator: IGasSimulator;
 }> = observer(({ gasConfig, gasSimulator }) => {
   return (
     <div className={styleAuto.container}>
-      {gasSimulator.outdatedCosmosSdk ? (
-        <Alert color="warning">
-          Gas estimation is not supported, because this chain uses outdated
-          cosmos-sdk
-        </Alert>
-      ) : null}
       <div className={styleAuto.gasAdjustmentContainer}>
         <Input
           label="Gas Adjustment"

--- a/packages/extension/src/components/form/gas-form/auto.tsx
+++ b/packages/extension/src/components/form/gas-form/auto.tsx
@@ -1,0 +1,42 @@
+import React, { FunctionComponent } from "react";
+import { observer } from "mobx-react-lite";
+import styleAuto from "./auto.module.scss";
+import { Input } from "../input";
+import { IGasConfig, IGasSimulator } from "@keplr-wallet/hooks";
+
+export const GasAutoContainer: FunctionComponent<{
+  gasConfig: IGasConfig;
+
+  gasSimulator: IGasSimulator;
+}> = observer(({ gasConfig, gasSimulator }) => {
+  return (
+    <div className={styleAuto.container}>
+      <div className={styleAuto.gasAdjustmentContainer}>
+        <Input
+          label="Gas Adjustment"
+          value={
+            gasSimulator.gasEstimated != null
+              ? gasSimulator.gasAdjustmentRaw
+              : "-"
+          }
+          type={gasSimulator.gasEstimated != null ? "number" : "text"}
+          readOnly={gasSimulator.gasEstimated == null}
+          step={0.1}
+          onChange={(e) => {
+            e.preventDefault();
+
+            gasSimulator.setGasAdjustment(e.target.value);
+          }}
+        />
+        <Input
+          label="Estimated"
+          readOnly={true}
+          value={gasSimulator.gasEstimated ?? "-"}
+        />
+      </div>
+      <div>
+        <Input label="Gas amount" readOnly={true} value={gasConfig.gas} />
+      </div>
+    </div>
+  );
+});

--- a/packages/extension/src/components/form/gas-form/auto.tsx
+++ b/packages/extension/src/components/form/gas-form/auto.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent } from "react";
 import { observer } from "mobx-react-lite";
 import styleAuto from "./auto.module.scss";
 import { Input } from "../input";
-import { IGasConfig, IGasSimulator, GasSimulator } from "@keplr-wallet/hooks";
+import { IGasConfig, IGasSimulator } from "@keplr-wallet/hooks";
 import { Alert } from "reactstrap";
 
 const MultiplyIcon: FunctionComponent<{
@@ -31,12 +31,13 @@ const MultiplyIcon: FunctionComponent<{
 export const GasAutoContainer: FunctionComponent<{
   gasConfig: IGasConfig;
 
-  gasSimulator: IGasSimulator;
+  gasSimulator: IGasSimulator & {
+    outdatedCosmosSdk?: boolean;
+  };
 }> = observer(({ gasConfig, gasSimulator }) => {
   return (
     <div className={styleAuto.container}>
-      {gasSimulator instanceof GasSimulator &&
-      gasSimulator.outdatedCosmosSdk ? (
+      {gasSimulator.outdatedCosmosSdk ? (
         <Alert color="warning">
           Gas estimation is not supported, because this chain uses outdated
           cosmos-sdk

--- a/packages/extension/src/components/form/gas-form/auto.tsx
+++ b/packages/extension/src/components/form/gas-form/auto.tsx
@@ -4,6 +4,29 @@ import styleAuto from "./auto.module.scss";
 import { Input } from "../input";
 import { IGasConfig, IGasSimulator } from "@keplr-wallet/hooks";
 
+const MultiplyIcon: FunctionComponent<{
+  size: number;
+  color: string;
+}> = ({ size, color }) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      fill="none"
+      viewBox="0 0 14 14"
+    >
+      <path
+        stroke={color}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
+        d="M12.657 12.686L1.343 1.373m11.314 0L1.343 12.686 12.657 1.373z"
+      />
+    </svg>
+  );
+};
+
 export const GasAutoContainer: FunctionComponent<{
   gasConfig: IGasConfig;
 
@@ -28,6 +51,9 @@ export const GasAutoContainer: FunctionComponent<{
             gasSimulator.setGasAdjustment(e.target.value);
           }}
         />
+        <div className={styleAuto.multiplyIcon}>
+          <MultiplyIcon size={16} color="#C6C6CD" />
+        </div>
         <Input
           label="Estimated"
           readOnly={true}

--- a/packages/extension/src/components/form/gas-form/container.module.scss
+++ b/packages/extension/src/components/form/gas-form/container.module.scss
@@ -1,0 +1,24 @@
+.container {
+  padding: 12px;
+  background-color: white;
+  border-radius: 6px;
+
+  box-shadow: 0 1px 3px rgb(50 50 93 / 15%), 0 1px 0 rgb(0 0 0 / 2%) !important;
+
+  margin-bottom: 1.5rem;
+
+  .auto-button-group {
+    margin-bottom: 0.5rem;
+
+    display: flex;
+    align-items: center;
+
+    .label {
+      font-weight: 500;
+      font-size: 14px;
+      line-height: 21px;
+      color: #323c4a;
+      margin-right: 0.325rem;
+    }
+  }
+}

--- a/packages/extension/src/components/form/gas-form/container.tsx
+++ b/packages/extension/src/components/form/gas-form/container.tsx
@@ -1,0 +1,41 @@
+import React, { FunctionComponent } from "react";
+import { IGasConfig, IGasSimulator } from "@keplr-wallet/hooks";
+import { observer } from "mobx-react-lite";
+import { GasAutoContainer } from "./auto";
+import { GasInput } from "../gas-input";
+
+export const GasContainer: FunctionComponent<{
+  label?: string;
+  gasConfig: IGasConfig;
+
+  gasSimulator: IGasSimulator;
+}> = observer(({ label, gasConfig, gasSimulator }) => {
+  return (
+    <div
+      style={{
+        padding: "8px",
+        backgroundColor: "white",
+        borderStyle: "solid",
+        borderWidth: "1px",
+        borderColor: "black",
+      }}
+    >
+      {label ? <div>{label}</div> : null}
+      <label key="toggle" className="custom-toggle" style={{ marginBottom: 0 }}>
+        <input
+          type="checkbox"
+          checked={gasSimulator.enabled}
+          onChange={() => {
+            gasSimulator.setEnabled(!gasSimulator.enabled);
+          }}
+        />
+        <span className="custom-toggle-slider rounded-circle" />
+      </label>
+      {gasSimulator.enabled ? (
+        <GasAutoContainer gasConfig={gasConfig} gasSimulator={gasSimulator} />
+      ) : (
+        <GasInput gasConfig={gasConfig} />
+      )}
+    </div>
+  );
+});

--- a/packages/extension/src/components/form/gas-form/container.tsx
+++ b/packages/extension/src/components/form/gas-form/container.tsx
@@ -4,12 +4,17 @@ import { observer } from "mobx-react-lite";
 import { GasAutoContainer } from "./auto";
 import { GasInput } from "../gas-input";
 import styleContainer from "./container.module.scss";
+import { Alert } from "reactstrap";
 
 export const GasContainer: FunctionComponent<{
   label?: string;
   gasConfig: IGasConfig;
 
-  gasSimulator: IGasSimulator;
+  gasSimulator: IGasSimulator & {
+    outdatedCosmosSdk?: boolean;
+    forceDisabled?: boolean;
+    forceDisableReason?: Error | undefined;
+  };
 }> = observer(({ label, gasConfig, gasSimulator }) => {
   return (
     <div className={styleContainer.container}>
@@ -25,12 +30,23 @@ export const GasContainer: FunctionComponent<{
             type="checkbox"
             checked={gasSimulator.enabled}
             onChange={() => {
-              gasSimulator.setEnabled(!gasSimulator.enabled);
+              if (!gasSimulator.forceDisabled) {
+                gasSimulator.setEnabled(!gasSimulator.enabled);
+              }
             }}
           />
           <span className="custom-toggle-slider rounded-circle" />
         </label>
       </div>
+      {gasSimulator.outdatedCosmosSdk ? (
+        <Alert color="warning">
+          Gas estimation is not supported, because this chain uses outdated
+          cosmos-sdk
+        </Alert>
+      ) : null}
+      {gasSimulator.forceDisabled && gasSimulator.forceDisableReason ? (
+        <Alert color="warning">{gasSimulator.forceDisableReason.message}</Alert>
+      ) : null}
       {gasSimulator.enabled ? (
         <GasAutoContainer gasConfig={gasConfig} gasSimulator={gasSimulator} />
       ) : (

--- a/packages/extension/src/components/form/gas-form/container.tsx
+++ b/packages/extension/src/components/form/gas-form/container.tsx
@@ -3,6 +3,7 @@ import { IGasConfig, IGasSimulator } from "@keplr-wallet/hooks";
 import { observer } from "mobx-react-lite";
 import { GasAutoContainer } from "./auto";
 import { GasInput } from "../gas-input";
+import styleContainer from "./container.module.scss";
 
 export const GasContainer: FunctionComponent<{
   label?: string;
@@ -11,30 +12,29 @@ export const GasContainer: FunctionComponent<{
   gasSimulator: IGasSimulator;
 }> = observer(({ label, gasConfig, gasSimulator }) => {
   return (
-    <div
-      style={{
-        padding: "8px",
-        backgroundColor: "white",
-        borderStyle: "solid",
-        borderWidth: "1px",
-        borderColor: "black",
-      }}
-    >
-      {label ? <div>{label}</div> : null}
-      <label key="toggle" className="custom-toggle" style={{ marginBottom: 0 }}>
-        <input
-          type="checkbox"
-          checked={gasSimulator.enabled}
-          onChange={() => {
-            gasSimulator.setEnabled(!gasSimulator.enabled);
-          }}
-        />
-        <span className="custom-toggle-slider rounded-circle" />
-      </label>
+    <div className={styleContainer.container}>
+      <div className={styleContainer.autoButtonGroup}>
+        <div style={{ flex: 1 }} />
+        <div className={styleContainer.label}>Auto</div>
+        <label
+          key="toggle"
+          className="custom-toggle"
+          style={{ marginBottom: 0 }}
+        >
+          <input
+            type="checkbox"
+            checked={gasSimulator.enabled}
+            onChange={() => {
+              gasSimulator.setEnabled(!gasSimulator.enabled);
+            }}
+          />
+          <span className="custom-toggle-slider rounded-circle" />
+        </label>
+      </div>
       {gasSimulator.enabled ? (
         <GasAutoContainer gasConfig={gasConfig} gasSimulator={gasSimulator} />
       ) : (
-        <GasInput gasConfig={gasConfig} />
+        <GasInput label={label} gasConfig={gasConfig} />
       )}
     </div>
   );

--- a/packages/extension/src/components/form/gas-form/index.ts
+++ b/packages/extension/src/components/form/gas-form/index.ts
@@ -1,0 +1,2 @@
+export * from "./container";
+export * from "./auto";

--- a/packages/extension/src/config.ui.ts
+++ b/packages/extension/src/config.ui.ts
@@ -18,6 +18,8 @@ export const AutoFetchingFiatValueInterval = 300 * 1000; // 5min
 
 export const AutoFetchingAssetsInterval = 15 * 1000; // 15sec
 
+export const DefaultGasMsgWithdrawRewards = 140000; // Gas per messages.
+
 // Endpoint for Ethereum node.
 // This is used for ENS.
 export const EthereumEndpoint = ETHEREUM_ENDPOINT;

--- a/packages/extension/src/pages/ibc-transfer/index.tsx
+++ b/packages/extension/src/pages/ibc-transfer/index.tsx
@@ -51,7 +51,6 @@ export const IBCTransferPage: FunctionComponent = observer(() => {
     new ExtensionKVStore("gas-simulator.ibc.transfer"),
     chainStore,
     chainStore.current.chainId,
-    ibcTransferConfigs.memoConfig,
     ibcTransferConfigs.gasConfig,
     ibcTransferConfigs.feeConfig,
     "native",

--- a/packages/extension/src/pages/ibc-transfer/index.tsx
+++ b/packages/extension/src/pages/ibc-transfer/index.tsx
@@ -49,6 +49,7 @@ export const IBCTransferPage: FunctionComponent = observer(() => {
   );
   const gasSimulator = useGasSimulator(
     new ExtensionKVStore("gas-simulator.ibc.transfer"),
+    chainStore,
     chainStore.current.chainId,
     ibcTransferConfigs.gasConfig,
     "native",

--- a/packages/extension/src/pages/ibc-transfer/index.tsx
+++ b/packages/extension/src/pages/ibc-transfer/index.tsx
@@ -16,15 +16,18 @@ import {
   IAmountConfig,
   IFeeConfig,
   IGasConfig,
+  IGasSimulator,
   IIBCChannelConfig,
   IMemoConfig,
   IRecipientConfig,
+  useGasSimulator,
   useIBCTransferConfig,
 } from "@keplr-wallet/hooks";
 import { useStore } from "../../stores";
 import { EthereumEndpoint } from "../../config.ui";
 import { useNotification } from "../../components/notification";
 import { FormattedMessage, useIntl } from "react-intl";
+import { ExtensionKVStore } from "@keplr-wallet/common";
 
 export const IBCTransferPage: FunctionComponent = observer(() => {
   const history = useHistory();
@@ -43,6 +46,31 @@ export const IBCTransferPage: FunctionComponent = observer(() => {
     chainStore.current.chainId,
     accountInfo.bech32Address,
     EthereumEndpoint
+  );
+  const gasSimulator = useGasSimulator(
+    new ExtensionKVStore("gas-simulator.ibc.transfer"),
+    chainStore.current.chainId,
+    ibcTransferConfigs.gasConfig,
+    "native",
+    async () => {
+      if (!ibcTransferConfigs.channelConfig.channel) {
+        throw new Error("Channel not set yet");
+      }
+
+      const tx = accountInfo.cosmos.makeIBCTransferTx(
+        ibcTransferConfigs.channelConfig.channel,
+        ibcTransferConfigs.amountConfig.amount,
+        ibcTransferConfigs.amountConfig.sendCurrency,
+        ibcTransferConfigs.recipientConfig.recipient
+      );
+
+      return (
+        await tx.simulate(
+          ibcTransferConfigs.feeConfig.toStdFee(),
+          ibcTransferConfigs.memoConfig.memo
+        )
+      ).gasUsed;
+    }
   );
 
   const toChainId =
@@ -77,16 +105,20 @@ export const IBCTransferPage: FunctionComponent = observer(() => {
           amountConfig={ibcTransferConfigs.amountConfig}
           feeConfig={ibcTransferConfigs.feeConfig}
           gasConfig={ibcTransferConfigs.gasConfig}
+          gasSimulator={gasSimulator}
           onSubmit={async () => {
             if (ibcTransferConfigs.channelConfig.channel) {
               try {
-                await accountInfo.cosmos.sendIBCTransferMsg(
+                const tx = accountInfo.cosmos.makeIBCTransferTx(
                   ibcTransferConfigs.channelConfig.channel,
                   ibcTransferConfigs.amountConfig.amount,
                   ibcTransferConfigs.amountConfig.sendCurrency,
-                  ibcTransferConfigs.recipientConfig.recipient,
-                  ibcTransferConfigs.memoConfig.memo,
+                  ibcTransferConfigs.recipientConfig.recipient
+                );
+
+                await tx.send(
                   ibcTransferConfigs.feeConfig.toStdFee(),
+                  ibcTransferConfigs.memoConfig.memo,
                   {
                     preferNoSetFee: true,
                     preferNoSetMemo: true,
@@ -104,6 +136,7 @@ export const IBCTransferPage: FunctionComponent = observer(() => {
                     },
                   }
                 );
+
                 history.push("/");
               } catch (e) {
                 history.replace("/");
@@ -193,51 +226,55 @@ export const IBCTransferPageAmount: FunctionComponent<{
   amountConfig: IAmountConfig;
   feeConfig: IFeeConfig;
   gasConfig: IGasConfig;
+  gasSimulator?: IGasSimulator;
   onSubmit: () => void;
-}> = observer(({ amountConfig, feeConfig, gasConfig, onSubmit }) => {
-  const intl = useIntl();
-  const { accountStore, chainStore, priceStore } = useStore();
+}> = observer(
+  ({ amountConfig, feeConfig, gasConfig, gasSimulator, onSubmit }) => {
+    const intl = useIntl();
+    const { accountStore, chainStore, priceStore } = useStore();
 
-  const accountInfo = accountStore.getAccount(chainStore.current.chainId);
+    const accountInfo = accountStore.getAccount(chainStore.current.chainId);
 
-  const isValid =
-    amountConfig.error == null &&
-    feeConfig.error == null &&
-    gasConfig.error == null;
+    const isValid =
+      amountConfig.error == null &&
+      feeConfig.error == null &&
+      gasConfig.error == null;
 
-  return (
-    <form className={style.formContainer}>
-      <div className={style.formInnerContainer}>
-        <CoinInput
-          label={intl.formatMessage({
-            id: "send.input.amount",
-          })}
-          amountConfig={amountConfig}
-        />
-        <div style={{ flex: 1 }} />
-        <FeeButtons
-          label={intl.formatMessage({
-            id: "send.input.fee",
-          })}
-          feeConfig={feeConfig}
-          gasConfig={gasConfig}
-          priceStore={priceStore}
-        />
-        <Button
-          type="submit"
-          color="primary"
-          block
-          disabled={!isValid}
-          data-loading={accountInfo.isSendingMsg === "ibcTransfer"}
-          onClick={(e) => {
-            e.preventDefault();
+    return (
+      <form className={style.formContainer}>
+        <div className={style.formInnerContainer}>
+          <CoinInput
+            label={intl.formatMessage({
+              id: "send.input.amount",
+            })}
+            amountConfig={amountConfig}
+          />
+          <div style={{ flex: 1 }} />
+          <FeeButtons
+            label={intl.formatMessage({
+              id: "send.input.fee",
+            })}
+            feeConfig={feeConfig}
+            gasConfig={gasConfig}
+            priceStore={priceStore}
+            gasSimulator={gasSimulator}
+          />
+          <Button
+            type="submit"
+            color="primary"
+            block
+            disabled={!isValid}
+            data-loading={accountInfo.isSendingMsg === "ibcTransfer"}
+            onClick={(e) => {
+              e.preventDefault();
 
-            onSubmit();
-          }}
-        >
-          <FormattedMessage id="ibc.transfer.submit" />
-        </Button>
-      </div>
-    </form>
-  );
-});
+              onSubmit();
+            }}
+          >
+            <FormattedMessage id="ibc.transfer.submit" />
+          </Button>
+        </div>
+      </form>
+    );
+  }
+);

--- a/packages/extension/src/pages/ibc-transfer/index.tsx
+++ b/packages/extension/src/pages/ibc-transfer/index.tsx
@@ -51,26 +51,21 @@ export const IBCTransferPage: FunctionComponent = observer(() => {
     new ExtensionKVStore("gas-simulator.ibc.transfer"),
     chainStore,
     chainStore.current.chainId,
+    ibcTransferConfigs.memoConfig,
     ibcTransferConfigs.gasConfig,
+    ibcTransferConfigs.feeConfig,
     "native",
-    async () => {
+    () => {
       if (!ibcTransferConfigs.channelConfig.channel) {
         throw new Error("Channel not set yet");
       }
 
-      const tx = accountInfo.cosmos.makeIBCTransferTx(
+      return accountInfo.cosmos.makeIBCTransferTx(
         ibcTransferConfigs.channelConfig.channel,
         ibcTransferConfigs.amountConfig.amount,
         ibcTransferConfigs.amountConfig.sendCurrency,
         ibcTransferConfigs.recipientConfig.recipient
       );
-
-      return (
-        await tx.simulate(
-          ibcTransferConfigs.feeConfig.toStdFee(),
-          ibcTransferConfigs.memoConfig.memo
-        )
-      ).gasUsed;
     }
   );
 

--- a/packages/extension/src/pages/ibc-transfer/index.tsx
+++ b/packages/extension/src/pages/ibc-transfer/index.tsx
@@ -59,6 +59,16 @@ export const IBCTransferPage: FunctionComponent = observer(() => {
         throw new Error("Channel not set yet");
       }
 
+      // Prefer not to use the gas config or fee config,
+      // because gas simulator can change the gas config and fee config from the result of reaction,
+      // and it can make repeated reaction.
+      if (
+        ibcTransferConfigs.amountConfig.error != null ||
+        ibcTransferConfigs.recipientConfig.error != null
+      ) {
+        throw new Error("Not ready to simulate tx");
+      }
+
       return accountInfo.cosmos.makeIBCTransferTx(
         ibcTransferConfigs.channelConfig.channel,
         ibcTransferConfigs.amountConfig.amount,

--- a/packages/extension/src/pages/main/stake.tsx
+++ b/packages/extension/src/pages/main/stake.tsx
@@ -15,6 +15,7 @@ import { useNotification } from "../../components/notification";
 import { useHistory } from "react-router";
 
 import { FormattedMessage } from "react-intl";
+import { DefaultGasMsgWithdrawRewards } from "../../config.ui";
 
 export const StakeView: FunctionComponent = observer(() => {
   const history = useHistory();
@@ -49,8 +50,11 @@ export const StakeView: FunctionComponent = observer(() => {
         // When the user delegated too many validators,
         // it can't be sent to withdraw rewards from all validators due to the block gas limit.
         // So, to prevent this problem, just send the msgs up to 8.
+        const validatorAddresses = rewards.getDescendingPendingRewardValidatorAddresses(
+          8
+        );
         const tx = accountInfo.cosmos.makeWithdrawDelegationRewardTx(
-          rewards.getDescendingPendingRewardValidatorAddresses(8)
+          validatorAddresses
         );
 
         let gas: number;
@@ -60,7 +64,7 @@ export const StakeView: FunctionComponent = observer(() => {
         } catch (e) {
           console.log(e);
 
-          gas = tx.defaultGas;
+          gas = DefaultGasMsgWithdrawRewards * validatorAddresses.length;
         }
 
         await tx.send(

--- a/packages/extension/src/pages/main/stake.tsx
+++ b/packages/extension/src/pages/main/stake.tsx
@@ -59,8 +59,10 @@ export const StakeView: FunctionComponent = observer(() => {
 
         let gas: number;
         try {
-          // Gas adjustment is 1.3
-          gas = (await tx.simulate()).gasUsed * 1.3;
+          // Gas adjustment is 1.5
+          // Since there is currently no convenient way to adjust the gas adjustment on the UI,
+          // Use high gas adjustment to prevent failure.
+          gas = (await tx.simulate()).gasUsed * 1.5;
         } catch (e) {
           console.log(e);
 

--- a/packages/extension/src/pages/send/index.tsx
+++ b/packages/extension/src/pages/send/index.tsx
@@ -100,6 +100,16 @@ export const SendPage: FunctionComponent = observer(() => {
         throw new Error("Send currency not set");
       }
 
+      // Prefer not to use the gas config or fee config,
+      // because gas simulator can change the gas config and fee config from the result of reaction,
+      // and it can make repeated reaction.
+      if (
+        sendConfigs.amountConfig.error != null ||
+        sendConfigs.recipientConfig.error != null
+      ) {
+        throw new Error("Not ready to simulate tx");
+      }
+
       const denomHelper = new DenomHelper(
         sendConfigs.amountConfig.sendCurrency.coinMinimalDenom
       );

--- a/packages/extension/src/pages/send/index.tsx
+++ b/packages/extension/src/pages/send/index.tsx
@@ -92,7 +92,6 @@ export const SendPage: FunctionComponent = observer(() => {
     new ExtensionKVStore("gas-simulator.main.send"),
     chainStore,
     current.chainId,
-    sendConfigs.memoConfig,
     sendConfigs.gasConfig,
     sendConfigs.feeConfig,
     gasSimulatorKey,

--- a/packages/extension/src/pages/send/index.tsx
+++ b/packages/extension/src/pages/send/index.tsx
@@ -92,9 +92,11 @@ export const SendPage: FunctionComponent = observer(() => {
     new ExtensionKVStore("gas-simulator.main.send"),
     chainStore,
     current.chainId,
+    sendConfigs.memoConfig,
     sendConfigs.gasConfig,
+    sendConfigs.feeConfig,
     gasSimulatorKey,
-    async () => {
+    () => {
       if (!sendConfigs.amountConfig.sendCurrency) {
         throw new Error("Send currency not set");
       }
@@ -104,22 +106,15 @@ export const SendPage: FunctionComponent = observer(() => {
       );
       // I don't know why, but simulation does not work for secret20
       if (denomHelper.type === "secret20") {
-        return accountInfo.secret.msgOpts.send.secret20.gas;
+        throw new Error("Simulating secret wasm not supported");
       }
 
-      const tx = accountInfo.makeSendTokenTx(
+      return accountInfo.makeSendTokenTx(
         sendConfigs.amountConfig.amount,
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         sendConfigs.amountConfig.sendCurrency!,
         sendConfigs.recipientConfig.recipient
       );
-
-      return (
-        await tx.simulate(
-          sendConfigs.feeConfig.toStdFee(),
-          sendConfigs.memoConfig.memo
-        )
-      ).gasUsed;
     }
   );
 

--- a/packages/extension/src/pages/send/index.tsx
+++ b/packages/extension/src/pages/send/index.tsx
@@ -185,15 +185,18 @@ export const SendPage: FunctionComponent = observer(() => {
 
           if (accountInfo.isReadyToSendMsgs && txStateIsValid) {
             try {
-              const stdFee = sendConfigs.feeConfig.toStdFee();
-
-              await accountInfo.sendToken(
+              const tx = accountInfo.makeSendTokenTx(
                 sendConfigs.amountConfig.amount,
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 sendConfigs.amountConfig.sendCurrency!,
-                sendConfigs.recipientConfig.recipient,
+                sendConfigs.recipientConfig.recipient
+              );
+
+              await tx.simulateAndSend(
+                {
+                  gasAdjustment: 1.3,
+                },
                 sendConfigs.memoConfig.memo,
-                stdFee,
                 {
                   preferNoSetFee: true,
                   preferNoSetMemo: true,
@@ -208,6 +211,7 @@ export const SendPage: FunctionComponent = observer(() => {
                   },
                 }
               );
+
               if (!isDetachedPage) {
                 history.replace("/");
               }

--- a/packages/extension/src/pages/send/index.tsx
+++ b/packages/extension/src/pages/send/index.tsx
@@ -90,6 +90,7 @@ export const SendPage: FunctionComponent = observer(() => {
 
   const gasSimulator = useGasSimulator(
     new ExtensionKVStore("gas-simulator.main.send"),
+    chainStore,
     current.chainId,
     sendConfigs.gasConfig,
     gasSimulatorKey,

--- a/packages/extension/src/pages/send/index.tsx
+++ b/packages/extension/src/pages/send/index.tsx
@@ -113,7 +113,12 @@ export const SendPage: FunctionComponent = observer(() => {
         sendConfigs.recipientConfig.recipient
       );
 
-      return (await tx.simulate()).gasUsed;
+      return (
+        await tx.simulate(
+          sendConfigs.feeConfig.toStdFee(),
+          sendConfigs.memoConfig.memo
+        )
+      ).gasUsed;
     }
   );
 

--- a/packages/extension/src/pages/send/index.tsx
+++ b/packages/extension/src/pages/send/index.tsx
@@ -118,6 +118,31 @@ export const SendPage: FunctionComponent = observer(() => {
   );
 
   useEffect(() => {
+    // To simulate secretwasm, we need to include the signature in the tx.
+    // With the current structure, this approach is not possible.
+    if (
+      sendConfigs.amountConfig.sendCurrency &&
+      new DenomHelper(sendConfigs.amountConfig.sendCurrency.coinMinimalDenom)
+        .type === "secret20"
+    ) {
+      gasSimulator.forceDisable(
+        new Error("Simulating secret20 is not supported")
+      );
+      sendConfigs.gasConfig.setGas(
+        accountInfo.secret.msgOpts.send.secret20.gas
+      );
+    } else {
+      gasSimulator.forceDisable(false);
+      gasSimulator.setEnabled(true);
+    }
+  }, [
+    accountInfo.secret.msgOpts.send.secret20.gas,
+    gasSimulator,
+    sendConfigs.amountConfig.sendCurrency,
+    sendConfigs.gasConfig,
+  ]);
+
+  useEffect(() => {
     if (query.defaultDenom) {
       const currency = current.currencies.find(
         (cur) => cur.coinMinimalDenom === query.defaultDenom

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -32,6 +32,7 @@
     "@keplr-wallet/stores": "0.10.13",
     "@keplr-wallet/types": "0.10.13",
     "@keplr-wallet/unit": "0.10.13",
+    "axios": "^0.21.4",
     "long": "^4.0.0",
     "mobx": "^6.1.7",
     "mobx-utils": "^6.0.3",

--- a/packages/hooks/src/tx/gas-simulator.ts
+++ b/packages/hooks/src/tx/gas-simulator.ts
@@ -1,0 +1,163 @@
+import { IGasConfig } from "./types";
+import {
+  action,
+  autorun,
+  IReactionDisposer,
+  makeObservable,
+  observable,
+} from "mobx";
+
+export type SimulateGasFn = () => Promise<number>;
+
+export class GasSimulator {
+  @observable
+  protected _gasEstimated: number | undefined = undefined;
+
+  @observable
+  protected _gasAdjustmentRaw: string = "1.3";
+
+  @observable
+  protected _enabled: boolean = false;
+  @observable
+  protected _simulateGasFnIsProvided: boolean;
+
+  protected _disposers: IReactionDisposer[] = [];
+
+  constructor(
+    protected readonly gasConfig: IGasConfig,
+    protected simulateGasFn?: SimulateGasFn
+  ) {
+    this._simulateGasFnIsProvided = simulateGasFn != null;
+
+    makeObservable(this);
+
+    this.init();
+  }
+
+  get canEnabled(): boolean {
+    return this._simulateGasFnIsProvided;
+  }
+
+  /*
+   * Set `simulateGasFn` and `simulateGasFnIsProvided` and turn off `enabled` if simulateGasFn is null.
+   * But `simulateGasFn` is not observable.
+   * It is intended that `simulateGasFn` is not observable.
+   * See other comments for why `simulateGasFn` is not observable...
+   */
+  @action
+  setSimulateGasFn(simulateGasFn?: SimulateGasFn) {
+    this.simulateGasFn = simulateGasFn;
+    this._simulateGasFnIsProvided = simulateGasFn != null;
+
+    if (!simulateGasFn && this.enabled) {
+      console.log(
+        "Turn off gas simulator because the simulateGasFn becomes null"
+      );
+      this.setEnabled(false);
+    }
+  }
+
+  get enabled(): boolean {
+    return this._enabled;
+  }
+
+  @action
+  setEnabled(value: boolean) {
+    if (value && !this.canEnabled) {
+      console.log(
+        "You can't enable gas simulator because no simulateGasFn is provided"
+      );
+      this._enabled = false;
+      return;
+    }
+    this._enabled = value;
+  }
+
+  get gasEstimated(): number | undefined {
+    return this._gasEstimated;
+  }
+
+  get gasAdjustment(): number {
+    if (this._gasAdjustmentRaw === "") {
+      return 0;
+    }
+
+    const num = parseFloat(this._gasAdjustmentRaw);
+    if (Number.isNaN(num) || num < 0) {
+      return 0;
+    }
+
+    return num;
+  }
+
+  get gasAdjustmentRaw(): string {
+    return this._gasAdjustmentRaw;
+  }
+
+  @action
+  setGasAdjustment(gasAdjustment: string | number) {
+    if (typeof gasAdjustment === "number") {
+      if (gasAdjustment < 0 || gasAdjustment > 2) {
+        return;
+      }
+
+      this._gasAdjustmentRaw = gasAdjustment.toString();
+      return;
+    }
+
+    if (gasAdjustment === "") {
+      this._gasAdjustmentRaw = "";
+      return;
+    }
+
+    if (gasAdjustment.startsWith(".")) {
+      this._gasAdjustmentRaw = "0" + gasAdjustment;
+    }
+
+    const num = parseFloat(gasAdjustment);
+    if (Number.isNaN(num) || num < 0 || num > 2) {
+      return;
+    }
+
+    this._gasAdjustmentRaw = gasAdjustment;
+  }
+
+  protected init() {
+    this._disposers.push(
+      autorun(() => {
+        if (!this.enabled || !this.simulateGasFn) {
+          return;
+        }
+
+        const promise = this.simulateGasFn();
+
+        promise
+          .then((gasEstimated) => {
+            if (this.enabled) {
+              this._gasEstimated = gasEstimated;
+            }
+          })
+          .catch((e) => {
+            console.log(e);
+          });
+      })
+    );
+
+    this._disposers.push(
+      autorun(() => {
+        if (this.gasEstimated != null) {
+          this.gasConfig.setGas(this.gasEstimated * this.gasAdjustment);
+        }
+      })
+    );
+  }
+
+  protected dispose() {
+    for (const disposer of this._disposers) {
+      disposer();
+    }
+  }
+}
+
+// CONTRACT: Use with `observer`
+export const useGasSimulator: (gasConfig: IGasConfig, enabled: boolean) => {};

--- a/packages/hooks/src/tx/gas-simulator.ts
+++ b/packages/hooks/src/tx/gas-simulator.ts
@@ -165,7 +165,9 @@ export class GasSimulator implements IGasSimulator {
 
         const key = this.storeKey;
         if (!this._initialGasEstimatedMap.has(key)) {
-          this._initialGasEstimatedMap.set(key, null);
+          runInAction(() => {
+            this._initialGasEstimatedMap.set(key, null);
+          });
           this.kvStore.get<number>(key).then((saved) => {
             if (saved) {
               runInAction(() => {

--- a/packages/hooks/src/tx/gas-simulator.ts
+++ b/packages/hooks/src/tx/gas-simulator.ts
@@ -2,18 +2,24 @@ import { IGasConfig, IGasSimulator } from "./types";
 import {
   action,
   autorun,
+  computed,
   IReactionDisposer,
   makeObservable,
   observable,
   runInAction,
 } from "mobx";
 import { useEffect, useState } from "react";
+import { KVStore } from "@keplr-wallet/common";
+import { ChainIdHelper } from "@keplr-wallet/cosmos";
 
 export type SimulateGasFn = () => Promise<number>;
 
 export class GasSimulator implements IGasSimulator {
   @observable
-  protected _gasEstimated: number | undefined = undefined;
+  protected _chainId: string;
+
+  @observable
+  protected _key: string;
 
   @observable
   protected _gasAdjustmentRaw: string = "1.3";
@@ -21,16 +27,54 @@ export class GasSimulator implements IGasSimulator {
   @observable
   protected _enabled: boolean = false;
 
+  // Key is the store key (probably, ${chainIdentifier}/${key})
+  // Value is the last stored value.
+  // If the value is null, it means that there is no value stored or being loaded.
+  @observable.shallow
+  protected _initialGasEstimatedMap: Map<string, number | null> = new Map();
+
+  @observable.shallow
+  protected _recentGasEstimatedMap: Map<string, number> = new Map();
+
   protected _disposers: IReactionDisposer[] = [];
 
   constructor(
+    // TODO: Add comment about the reason why kvStore field is not observable.
+    protected kvStore: KVStore,
+    protected readonly initialChainId: string,
     protected readonly gasConfig: IGasConfig,
+    protected readonly initialKey: string,
     // TODO: Add comment about the reason why simulateGasFn field is not observable.
     protected simulateGasFn: SimulateGasFn
   ) {
+    this._chainId = initialChainId;
+    this._key = initialKey;
+
     makeObservable(this);
 
     this.init();
+  }
+
+  setKVStore(kvStore: KVStore) {
+    this.kvStore = kvStore;
+  }
+
+  get chainId(): string {
+    return this._chainId;
+  }
+
+  @action
+  setChainId(value: string) {
+    this._chainId = value;
+  }
+
+  get key(): string {
+    return this._key;
+  }
+
+  @action
+  setKey(value: string) {
+    this._key = value;
   }
 
   setSimulateGasFn(simulateGasFn: SimulateGasFn) {
@@ -47,7 +91,17 @@ export class GasSimulator implements IGasSimulator {
   }
 
   get gasEstimated(): number | undefined {
-    return this._gasEstimated;
+    const key = this.storeKey;
+    if (this._recentGasEstimatedMap.has(key)) {
+      return this._recentGasEstimatedMap.get(key);
+    }
+
+    const saved = this._initialGasEstimatedMap.get(key);
+    if (saved != null) {
+      return saved;
+    }
+
+    return undefined;
   }
 
   get gasAdjustment(): number {
@@ -102,6 +156,28 @@ export class GasSimulator implements IGasSimulator {
           return;
         }
 
+        const key = this.storeKey;
+        if (!this._initialGasEstimatedMap.has(key)) {
+          this._initialGasEstimatedMap.set(key, null);
+          this.kvStore.get<number>(key).then((saved) => {
+            if (saved) {
+              runInAction(() => {
+                this._initialGasEstimatedMap.set(key, saved);
+              });
+            }
+          });
+        }
+      })
+    );
+
+    this._disposers.push(
+      autorun(() => {
+        if (!this.enabled) {
+          return;
+        }
+
+        const key = this.storeKey;
+
         // The lines below look a bit odd...
         // But did this intentionally because we have to catch the error in both cases,
         // the error from the function returning the promise and the error from the returned promise.
@@ -110,7 +186,10 @@ export class GasSimulator implements IGasSimulator {
             .then((gasEstimated) => {
               if (this.enabled) {
                 runInAction(() => {
-                  this._gasEstimated = gasEstimated;
+                  this._recentGasEstimatedMap.set(key, gasEstimated);
+                });
+                this.kvStore.set(key, gasEstimated).catch((e) => {
+                  console.log(e);
                 });
               }
             })
@@ -138,16 +217,31 @@ export class GasSimulator implements IGasSimulator {
       disposer();
     }
   }
+
+  @computed
+  protected get storeKey(): string {
+    const chainIdentifier = ChainIdHelper.parse(this.chainId);
+    return `${chainIdentifier.identifier}/${this.key}`;
+  }
 }
 
 // CONTRACT: Use with `observer`
 export const useGasSimulator = (
+  kvStore: KVStore,
+  chainId: string,
   gasConfig: IGasConfig,
+  key: string,
   simulateGasFn: SimulateGasFn,
   initialDisabled?: boolean
 ) => {
   const [gasSimulator] = useState(() => {
-    const gasSimulator = new GasSimulator(gasConfig, simulateGasFn);
+    const gasSimulator = new GasSimulator(
+      kvStore,
+      chainId,
+      gasConfig,
+      key,
+      simulateGasFn
+    );
     if (initialDisabled) {
       gasSimulator.setEnabled(false);
     } else {
@@ -156,6 +250,9 @@ export const useGasSimulator = (
 
     return gasSimulator;
   });
+  gasSimulator.setKVStore(kvStore);
+  gasSimulator.setChainId(chainId);
+  gasSimulator.setKey(key);
   gasSimulator.setSimulateGasFn(simulateGasFn);
 
   useEffect(() => {

--- a/packages/hooks/src/tx/gas-simulator.ts
+++ b/packages/hooks/src/tx/gas-simulator.ts
@@ -110,6 +110,11 @@ export class GasSimulator extends TxChainSetter implements IGasSimulator {
   protected _enabled: boolean = false;
 
   @observable
+  protected _forceDisabled: boolean = false;
+  @observable
+  protected _forceDisableReason: Error | undefined = undefined;
+
+  @observable
   protected _isSimulating: boolean = false;
 
   // Key is the store key (probably, ${chainIdentifier}/${key})
@@ -161,12 +166,47 @@ export class GasSimulator extends TxChainSetter implements IGasSimulator {
   }
 
   get enabled(): boolean {
+    if (this._forceDisabled) {
+      return false;
+    }
+
     return this._enabled;
   }
 
   @action
   setEnabled(value: boolean) {
+    if (this._forceDisabled && value) {
+      console.log(
+        "Gas simulator is disabled by force. You can not enable the gas simulator"
+      );
+      return;
+    }
+
     this._enabled = value;
+  }
+
+  get forceDisabled(): boolean {
+    return this._forceDisabled;
+  }
+
+  get forceDisableReason(): Error | undefined {
+    return this._forceDisableReason;
+  }
+
+  @action
+  forceDisable(valueOrReason: boolean | Error) {
+    if (!valueOrReason) {
+      this._forceDisabled = false;
+      this._forceDisableReason = undefined;
+    } else {
+      if (this.enabled) {
+        this.setEnabled(false);
+      }
+      this._forceDisabled = true;
+      if (typeof valueOrReason !== "boolean") {
+        this._forceDisableReason = valueOrReason;
+      }
+    }
   }
 
   get outdatedCosmosSdk(): boolean {

--- a/packages/hooks/src/tx/index.ts
+++ b/packages/hooks/src/tx/index.ts
@@ -11,3 +11,4 @@ export * from "./chain";
 export * from "./delegate-tx";
 export * from "./undelegate-tx";
 export * from "./redelegate-tx";
+export * from "./gas-simulator";

--- a/packages/hooks/src/tx/types.ts
+++ b/packages/hooks/src/tx/types.ts
@@ -90,3 +90,13 @@ export const DefaultGasPriceStep: {
 };
 
 export type FeeType = "high" | "average" | "low";
+
+export interface IGasSimulator {
+  enabled: boolean;
+  setEnabled(value: boolean): void;
+
+  gasEstimated: number | undefined;
+  gasAdjustment: number;
+  gasAdjustmentRaw: string;
+  setGasAdjustment(gasAdjustment: string | number): void;
+}

--- a/packages/hooks/src/tx/types.ts
+++ b/packages/hooks/src/tx/types.ts
@@ -95,6 +95,8 @@ export interface IGasSimulator {
   enabled: boolean;
   setEnabled(value: boolean): void;
 
+  isSimulating: boolean;
+
   gasEstimated: number | undefined;
   gasAdjustment: number;
   gasAdjustmentRaw: string;

--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -4,6 +4,7 @@ import { ChainGetter } from "../common";
 import { DenomHelper, toGenerator } from "@keplr-wallet/common";
 import { StdFee } from "@cosmjs/launchpad";
 import { evmosToEth } from "@tharsis/address-converter";
+import { MakeTxResponse } from "./types";
 
 export enum WalletStatus {
   NotInit = "NotInit",
@@ -67,6 +68,12 @@ export class AccountSetBase {
         }
   ) => Promise<boolean>)[] = [];
 
+  protected makeSendTokenTxFns: ((
+    amount: string,
+    currency: AppCurrency,
+    recipient: string
+  ) => (MakeTxResponse & { defaultGas?: number }) | undefined)[] = [];
+
   constructor(
     protected readonly eventListener: {
       addEventListener: (type: string, fn: () => unknown) => void;
@@ -106,6 +113,16 @@ export class AccountSetBase {
     ) => Promise<boolean>
   ) {
     this.sendTokenFns.push(fn);
+  }
+
+  registerMakeSendTokenFn(
+    fn: (
+      amount: string,
+      currency: AppCurrency,
+      recipient: string
+    ) => (MakeTxResponse & { defaultGas?: number }) | undefined
+  ) {
+    this.makeSendTokenTxFns.push(fn);
   }
 
   protected async enable(keplr: Keplr, chainId: string): Promise<void> {
@@ -225,6 +242,25 @@ export class AccountSetBase {
     return (
       this.walletStatus === WalletStatus.Loaded && this.bech32Address !== ""
     );
+  }
+
+  makeSendTokenTx(
+    amount: string,
+    currency: AppCurrency,
+    recipient: string
+  ): MakeTxResponse & { defaultGas?: number } {
+    for (let i = 0; i < this.makeSendTokenTxFns.length; i++) {
+      const fn = this.makeSendTokenTxFns[i];
+
+      const res = fn(amount, currency, recipient);
+      if (res) {
+        return res;
+      }
+    }
+
+    const denomHelper = new DenomHelper(currency.coinMinimalDenom);
+
+    throw new Error(`Unsupported type of currency (${denomHelper.type})`);
   }
 
   async sendToken(

--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -72,7 +72,7 @@ export class AccountSetBase {
     amount: string,
     currency: AppCurrency,
     recipient: string
-  ) => (MakeTxResponse & { defaultGas?: number }) | undefined)[] = [];
+  ) => MakeTxResponse | undefined)[] = [];
 
   constructor(
     protected readonly eventListener: {
@@ -120,7 +120,7 @@ export class AccountSetBase {
       amount: string,
       currency: AppCurrency,
       recipient: string
-    ) => (MakeTxResponse & { defaultGas?: number }) | undefined
+    ) => MakeTxResponse | undefined
   ) {
     this.makeSendTokenTxFns.push(fn);
   }
@@ -248,7 +248,7 @@ export class AccountSetBase {
     amount: string,
     currency: AppCurrency,
     recipient: string
-  ): MakeTxResponse & { defaultGas?: number } {
+  ): MakeTxResponse {
     for (let i = 0; i < this.makeSendTokenTxFns.length; i++) {
       const fn = this.makeSendTokenTxFns[i];
 

--- a/packages/stores/src/account/cosmos.ts
+++ b/packages/stores/src/account/cosmos.ts
@@ -650,9 +650,7 @@ export class CosmosAccountImpl {
 
   makeTx(
     type: string | "unknown",
-    msgs:
-      | ProtoMsgsOrWithAminoMsgs
-      | (() => Promise<ProtoMsgsOrWithAminoMsgs> | ProtoMsgsOrWithAminoMsgs),
+    msgs: ProtoMsgsOrWithAminoMsgs | (() => Promise<ProtoMsgsOrWithAminoMsgs>),
     preOnTxEvents?:
       | ((tx: any) => void)
       | {

--- a/packages/stores/src/account/cosmos.ts
+++ b/packages/stores/src/account/cosmos.ts
@@ -1137,34 +1137,30 @@ export class CosmosAccountImpl {
   }
 
   makeWithdrawDelegationRewardTx(validatorAddresses: string[]) {
-    return {
-      defaultGas: this.msgOpts.withdrawRewards.gas * validatorAddresses.length,
-      ...this.makeTx("withdrawRewards", () => {
-        const msgs = validatorAddresses.map((validatorAddress) => {
-          return {
-            type: this.msgOpts.withdrawRewards.type,
-            value: {
-              delegator_address: this.base.bech32Address,
-              validator_address: validatorAddress,
-            },
-          };
-        });
-
+    return this.makeTx("withdrawRewards", () => {
+      const msgs = validatorAddresses.map((validatorAddress) => {
         return {
-          aminoMsgs: msgs,
-          protoMsgs: msgs.map((msg) => {
-            return {
-              typeUrl:
-                "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward",
-              value: MsgWithdrawDelegatorReward.encode({
-                delegatorAddress: msg.value.delegator_address,
-                validatorAddress: msg.value.validator_address,
-              }).finish(),
-            };
-          }),
+          type: this.msgOpts.withdrawRewards.type,
+          value: {
+            delegator_address: this.base.bech32Address,
+            validator_address: validatorAddress,
+          },
         };
-      }),
-    };
+      });
+
+      return {
+        aminoMsgs: msgs,
+        protoMsgs: msgs.map((msg) => {
+          return {
+            typeUrl: "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward",
+            value: MsgWithdrawDelegatorReward.encode({
+              delegatorAddress: msg.value.delegator_address,
+              validatorAddress: msg.value.validator_address,
+            }).finish(),
+          };
+        }),
+      };
+    });
   }
 
   async sendWithdrawDelegationRewardMsgs(

--- a/packages/stores/src/account/cosmos.ts
+++ b/packages/stores/src/account/cosmos.ts
@@ -89,6 +89,9 @@ export const CosmosAccount = {
   },
 };
 
+/**
+ * @deprecated Predict gas through simulation rather than using a fixed gas.
+ */
 export interface CosmosMsgOpts {
   readonly send: {
     readonly native: MsgOpt;
@@ -102,6 +105,9 @@ export interface CosmosMsgOpts {
   readonly govVote: MsgOpt;
 }
 
+/**
+ * @deprecated Predict gas through simulation rather than using a fixed gas.
+ */
 export const defaultCosmosMsgOpts: CosmosMsgOpts = {
   send: {
     native: {
@@ -158,6 +164,9 @@ export class CosmosAccountImpl {
     this.base.registerSendTokenFn(this.processSendToken.bind(this));
   }
 
+  /**
+   * @deprecated Predict gas through simulation rather than using a fixed gas.
+   */
   get msgOpts(): CosmosMsgOpts {
     return this._msgOpts;
   }

--- a/packages/stores/src/account/cosmos.ts
+++ b/packages/stores/src/account/cosmos.ts
@@ -203,11 +203,17 @@ export class CosmosAccountImpl {
         return dec.truncate().toString();
       })();
 
+      recipient = hexAdjustedRecipient(recipient);
+      Bech32Address.validate(
+        recipient,
+        this.chainGetter.getChain(this.chainId).bech32Config.bech32PrefixAccAddr
+      );
+
       const msg = {
         type: this.msgOpts.send.native.type,
         value: {
           from_address: this.base.bech32Address,
-          to_address: hexAdjustedRecipient(recipient),
+          to_address: recipient,
           amount: [
             {
               denom: currency.coinMinimalDenom,

--- a/packages/stores/src/account/cosmwasm.ts
+++ b/packages/stores/src/account/cosmwasm.ts
@@ -147,6 +147,9 @@ export class CosmwasmAccountImpl {
     }
   }
 
+  /**
+   * @deprecated
+   */
   protected async processSendToken(
     amount: string,
     currency: AppCurrency,
@@ -227,6 +230,11 @@ export class CosmwasmAccountImpl {
           onFulfill?: (tx: any) => void;
         }
   ) {
+    Bech32Address.validate(
+      contractAddress,
+      this.chainGetter.getChain(this.chainId).bech32Config.bech32PrefixAccAddr
+    );
+
     const msg = {
       type: this.msgOpts.executeWasm.type,
       value: {
@@ -257,6 +265,9 @@ export class CosmwasmAccountImpl {
     );
   }
 
+  /**
+   * @deprecated
+   */
   async sendExecuteContractMsg(
     // This arg can be used to override the type of sending tx if needed.
     type: keyof CosmwasmMsgOpts | "unknown" = "executeWasm",

--- a/packages/stores/src/account/cosmwasm.ts
+++ b/packages/stores/src/account/cosmwasm.ts
@@ -47,6 +47,9 @@ export const CosmwasmAccount = {
   },
 };
 
+/**
+ * @deprecated Predict gas through simulation rather than using a fixed gas.
+ */
 export interface CosmwasmMsgOpts {
   readonly send: {
     readonly cw20: Pick<MsgOpt, "gas">;
@@ -55,6 +58,9 @@ export interface CosmwasmMsgOpts {
   readonly executeWasm: Pick<MsgOpt, "type">;
 }
 
+/**
+ * @deprecated Predict gas through simulation rather than using a fixed gas.
+ */
 export const defaultCosmwasmMsgOpts: CosmwasmMsgOpts = {
   send: {
     cw20: {
@@ -78,6 +84,9 @@ export class CosmwasmAccountImpl {
     this.base.registerSendTokenFn(this.processSendToken.bind(this));
   }
 
+  /**
+   * @deprecated Predict gas through simulation rather than using a fixed gas.
+   */
   get msgOpts(): CosmwasmMsgOpts {
     return this._msgOpts;
   }

--- a/packages/stores/src/account/cosmwasm.ts
+++ b/packages/stores/src/account/cosmwasm.ts
@@ -11,6 +11,7 @@ import { Buffer } from "buffer/";
 import deepmerge from "deepmerge";
 import { CosmosAccount } from "./cosmos";
 import { txEventsWithPreOnFulfill } from "./utils";
+import { Bech32Address } from "@keplr-wallet/cosmos";
 
 export interface CosmwasmAccount {
   cosmwasm: CosmwasmAccountImpl;
@@ -110,6 +111,11 @@ export class CosmwasmAccountImpl {
       if (!("type" in currency) || currency.type !== "cw20") {
         throw new Error("Currency is not cw20");
       }
+
+      Bech32Address.validate(
+        recipient,
+        this.chainGetter.getChain(this.chainId).bech32Config.bech32PrefixAccAddr
+      );
 
       return this.makeExecuteContractTx(
         "send",

--- a/packages/stores/src/account/index.ts
+++ b/packages/stores/src/account/index.ts
@@ -1,3 +1,4 @@
+export * from "./types";
 export * from "./base";
 export * from "./cosmos";
 export * from "./get-keplr";

--- a/packages/stores/src/account/index.ts
+++ b/packages/stores/src/account/index.ts
@@ -5,3 +5,4 @@ export * from "./get-keplr";
 export * from "./secret";
 export * from "./store";
 export * from "./cosmwasm";
+export * from "./utils";

--- a/packages/stores/src/account/secret.ts
+++ b/packages/stores/src/account/secret.ts
@@ -116,6 +116,12 @@ export class SecretAccountImpl {
       if (!("type" in currency) || currency.type !== "secret20") {
         throw new Error("Currency is not secret20");
       }
+
+      Bech32Address.validate(
+        recipient,
+        this.chainGetter.getChain(this.chainId).bech32Config.bech32PrefixAccAddr
+      );
+
       return this.makeExecuteSecretContractTx(
         "send",
         currency.contractAddress,

--- a/packages/stores/src/account/secret.ts
+++ b/packages/stores/src/account/secret.ts
@@ -48,6 +48,9 @@ export const SecretAccount = {
   },
 };
 
+/**
+ * @deprecated Predict gas through simulation rather than using a fixed gas.
+ */
 export interface SecretMsgOpts {
   readonly send: {
     readonly secret20: Pick<MsgOpt, "gas">;
@@ -57,6 +60,9 @@ export interface SecretMsgOpts {
   readonly executeSecretWasm: Pick<MsgOpt, "type">;
 }
 
+/**
+ * @deprecated Predict gas through simulation rather than using a fixed gas.
+ */
 export const defaultSecretMsgOpts: SecretMsgOpts = {
   send: {
     secret20: {
@@ -84,6 +90,9 @@ export class SecretAccountImpl {
     this.base.registerSendTokenFn(this.processSendToken.bind(this));
   }
 
+  /**
+   * @deprecated Predict gas through simulation rather than using a fixed gas.
+   */
   get msgOpts(): SecretMsgOpts {
     return this._msgOpts;
   }

--- a/packages/stores/src/account/secret.ts
+++ b/packages/stores/src/account/secret.ts
@@ -152,6 +152,9 @@ export class SecretAccountImpl {
     }
   }
 
+  /**
+   * @deprecated
+   */
   protected async processSendToken(
     amount: string,
     currency: AppCurrency,
@@ -229,20 +232,21 @@ export class SecretAccountImpl {
     crypto.getRandomValues(random);
     const key = Buffer.from(random).toString("hex");
 
-    await this.sendExecuteSecretContractMsg(
+    await this.makeExecuteSecretContractTx(
       "createSecret20ViewingKey",
       contractAddress,
       {
         set_viewing_key: { key },
       },
-      [],
-      memo,
+      []
+    ).send(
       {
         amount: stdFee.amount ?? [],
         gas: stdFee.gas ?? this.msgOpts.createSecret20ViewingKey.gas.toString(),
       },
+      memo,
       signOptions,
-      async (tx) => {
+      (tx) => {
         let viewingKey = "";
         if (tx.code == null || tx.code === 0) {
           viewingKey = key;
@@ -270,6 +274,11 @@ export class SecretAccountImpl {
           onFulfill?: (tx: any) => void;
         }
   ) {
+    Bech32Address.validate(
+      contractAddress,
+      this.chainGetter.getChain(this.chainId).bech32Config.bech32PrefixAccAddr
+    );
+
     let encryptedMsg: Uint8Array;
 
     return this.base.cosmos.makeTx(
@@ -314,6 +323,9 @@ export class SecretAccountImpl {
     );
   }
 
+  /**
+   * @deprecated
+   */
   async sendExecuteSecretContractMsg(
     // This arg can be used to override the type of sending tx if needed.
     type: keyof SecretMsgOpts | "unknown" = "executeSecretWasm",

--- a/packages/stores/src/account/types.ts
+++ b/packages/stores/src/account/types.ts
@@ -1,0 +1,69 @@
+import { Msg, StdFee } from "@cosmjs/launchpad";
+import { Any } from "@keplr-wallet/proto-types/google/protobuf/any";
+import { Dec } from "@keplr-wallet/unit";
+import { KeplrSignOptions } from "@keplr-wallet/types";
+
+export type ProtoMsgsOrWithAminoMsgs = {
+  // TODO: Make `aminoMsgs` nullable
+  //       And, make proto sign doc if `aminoMsgs` is null
+  aminoMsgs: Msg[];
+  protoMsgs: Any[];
+};
+
+export interface MakeTxResponse {
+  msgs(): Promise<ProtoMsgsOrWithAminoMsgs>;
+  simulate(
+    fee?: Partial<Omit<StdFee, "gas">>,
+    memo?: string
+  ): Promise<{
+    gasUsed: number;
+  }>;
+  simulateAndSend(
+    feeOptions: {
+      gasAdjustment: number;
+      gasPrice?: {
+        denom: string;
+        amount: Dec;
+      };
+    },
+    memo?: string,
+    signOptions?: KeplrSignOptions,
+    onTxEvents?:
+      | ((tx: any) => void)
+      | {
+          onBroadcastFailed?: (e?: Error) => void;
+          onBroadcasted?: (txHash: Uint8Array) => void;
+          onFulfill?: (tx: any) => void;
+        }
+  ): Promise<void>;
+  send(
+    fee: StdFee,
+    memo?: string,
+    signOptions?: KeplrSignOptions,
+    onTxEvents?:
+      | ((tx: any) => void)
+      | {
+          onBroadcastFailed?: (e?: Error) => void;
+          onBroadcasted?: (txHash: Uint8Array) => void;
+          onFulfill?: (tx: any) => void;
+        }
+  ): Promise<void>;
+  sendWithGasPrice(
+    gasInfo: {
+      gas: number;
+      gasPrice?: {
+        denom: string;
+        amount: Dec;
+      };
+    },
+    memo?: string,
+    signOptions?: KeplrSignOptions,
+    onTxEvents?:
+      | ((tx: any) => void)
+      | {
+          onBroadcastFailed?: (e?: Error) => void;
+          onBroadcasted?: (txHash: Uint8Array) => void;
+          onFulfill?: (tx: any) => void;
+        }
+  ): Promise<void>;
+}

--- a/packages/stores/src/account/utils.ts
+++ b/packages/stores/src/account/utils.ts
@@ -1,0 +1,74 @@
+export function txEventsWithPreOnFulfill(
+  onTxEvents:
+    | ((tx: any) => void)
+    | {
+        onBroadcasted?: (txHash: Uint8Array) => void;
+        onFulfill?: (tx: any) => void;
+      }
+    | undefined,
+  preOnTxEvents:
+    | ((tx: any) => void)
+    | {
+        onBroadcasted?: (txHash: Uint8Array) => void;
+        onFulfill?: (tx: any) => void;
+      }
+    | undefined
+):
+  | {
+      onBroadcasted?: (txHash: Uint8Array) => void;
+      onFulfill?: (tx: any) => void;
+    }
+  | undefined {
+  const onBroadcasted = onTxEvents
+    ? typeof onTxEvents === "function"
+      ? undefined
+      : onTxEvents.onBroadcasted
+    : undefined;
+  const onFulfill = onTxEvents
+    ? typeof onTxEvents === "function"
+      ? onTxEvents
+      : onTxEvents.onFulfill
+    : undefined;
+
+  const onPreBroadcasted = preOnTxEvents
+    ? typeof preOnTxEvents === "function"
+      ? undefined
+      : preOnTxEvents.onBroadcasted
+    : undefined;
+  const onPreFulfill = preOnTxEvents
+    ? typeof preOnTxEvents === "function"
+      ? preOnTxEvents
+      : preOnTxEvents.onFulfill
+    : undefined;
+
+  if (!onBroadcasted && !onFulfill && !onPreBroadcasted && !onPreFulfill) {
+    return undefined;
+  }
+
+  return {
+    onBroadcasted:
+      onBroadcasted || onPreBroadcasted
+        ? (txHash: Uint8Array) => {
+            if (onPreBroadcasted) {
+              onPreBroadcasted(txHash);
+            }
+
+            if (onBroadcasted) {
+              onBroadcasted(txHash);
+            }
+          }
+        : undefined,
+    onFulfill:
+      onFulfill || onPreFulfill
+        ? (tx: any) => {
+            if (onPreFulfill) {
+              onPreFulfill(tx);
+            }
+
+            if (onFulfill) {
+              onFulfill(tx);
+            }
+          }
+        : undefined,
+  };
+}


### PR DESCRIPTION
KO:
Tx를 처리하기 위해 필요한 gas를 POST /cosmos/tx/v1beta1/simulate endpoint를 사용해서 simulation하는 기능을 추가한다.
Tx의 consumed gas가 gas limit(gas wanted)에 도달하는 즉시 tx가 실패하기 때문에 이 기능을 통해서 얻은 gas used를 tx에 그대로 사용하면 잠재적으로 약간의 gas 소모량 변화에도 tx가 실패할 수 있다. 그러므로 적당한 값 (gas adjustment)를 곱해서 사용해야한다.

#### 변화들
- AccountStore에서 send...Msg 형태의 method로는 각이 안나와서 make...Tx 형태의 method들을 새롭게 만들었다. send...Msg 형태의 method는 deprecated 되었다.
   - make...Tx 형태의 method는 simulate, simulateAndSend, send, sendWithGasPrice 함수를 반환한다.
   - 웹페이지에서 사용할 때 가장 기본적인 형태는 아래와 같을듯...
```
const tx = accountInfo.cosmos.makeWithdrawDelegationRewardTx(
  validatorAddresses
);
await tx.simulateAndSend({ gasAdjustment: 1.3 });
```
- 하지만 귀찮은 문제가... 이 기능을 cosmos-sdk@0.43부터 사용할 수 있다. 0.43 이전의 형태의 simulation 방식은 구현하기 귀찮은 요소들이 있어서 안했다. 결론적으로 케플러에서 integration된 체인들 기준으로 starname, ixo, emoney chain의 경우엔 simulation을 할 수 없다.
- 그러므로 keplr dashboard나 osmosis의 ibc assets 페이지처럼 여러 체인을 다뤄야하는 경우에는 이 기능이 작동하지 않는 잡체인들을 위한 실패처리가 필요하다.
      
#### TODO
- tx simulation을 할 때 account의 sequence가 필요하다. 지금은 simulation할 때마다 account의 sequence를 fetch한다. 근데 send page같은 곳의 경우 UI 상에서 계속 tx simulation을 통해서 수수료를 업데이트하는데 이러한 연속적인 simulation의 경우는 처음에 account의 sequence를 fetch하고 그 값을 계속 재사용하는게 나을 것이다.
- Gas simulator에 debounce logic을 추가하자...

-------
EN: To be translated