### PR TITLE
refactoring extension/<Address /> component with Functional Component

### DIFF
--- a/packages/extension/src/components/address/index.tsx
+++ b/packages/extension/src/components/address/index.tsx
@@ -1,4 +1,9 @@
-import React from "react";
+import React, {
+  FunctionComponent,
+  useCallback,
+  useEffect,
+  useRef,
+} from "react";
 
 import { ToolTip } from "../tooltip";
 import { Bech32Address } from "@keplr-wallet/cosmos";
@@ -19,82 +24,77 @@ export interface RawAddressProps {
   isRaw: true;
 }
 
-export class Address extends React.Component<
+export const Address: FunctionComponent<
   AddressProps & (Bech32AddressProps | RawAddressProps)
-> {
-  copyRef = React.createRef<HTMLDivElement>();
+> = (props) => {
+  const { tooltipFontSize, children } = props;
+  const tooltipAddress = props.tooltipAddress ? props.tooltipAddress : children;
 
-  componentDidMount(): void {
-    if (this.copyRef.current) {
-      this.copyRef.current.addEventListener("copy", this.onCopy);
-    }
-  }
+  const copyRef = useRef<HTMLDivElement>(null);
 
-  componentWillUnmount(): void {
-    if (this.copyRef.current) {
-      this.copyRef.current.removeEventListener("copy", this.onCopy);
-    }
-  }
-
-  render() {
-    const { tooltipFontSize, children } = this.props;
-    const tooltipAddress = this.props.tooltipAddress
-      ? this.props.tooltipAddress
-      : children;
-
-    if ("maxCharacters" in this.props) {
-      const { lineBreakBeforePrefix } = this.props;
-
-      return (
-        <ToolTip
-          trigger="hover"
-          options={{ placement: "top" }}
-          tooltip={
-            <div
-              ref={this.copyRef}
-              className="address-tooltip"
-              style={{ fontSize: tooltipFontSize }}
-            >
-              {lineBreakBeforePrefix && tooltipAddress.length > 0
-                ? tooltipAddress.split("1").map((item, i) => {
-                    if (i === 0) {
-                      return <div key={i}>{item + "1"}</div>;
-                    }
-                    return <div key={i}>{item}</div>;
-                  })
-                : tooltipAddress}
-            </div>
-          }
-        >
-          {Bech32Address.shortenAddress(children, this.props.maxCharacters)}
-        </ToolTip>
-      );
-    } else {
-      return (
-        <ToolTip
-          trigger="hover"
-          options={{ placement: "top" }}
-          tooltip={
-            <div
-              ref={this.copyRef}
-              className="address-tooltip"
-              style={{ fontSize: tooltipFontSize }}
-            >
-              {tooltipAddress}
-            </div>
-          }
-        >
-          {children}
-        </ToolTip>
-      );
-    }
-  }
-
-  onCopy = async (e: ClipboardEvent) => {
+  const onCopy = useCallback(async (e: ClipboardEvent) => {
     if (e.clipboardData) {
       // Remove line breaks.
       const pre = await navigator.clipboard.readText();
       await navigator.clipboard.writeText(pre.replace(/(\r\n|\n|\r)/gm, ""));
     }
-  };
-}
+  }, []);
+
+  useEffect(() => {
+    if (copyRef.current) {
+      copyRef.current.addEventListener("copy", onCopy);
+    }
+    return () => {
+      if (copyRef.current) {
+        copyRef.current.removeEventListener("copy", onCopy);
+      }
+    };
+  }, [copyRef, onCopy]);
+
+  if ("maxCharacters" in props) {
+    const { lineBreakBeforePrefix } = props;
+
+    return (
+      <ToolTip
+        trigger="hover"
+        options={{ placement: "top" }}
+        tooltip={
+          <div
+            ref={copyRef}
+            className="address-tooltip"
+            style={{ fontSize: tooltipFontSize }}
+          >
+            {lineBreakBeforePrefix && tooltipAddress.length > 0
+              ? tooltipAddress.split("1").map((item, i) => {
+                  if (i === 0) {
+                    return <div key={i}>{item + "1"}</div>;
+                  }
+                  return <div key={i}>{item}</div>;
+                })
+              : tooltipAddress}
+          </div>
+        }
+      >
+        {Bech32Address.shortenAddress(children, props.maxCharacters)}
+      </ToolTip>
+    );
+  }
+
+  return (
+    <ToolTip
+      trigger="hover"
+      options={{ placement: "top" }}
+      tooltip={
+        <div
+          ref={copyRef}
+          className="address-tooltip"
+          style={{ fontSize: tooltipFontSize }}
+        >
+          {tooltipAddress}
+        </div>
+      }
+    >
+      {children}
+    </ToolTip>
+  );
+};


### PR DESCRIPTION
`<Address />` component can be written as a hook without using the lifecycle of the react class component. so I suggest changing to functional component.
