### PR TITLE
Allow ETH tokens to be used for g-bridge fees

### DIFF
--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -1710,6 +1710,26 @@ export const EmbedChainInfos: ChainInfo[] = [
         coinMinimalDenom: "ugraviton",
         coinDecimals: 6,
       },
+      {
+        coinDenom: "USDC",
+        coinMinimalDenom: "gravity0xA0b73E1Ff0B80914AB6fe0444E65848C4C34450b",
+        coinDecimals: 6,
+      },
+      {
+        coinDenom: "WETH",
+        coinMinimalDenom: "gravity0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+        coinDecimals: 18,
+      },
+      {
+        coinDenom: "WBTC",
+        coinMinimalDenom: "gravity0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+        coinDecimals: 8,
+      },
+      {
+        coinDenom: "USDT",
+        coinMinimalDenom: "gravity0xdAC17F958D2ee523a2206206994597C13D831ec7",
+        coinDecimals: 6,
+      }
     ],
     feeCurrencies: [
       {
@@ -1717,6 +1737,26 @@ export const EmbedChainInfos: ChainInfo[] = [
         coinMinimalDenom: "ugraviton",
         coinDecimals: 6,
       },
+      {
+        coinDenom: "USDC",
+        coinMinimalDenom: "gravity0xA0b73E1Ff0B80914AB6fe0444E65848C4C34450b",
+        coinDecimals: 6,
+      },
+      {
+        coinDenom: "WETH",
+        coinMinimalDenom: "gravity0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+        coinDecimals: 18,
+      },
+      {
+        coinDenom: "WBTC",
+        coinMinimalDenom: "gravity0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+        coinDecimals: 8,
+      },
+      {
+        coinDenom: "USDT",
+        coinMinimalDenom: "gravity0xdAC17F958D2ee523a2206206994597C13D831ec7",
+        coinDecimals: 6,
+      }
     ],
     features: ["ibc-transfer", "ibc-go"],
   },


### PR DESCRIPTION
This patch expands the token list and fees list for Gravity Bridge to include a few Ethereum based assets, to allow their use as fee tokens. 