### PR TITLE
Add axelar evm bridge currency registrar

### DIFF
--- a/packages/background/src/chains/types.ts
+++ b/packages/background/src/chains/types.ts
@@ -114,7 +114,8 @@ export const ChainInfoSchema = Joi.object<ChainInfo>({
         "ibc-go",
         "eth-address-gen",
         "eth-key-sign",
-        "query:/cosmos/bank/v1beta1/spendable_balances"
+        "query:/cosmos/bank/v1beta1/spendable_balances",
+        "axelar-evm-bridge"
       )
     )
     .unique()

--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -1595,7 +1595,7 @@ export const EmbedChainInfos: ChainInfo[] = [
       average: 0.075,
       high: 0.1,
     },
-    features: ["ibc-transfer", "ibc-go"],
+    features: ["ibc-transfer", "ibc-go", "axelar-evm-bridge"],
   },
   {
     rpc: SOMMELIER_RPC_ENDPOINT,

--- a/packages/extension/src/stores/root.tsx
+++ b/packages/extension/src/stores/root.tsx
@@ -32,6 +32,7 @@ import {
 import {
   KeplrETCQueries,
   GravityBridgeCurrencyRegsitrar,
+  AxelarEVMBridgeCurrencyRegistrar,
 } from "@keplr-wallet/stores-etc";
 import { ExtensionKVStore } from "@keplr-wallet/common";
 import {
@@ -73,6 +74,7 @@ export class RootStore {
 
   protected readonly ibcCurrencyRegistrar: IBCCurrencyRegsitrar<ChainInfoWithEmbed>;
   protected readonly gravityBridgeCurrencyRegistrar: GravityBridgeCurrencyRegsitrar<ChainInfoWithEmbed>;
+  protected readonly axelarEVMBridgeCurrencyRegistrar: AxelarEVMBridgeCurrencyRegistrar<ChainInfoWithEmbed>;
 
   public readonly analyticsStore: AnalyticsStore<
     {
@@ -340,6 +342,12 @@ export class RootStore {
       new ExtensionKVStore("store_gravity_bridge_currency_registrar"),
       this.chainStore,
       this.queriesStore
+    );
+    this.axelarEVMBridgeCurrencyRegistrar = new AxelarEVMBridgeCurrencyRegistrar<ChainInfoWithEmbed>(
+      new ExtensionKVStore("store_axelar_evm_bridge_currency_registrar"),
+      this.chainStore,
+      this.queriesStore,
+      "ethereum"
     );
 
     this.analyticsStore = new AnalyticsStore(

--- a/packages/mobile/src/config.ts
+++ b/packages/mobile/src/config.ts
@@ -943,7 +943,7 @@ export const EmbedChainInfos: AppChainInfo[] = [
       average: 0.075,
       high: 0.1,
     },
-    features: ["ibc-transfer", "ibc-go"],
+    features: ["ibc-transfer", "ibc-go", "axelar-evm-bridge"],
     chainSymbolImageUrl:
       "https://dhj8dql1kzq2v.cloudfront.net/white/axelar.png",
   },

--- a/packages/mobile/src/stores/root.tsx
+++ b/packages/mobile/src/stores/root.tsx
@@ -33,6 +33,7 @@ import { AnalyticsStore, NoopAnalyticsClient } from "@keplr-wallet/analytics";
 import { Amplitude } from "@amplitude/react-native";
 import { ChainIdHelper } from "@keplr-wallet/cosmos";
 import {
+  AxelarEVMBridgeCurrencyRegistrar,
   GravityBridgeCurrencyRegsitrar,
   KeplrETCQueries,
 } from "@keplr-wallet/stores-etc";
@@ -58,6 +59,7 @@ export class RootStore {
 
   protected readonly ibcCurrencyRegistrar: IBCCurrencyRegsitrar<ChainInfoWithEmbed>;
   protected readonly gravityBridgeCurrencyRegistrar: GravityBridgeCurrencyRegsitrar<ChainInfoWithEmbed>;
+  protected readonly axelarEVMBridgeCurrencyRegistrar: AxelarEVMBridgeCurrencyRegistrar<ChainInfoWithEmbed>;
 
   public readonly keychainStore: KeychainStore;
   public readonly walletConnectStore: WalletConnectStore;
@@ -294,6 +296,12 @@ export class RootStore {
       new AsyncKVStore("store_gravity_bridge_currency_registrar"),
       this.chainStore,
       this.queriesStore
+    );
+    this.axelarEVMBridgeCurrencyRegistrar = new AxelarEVMBridgeCurrencyRegistrar<ChainInfoWithEmbed>(
+      new AsyncKVStore("store_axelar_evm_bridge_currency_registrar"),
+      this.chainStore,
+      this.queriesStore,
+      "ethereum"
     );
 
     router.listen(APP_PORT);

--- a/packages/stores-etc/src/axelar/currency-registrar.ts
+++ b/packages/stores-etc/src/axelar/currency-registrar.ts
@@ -1,0 +1,119 @@
+import { observable, runInAction } from "mobx";
+import { AppCurrency, ChainInfo } from "@keplr-wallet/types";
+import {
+  ChainInfoInner,
+  ChainStore,
+  IQueriesStore,
+} from "@keplr-wallet/stores";
+import { KVStore } from "@keplr-wallet/common";
+import { DeepReadonly } from "utility-types";
+import { ObservableQueryEVMTokenInfo } from "./token-info";
+
+export class AxelarEVMBridgeCurrencyRegistrarInner<
+  C extends ChainInfo = ChainInfo
+> {
+  constructor(
+    protected readonly kvStore: KVStore,
+    protected readonly chainInfoInner: ChainInfoInner<C>,
+    protected readonly chainStore: ChainStore<C>,
+    protected readonly queriesStore: IQueriesStore<{
+      keplrETC: {
+        readonly queryEVMTokenInfo: DeepReadonly<ObservableQueryEVMTokenInfo>;
+      };
+    }>,
+    protected readonly mainChain: string
+  ) {}
+
+  registerUnknownCurrencies(
+    coinMinimalDenom: string
+  ): [AppCurrency | undefined, boolean] | undefined {
+    const chainInfo = this.chainStore.getChain(this.chainInfoInner.chainId);
+    if (
+      !chainInfo.features ||
+      !chainInfo.features.includes("axelar-evm-bridge")
+    ) {
+      return;
+    }
+
+    const queries = this.queriesStore.get(this.chainInfoInner.chainId);
+
+    const tokenInfo = queries.keplrETC.queryEVMTokenInfo.getAsset(
+      this.mainChain,
+      coinMinimalDenom
+    );
+    if (
+      tokenInfo.symbol &&
+      tokenInfo.decimals != null &&
+      tokenInfo.isConfirmed
+    ) {
+      return [
+        {
+          coinMinimalDenom,
+          coinDenom: tokenInfo.symbol,
+          coinDecimals: tokenInfo.decimals,
+        },
+        !tokenInfo.isFetching,
+      ];
+    }
+
+    // There is no matching response after query completes,
+    // there is no way to get the asset info.
+    if (!tokenInfo.isFetching) {
+      return;
+    }
+
+    return [undefined, false];
+  }
+}
+
+export class AxelarEVMBridgeCurrencyRegistrar<C extends ChainInfo = ChainInfo> {
+  @observable.shallow
+  protected map: Map<
+    string,
+    AxelarEVMBridgeCurrencyRegistrarInner<C>
+  > = new Map();
+
+  constructor(
+    protected readonly kvStore: KVStore,
+    protected readonly chainStore: ChainStore<C>,
+    protected readonly queriesStore: IQueriesStore<{
+      keplrETC: {
+        readonly queryEVMTokenInfo: DeepReadonly<ObservableQueryEVMTokenInfo>;
+      };
+    }>,
+    public readonly mainChain: string
+  ) {
+    this.chainStore.addSetChainInfoHandler((chainInfoInner) =>
+      this.setChainInfoHandler(chainInfoInner)
+    );
+  }
+
+  setChainInfoHandler(chainInfoInner: ChainInfoInner<C>): void {
+    const inner = this.get(chainInfoInner);
+    chainInfoInner.registerCurrencyRegistrar((coinMinimalDenom) =>
+      inner.registerUnknownCurrencies(coinMinimalDenom)
+    );
+  }
+
+  protected get(
+    chainInfoInner: ChainInfoInner<C>
+  ): AxelarEVMBridgeCurrencyRegistrarInner<C> {
+    if (!this.map.has(chainInfoInner.chainId)) {
+      runInAction(() => {
+        this.map.set(
+          chainInfoInner.chainId,
+          new AxelarEVMBridgeCurrencyRegistrarInner<C>(
+            this.kvStore,
+            chainInfoInner,
+            this.chainStore,
+            this.queriesStore,
+            this.mainChain
+          )
+        );
+      });
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return this.map.get(chainInfoInner.chainId)!;
+  }
+}

--- a/packages/stores-etc/src/axelar/index.ts
+++ b/packages/stores-etc/src/axelar/index.ts
@@ -1,0 +1,2 @@
+export * from "./currency-registrar";
+export * from "./token-info";

--- a/packages/stores-etc/src/axelar/token-info.ts
+++ b/packages/stores-etc/src/axelar/token-info.ts
@@ -1,0 +1,78 @@
+import {
+  ObservableChainQuery,
+  ChainGetter,
+  ObservableChainQueryMap,
+} from "@keplr-wallet/stores";
+import { KVStore } from "@keplr-wallet/common";
+import { TokenInfo } from "./types";
+
+export class ObservableQueryEVMTokenInfoInner extends ObservableChainQuery<TokenInfo> {
+  constructor(
+    kvStore: KVStore,
+    chainId: string,
+    chainGetter: ChainGetter,
+    protected readonly _chain: string,
+    protected readonly _denom: string
+  ) {
+    super(
+      kvStore,
+      chainId,
+      chainGetter,
+      `/axelar/evm/v1beta1/token_info/${_chain}?asset=${_denom}`
+    );
+  }
+
+  get chain(): string {
+    return this._chain;
+  }
+
+  get denom(): string {
+    return this._denom;
+  }
+
+  get tokenName(): string | undefined {
+    return this.response?.data.details.token_name;
+  }
+
+  get symbol(): string | undefined {
+    return this.response?.data.details.symbol;
+  }
+
+  get decimals(): number | undefined {
+    return this.response?.data.details.decimals;
+  }
+
+  get isConfirmed(): boolean | undefined {
+    return this.response?.data.confirmed;
+  }
+
+  get isExternal(): boolean | undefined {
+    return this.response?.data.is_external;
+  }
+}
+
+export class ObservableQueryEVMTokenInfo extends ObservableChainQueryMap<TokenInfo> {
+  constructor(
+    protected readonly kvStore: KVStore,
+    protected readonly chainId: string,
+    protected readonly chainGetter: ChainGetter
+  ) {
+    super(kvStore, chainId, chainGetter, (key: string) => {
+      const i = key.indexOf("/");
+      const chain = key.slice(0, i);
+      const denom = key.slice(i + 1);
+
+      return new ObservableQueryEVMTokenInfoInner(
+        this.kvStore,
+        this.chainId,
+        this.chainGetter,
+        chain,
+        denom
+      );
+    });
+  }
+
+  getAsset(chain: string, denom: string): ObservableQueryEVMTokenInfoInner {
+    return this.get(`${chain}/${denom}`) as ObservableQueryEVMTokenInfoInner;
+  }
+}

--- a/packages/stores-etc/src/axelar/types.ts
+++ b/packages/stores-etc/src/axelar/types.ts
@@ -1,0 +1,13 @@
+export type TokenInfo = {
+  asset: string;
+  details: {
+    token_name: string;
+    symbol: string;
+    decimals: number;
+    capacity: string;
+  };
+  address: string;
+  confirmed: boolean;
+  is_external: boolean;
+  burner_code_hash: string;
+};

--- a/packages/stores-etc/src/index.ts
+++ b/packages/stores-etc/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./queries";
 export * from "./erc20";
 export * from "./gravity-bridge";
+export * from "./axelar";

--- a/packages/stores-etc/src/queries.ts
+++ b/packages/stores-etc/src/queries.ts
@@ -1,7 +1,8 @@
 import { QueriesSetBase, ChainGetter } from "@keplr-wallet/stores";
 import { KVStore } from "@keplr-wallet/common";
 import { DeepReadonly } from "utility-types";
-import { ObservableQueryERC20Metadata } from "./erc20/query";
+import { ObservableQueryERC20Metadata } from "./erc20";
+import { ObservableQueryEVMTokenInfo } from "./axelar";
 
 export interface KeplrETCQueries {
   keplrETC: KeplrETCQueriesImpl;
@@ -37,17 +38,23 @@ export const KeplrETCQueries = {
 
 export class KeplrETCQueriesImpl {
   public readonly queryERC20Metadata: DeepReadonly<ObservableQueryERC20Metadata>;
+  public readonly queryEVMTokenInfo: DeepReadonly<ObservableQueryEVMTokenInfo>;
 
   constructor(
     _base: QueriesSetBase,
     kvStore: KVStore,
-    _chainId: string,
-    _chainGetter: ChainGetter,
+    chainId: string,
+    chainGetter: ChainGetter,
     ethereumURL: string
   ) {
     this.queryERC20Metadata = new ObservableQueryERC20Metadata(
       kvStore,
       ethereumURL
+    );
+    this.queryEVMTokenInfo = new ObservableQueryEVMTokenInfo(
+      kvStore,
+      chainId,
+      chainGetter
     );
   }
 }


### PR DESCRIPTION
Introduce experimental implementation of `AxelarEVMBridgeCurrencyRegistrar` which adds the currency from `/axelar/evm/v1beta1/token_info/${chain}?asset=${denom}` endpoint.
Only work with "axelar-evm-bridge" feature.