### PR TITLE
Enable code splitting

### DIFF
--- a/packages/extension/webpack.config.js
+++ b/packages/extension/webpack.config.js
@@ -89,6 +89,18 @@ const extensionConfig = (env, args) => {
       path: path.resolve(__dirname, isEnvDevelopment ? "dist" : "build/chrome"),
       filename: "[name].bundle.js",
     },
+    optimization: {
+      splitChunks: {
+        chunks(chunk) {
+          return chunk.name === "popup";
+        },
+        cacheGroups: {
+          popup: {
+            maxSize: 3_000_000,
+          },
+        },
+      },
+    },
     resolve: commonResolve("src/public/assets"),
     module: {
       rules: [sassRule, tsRule, fileRule],


### PR DESCRIPTION
Because the size of popup.bundle.js is too large, `File is too large to parse.` error occurs when publishing to firefox add-ons.
To solve this problem, code splitting is introduced.
The size of background.bundle.js is also a bit large, but that's not a problem right now as it won't stretch any more.