### PR TITLE
Add Ethereum Message and Tx Signing

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -215,6 +215,24 @@ Using `verifyArbitrary`, you can verify the results requested by `signArbitrary`
 `verifyArbitrary` has been only implemented for simple usage. `verifyArbitrary` returns the result of the verification of the current selected account's sign doc. If the account is not the currently selected account, it would throw an error.  
   
 It is recommended to use `verifyADR36Amino` function in the `@keplr-wallet/cosmos` package or your own implementation instead of using `verifyArbitrary` API.  
+
+### Request Ethereum Signature
+```javascript
+signEthereum(
+  chainId: string,
+  signer: string, // Bech32 address, not hex
+  data: string | Uint8Array,
+  type: 'message' | 'transaction'
+)
+```
+
+This is an experimental implementation of native Ethereum signing in Keplr to be used by dApps on EVM-compatible chains such as Evmos. 
+
+It supports signing either [Personal Messages](https://eips.ethereum.org/EIPS/eip-191) or [Transactions](https://ethereum.org/en/developers/docs/transactions/), with plans to support [Typed Data](https://eips.ethereum.org/EIPS/eip-712) in the future.
+
+Notes on Usage:
+- The `signer` field must be a Bech32 address, not an Ethereum hex address
+- The data should be either stringified JSON (for transactions) or a string message (for messages). Byte arrays are accepted as alternatives for either.
   
 ### Interaction Options
 

--- a/packages/background/src/keyring/service.ts
+++ b/packages/background/src/keyring/service.ts
@@ -17,7 +17,12 @@ import { escapeHTML, KVStore } from "@keplr-wallet/common";
 
 import { ChainsService } from "../chains";
 import { LedgerService } from "../ledger";
-import { BIP44, ChainInfo, KeplrSignOptions } from "@keplr-wallet/types";
+import {
+  BIP44,
+  ChainInfo,
+  EthSignType,
+  KeplrSignOptions,
+} from "@keplr-wallet/types";
 import { APP_PORT, Env, KeplrError, WEBPAGE_PORT } from "@keplr-wallet/router";
 import { InteractionService } from "../interaction";
 import { PermissionService } from "../permission";
@@ -28,6 +33,7 @@ import {
   AminoSignResponse,
   StdSignDoc,
   StdSignature,
+  encodeSecp256k1Pubkey,
 } from "@cosmjs/launchpad";
 import { DirectSignResponse, makeSignBytes } from "@cosmjs/proto-signing";
 
@@ -234,6 +240,7 @@ export class KeyRingService {
     signOptions: KeplrSignOptions & {
       // Hack option field to detect the sign arbitrary for string
       isADR36WithString?: boolean;
+      ethSignType?: EthSignType;
     }
   ): Promise<AminoSignResponse> {
     signDoc = {
@@ -289,6 +296,7 @@ export class KeyRingService {
         signOptions,
         isADR36SignDoc,
         isADR36WithString: signOptions.isADR36WithString,
+        ethSignType: signOptions.ethSignType,
       }
     )) as StdSignDoc;
 
@@ -313,6 +321,35 @@ export class KeyRingService {
           237,
           "Signing request was for ADR-36. But, accidentally, new sign doc is not for ADR-36"
         );
+      }
+    }
+
+    // Handle Ethereum signing
+    if (signOptions.ethSignType) {
+      if (newSignDoc.msgs.length !== 1) {
+        // Validate number of messages
+        throw new Error("Invalid number of messages for Ethereum sign request");
+      }
+
+      const signBytes = Buffer.from(newSignDoc.msgs[0].value.data, "base64");
+
+      try {
+        const signatureBytes = await this.keyRing.signEthereum(
+          chainId,
+          coinType,
+          signBytes,
+          signOptions.ethSignType
+        );
+
+        return {
+          signed: newSignDoc, // Included to match return type
+          signature: {
+            pub_key: encodeSecp256k1Pubkey(key.pubKey), // Included to match return type
+            signature: Buffer.from(signatureBytes).toString("base64"), // No byte limit
+          },
+        };
+      } finally {
+        this.interactionService.dispatchEvent(APP_PORT, "request-sign-end", {});
       }
     }
 

--- a/packages/extension/src/pages/sign/adr-36.tsx
+++ b/packages/extension/src/pages/sign/adr-36.tsx
@@ -6,13 +6,21 @@ import { Buffer } from "buffer/";
 import { MsgRender } from "./details-tab";
 import styleDetailsTab from "./details-tab.module.scss";
 import { Label } from "reactstrap";
+import { EthSignType } from "@keplr-wallet/types";
 
 export const ADR36SignDocDetailsTab: FunctionComponent<{
   signDocWrapper: SignDocWrapper;
   isADR36WithString?: boolean;
+  ethSignType?: EthSignType;
   origin?: string;
-}> = observer(({ signDocWrapper, isADR36WithString, origin }) => {
+}> = observer(({ signDocWrapper, isADR36WithString, ethSignType, origin }) => {
   const { chainStore } = useStore();
+  const renderTitleText = () => {
+    if (ethSignType && ethSignType === EthSignType.TRANSACTION) {
+      return "Sign transaction for";
+    }
+    return "Prove account ownership to";
+  };
 
   const signValue = useMemo(() => {
     if (signDocWrapper.aminoSignDoc.msgs.length !== 1) {
@@ -41,7 +49,7 @@ export const ADR36SignDocDetailsTab: FunctionComponent<{
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
       <div className={styleDetailsTab.msgContainer} style={{ flex: "none" }}>
-        <MsgRender icon="fas fa-pen-nib" title="Prove account ownership to">
+        <MsgRender icon="fas fa-pen-nib" title={renderTitleText()}>
           {origin ?? "Unknown"}
         </MsgRender>
       </div>

--- a/packages/extension/src/pages/sign/index.tsx
+++ b/packages/extension/src/pages/sign/index.tsx
@@ -25,6 +25,7 @@ import {
 import { ADR36SignDocDetailsTab } from "./adr-36";
 import { ChainIdHelper } from "@keplr-wallet/cosmos";
 import { unescapeHTML } from "@keplr-wallet/common";
+import { EthSignType } from "@keplr-wallet/types";
 
 enum Tab {
   Details,
@@ -51,6 +52,7 @@ export const SignPage: FunctionComponent = observer(() => {
   const [isADR36WithString, setIsADR36WithString] = useState<
     boolean | undefined
   >();
+  const [ethSignType, setEthSignType] = useState<EthSignType | undefined>();
 
   const current = chainStore.current;
   // There are services that sometimes use invalid tx to sign arbitrary data on the sign page.
@@ -81,6 +83,9 @@ export const SignPage: FunctionComponent = observer(() => {
       chainStore.selectChain(data.data.chainId);
       if (data.data.signDocWrapper.isADR36SignDoc) {
         setIsADR36WithString(data.data.isADR36WithString);
+      }
+      if (data.data.ethSignType) {
+        setEthSignType(data.data.ethSignType);
       }
       setOrigin(data.data.msgOrigin);
       if (
@@ -183,7 +188,8 @@ export const SignPage: FunctionComponent = observer(() => {
 
     if (
       signDocHelper.signDocWrapper &&
-      signDocHelper.signDocWrapper.isADR36SignDoc
+      signDocHelper.signDocWrapper.isADR36SignDoc &&
+      !ethSignType
     ) {
       return "Prove Ownership";
     }
@@ -271,6 +277,7 @@ export const SignPage: FunctionComponent = observer(() => {
                   <ADR36SignDocDetailsTab
                     signDocWrapper={signDocHelper.signDocWrapper}
                     isADR36WithString={isADR36WithString}
+                    ethSignType={ethSignType}
                     origin={origin}
                   />
                 ) : (

--- a/packages/provider-mock/src/mock.ts
+++ b/packages/provider-mock/src/mock.ts
@@ -1,4 +1,5 @@
 import {
+  EthSignType,
   Keplr,
   KeplrIntereactionOptions,
   KeplrMode,
@@ -118,6 +119,15 @@ export class MockKeplr implements Keplr {
     _data: string | Uint8Array,
     _signature: StdSignature
   ): Promise<boolean> {
+    throw new Error("Not implemented");
+  }
+
+  signEthereum(
+    _chainId: string,
+    _signer: string,
+    _data: string | Uint8Array,
+    _type: EthSignType
+  ): Promise<Uint8Array> {
     throw new Error("Not implemented");
   }
 

--- a/packages/provider/src/core.ts
+++ b/packages/provider/src/core.ts
@@ -170,8 +170,18 @@ export class Keplr implements IKeplr {
     _data: string | Uint8Array,
     type: EthSignType
   ): Promise<Uint8Array> {
+    if (type !== EthSignType.MESSAGE && type !== EthSignType.TRANSACTION) {
+      throw new Error(
+        "Unsupported Ethereum signing type: expected 'message' or 'transaction.'"
+      );
+    }
+
     const [data, isADR36WithString] = this.getDataForADR36(_data);
     const signDoc = this.getBlankSignDoc(signer, data);
+
+    if (data === "") {
+      throw new Error("Signing empty data is not supported.");
+    }
 
     const msg = new RequestSignAminoMsg(chainId, signer, signDoc, {
       isADR36WithString,

--- a/packages/provider/src/inject.ts
+++ b/packages/provider/src/inject.ts
@@ -1,5 +1,6 @@
 import {
   ChainInfo,
+  EthSignType,
   Keplr,
   Keplr as IKeplr,
   KeplrIntereactionOptions,
@@ -360,6 +361,20 @@ export class InjectedKeplr implements IKeplr {
       signer,
       data,
       signature,
+    ]);
+  }
+
+  async signEthereum(
+    chainId: string,
+    signer: string,
+    data: string | Uint8Array,
+    type: EthSignType
+  ): Promise<Uint8Array> {
+    return await this.requestMethod("signEthereum", [
+      chainId,
+      signer,
+      data,
+      type,
     ]);
   }
 

--- a/packages/provider/src/types/msgs.ts
+++ b/packages/provider/src/types/msgs.ts
@@ -1,5 +1,10 @@
 import { Message } from "@keplr-wallet/router";
-import { ChainInfo, KeplrSignOptions, Key } from "@keplr-wallet/types";
+import {
+  ChainInfo,
+  EthSignType,
+  KeplrSignOptions,
+  Key,
+} from "@keplr-wallet/types";
 import { AminoSignResponse, StdSignature, StdSignDoc } from "@cosmjs/launchpad";
 
 export class EnableAccessMsg extends Message<void> {
@@ -189,6 +194,7 @@ export class RequestSignAminoMsg extends Message<AminoSignResponse> {
     public readonly signOptions: KeplrSignOptions & {
       // Hack option field to detect the sign arbitrary for string
       isADR36WithString?: boolean;
+      ethSignType?: EthSignType;
     } = {}
   ) {
     super();

--- a/packages/stores/src/core/interaction/sign.ts
+++ b/packages/stores/src/core/interaction/sign.ts
@@ -3,7 +3,7 @@ import { autorun, computed, flow, makeObservable, observable } from "mobx";
 import { StdSignDoc } from "@cosmjs/launchpad";
 import { InteractionWaitingData } from "@keplr-wallet/background";
 import { SignDocWrapper } from "@keplr-wallet/cosmos";
-import { KeplrSignOptions } from "@keplr-wallet/types";
+import { EthSignType, KeplrSignOptions } from "@keplr-wallet/types";
 
 export class SignInteractionStore {
   @observable
@@ -35,6 +35,7 @@ export class SignInteractionStore {
           signOptions: KeplrSignOptions;
           isADR36SignDoc: boolean;
           isADR36WithString?: boolean;
+          ethSignType?: EthSignType;
         }
       | {
           msgOrigin: string;
@@ -56,6 +57,7 @@ export class SignInteractionStore {
         signDocWrapper: SignDocWrapper;
         signOptions: KeplrSignOptions;
         isADR36WithString?: boolean;
+        ethSignType?: EthSignType;
       }>
     | undefined {
     const datas = this.waitingDatas;
@@ -84,6 +86,8 @@ export class SignInteractionStore {
           "isADR36WithString" in data.data
             ? data.data.isADR36WithString
             : undefined,
+        ethSignType:
+          "ethSignType" in data.data ? data.data.ethSignType : undefined,
       },
     };
   }

--- a/packages/types/src/ethereum.ts
+++ b/packages/types/src/ethereum.ts
@@ -1,0 +1,5 @@
+export enum EthSignType {
+  MESSAGE = "message",
+  TRANSACTION = "transaction",
+  BYTE64 = "byte64",
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -4,3 +4,4 @@ export * from "./bip44";
 export * from "./chain-info";
 export * from "./wallet";
 export * from "./window";
+export * from "./ethereum";

--- a/packages/types/src/wallet/keplr.ts
+++ b/packages/types/src/wallet/keplr.ts
@@ -1,4 +1,5 @@
 import { ChainInfo } from "../chain-info";
+import { EthSignType } from "../ethereum";
 import {
   BroadcastMode,
   AminoSignResponse,
@@ -90,6 +91,13 @@ export interface Keplr {
     data: string | Uint8Array,
     signature: StdSignature
   ): Promise<boolean>;
+
+  signEthereum(
+    chainId: string,
+    signer: string,
+    data: string | Uint8Array,
+    type: EthSignType
+  ): Promise<Uint8Array>;
 
   getOfflineSigner(chainId: string): OfflineSigner & OfflineDirectSigner;
   getOfflineSignerOnlyAmino(chainId: string): OfflineSigner;

--- a/packages/wc-client/src/index.ts
+++ b/packages/wc-client/src/index.ts
@@ -5,6 +5,7 @@ import {
 } from "@walletconnect/types";
 import {
   ChainInfo,
+  EthSignType,
   Keplr,
   KeplrIntereactionOptions,
   KeplrMode,
@@ -382,6 +383,15 @@ export class KeplrWalletConnectV1 implements Keplr {
     _data: string | Uint8Array,
     _signature: StdSignature
   ): Promise<boolean> {
+    throw new Error("Not yet implemented");
+  }
+
+  signEthereum(
+    _chainId: string,
+    _signer: string,
+    _data: string | Uint8Array,
+    _mode: EthSignType
+  ): Promise<Uint8Array> {
     throw new Error("Not yet implemented");
   }
 


### PR DESCRIPTION
## Ethereum Signing
Implement Ethereum signing for messages and transactions in a new core function, to empower Keplr users on Cosmos-based EVM-compatible chains such as Evmos.

DApp developers can use `signEthereum(...)` and increase their supported audience to include Keplr users, thereby benefitting all ecosystems involved.

**Implementation**
- Create a new type (`EthSignType`) to indicate the type of Ethereum signature
- Create a new core function to perform arbitrary Amino signing with Ethereum parameters
- Modify the UI displayed when signing for Ethereum
- Add Ethereum Message and Transaction signing capabilities to the keyring
- Add relevant error handling

**Testing**
- Tested transaction and message signatures for correctness against `ethersjs` in Typescript
- Tested the following instances for error handling:
  - Invalid chain ID
  - Invalid signer
  - Empty payload
  - Invalid signType
  - Invalid transaction fields
- Verified correct behavior of default actions (sending tokens)