### PR TITLE
Add feature to select fee currency to pay from multiple fee currencies

### DIFF
--- a/packages/background/src/chains/types.ts
+++ b/packages/background/src/chains/types.ts
@@ -124,7 +124,8 @@ export const ChainInfoSchema = Joi.object<ChainInfo>({
         "eth-address-gen",
         "eth-key-sign",
         "query:/cosmos/bank/v1beta1/spendable_balances",
-        "axelar-evm-bridge"
+        "axelar-evm-bridge",
+        "osmosis-txfees"
       )
     )
     .unique()

--- a/packages/background/src/chains/types.ts
+++ b/packages/background/src/chains/types.ts
@@ -5,6 +5,7 @@ import {
   Currency,
   CW20Currency,
   Secret20Currency,
+  WithGasPriceStep,
 } from "@keplr-wallet/types";
 
 import Joi, { ObjectSchema } from "joi";
@@ -64,6 +65,12 @@ export const Secret20CurrencySchema = (CurrencySchema as ObjectSchema<Secret20Cu
     }
   });
 
+const GasPriceStepSchema = Joi.object({
+  low: Joi.number().required(),
+  average: Joi.number().required(),
+  high: Joi.number().required(),
+});
+
 export const Bech32ConfigSchema = Joi.object<Bech32Config>({
   bech32PrefixAccAddr: Joi.string().required(),
   bech32PrefixAccPub: Joi.string().required(),
@@ -94,14 +101,16 @@ export const ChainInfoSchema = Joi.object<ChainInfo>({
     .min(1)
     .items(CurrencySchema, CW20CurrencySchema, Secret20CurrencySchema)
     .required(),
-  feeCurrencies: Joi.array().min(1).items(CurrencySchema).required(),
+  feeCurrencies: Joi.array()
+    .min(1)
+    .items(
+      (CurrencySchema as Joi.ObjectSchema<WithGasPriceStep<Currency>>).keys({
+        gasPriceStep: GasPriceStepSchema,
+      })
+    )
+    .required(),
   coinType: Joi.number().integer(),
   beta: Joi.boolean(),
-  gasPriceStep: Joi.object({
-    low: Joi.number().required(),
-    average: Joi.number().required(),
-    high: Joi.number().required(),
-  }),
   features: Joi.array()
     .items(
       Joi.string().valid(

--- a/packages/extension/src/components/form/fee-buttons/fee-buttons.module.scss
+++ b/packages/extension/src/components/form/fee-buttons/fee-buttons.module.scss
@@ -28,3 +28,43 @@
     }
   }
 }
+
+.token-selector {
+  width: 100%;
+  height: 46px;
+
+  button {
+    width: 100%;
+
+    background: white;
+    text-align: left;
+    font-weight: normal;
+  }
+
+  :global(.dropdown-toggle) {
+    box-shadow: 0 1px 3px rgba(50, 50, 93, 0.15), 0 1px 0 rgba(0, 0, 0, 0.02) !important;
+
+    &::after {
+      border-radius: 2px;
+      content: " ";
+      display: block;
+      height: 0.625em;
+      margin-top: -0.4375em;
+      pointer-events: none;
+      position: absolute;
+      top: 50%;
+      transform: rotate(-45deg);
+      transform-origin: center;
+      width: 0.625em;
+      border: 0 solid black;
+      border-bottom-width: 3px;
+      border-left-width: 3px;
+      right: 1.125em;
+      z-index: 4;
+    }
+  }
+
+  :global(.dropdown-menu.show) {
+    width: 100%;
+  }
+}

--- a/packages/extension/src/components/form/fee-buttons/fee-buttons.tsx
+++ b/packages/extension/src/components/form/fee-buttons/fee-buttons.tsx
@@ -180,7 +180,7 @@ export const FeeCurrencySelector: FunctionComponent<{
         className="form-control-label"
         style={{ width: "100%" }}
       >
-        <FormattedMessage id="Fee Token" />
+        <FormattedMessage id="input.fee.selector.fee-currency" />
       </Label>
       <ButtonDropdown
         id={`selector-${randomId}`}

--- a/packages/extension/src/components/form/fee-buttons/fee-buttons.tsx
+++ b/packages/extension/src/components/form/fee-buttons/fee-buttons.tsx
@@ -53,6 +53,8 @@ export interface FeeButtonsProps {
 
   gasLabel?: string;
   gasSimulator?: IGasSimulator;
+
+  showFeeCurrencySelectorUnderSetGas?: boolean;
 }
 
 class FeeButtonState {
@@ -82,6 +84,7 @@ export const FeeButtons: FunctionComponent<FeeButtonsProps> = observer(
     feeSelectLabels = { low: "Low", average: "Average", high: "High" },
     gasLabel,
     gasSimulator,
+    showFeeCurrencySelectorUnderSetGas,
   }) => {
     // This may be not the good way to handle the states across the components.
     // But, rather than using the context API with boilerplate code, just use the mobx state to simplify the logic.
@@ -89,7 +92,8 @@ export const FeeButtons: FunctionComponent<FeeButtonsProps> = observer(
 
     return (
       <React.Fragment>
-        {feeConfig.feeCurrencies.length > 1 ? (
+        {feeConfig.feeCurrencies.length > 1 &&
+        !showFeeCurrencySelectorUnderSetGas ? (
           <FeeCurrencySelector feeConfig={feeConfig} />
         ) : null}
         {feeConfig.feeCurrency ? (
@@ -104,11 +108,27 @@ export const FeeButtons: FunctionComponent<FeeButtonsProps> = observer(
         ) : null}
         {feeButtonState.isGasInputOpen || !feeConfig.feeCurrency ? (
           gasSimulator ? (
-            <GasContainer
-              label={gasLabel}
-              gasConfig={gasConfig}
-              gasSimulator={gasSimulator}
-            />
+            showFeeCurrencySelectorUnderSetGas ? (
+              <React.Fragment>
+                <FeeCurrencySelector feeConfig={feeConfig} />
+                <GasContainer
+                  label={gasLabel}
+                  gasConfig={gasConfig}
+                  gasSimulator={gasSimulator}
+                />
+              </React.Fragment>
+            ) : (
+              <GasContainer
+                label={gasLabel}
+                gasConfig={gasConfig}
+                gasSimulator={gasSimulator}
+              />
+            )
+          ) : showFeeCurrencySelectorUnderSetGas ? (
+            <React.Fragment>
+              <FeeCurrencySelector feeConfig={feeConfig} />
+              <GasInput label={gasLabel} gasConfig={gasConfig} />
+            </React.Fragment>
           ) : (
             <GasInput label={gasLabel} gasConfig={gasConfig} />
           )
@@ -389,6 +409,7 @@ export const FeeButtonsInner: FunctionComponent<
               feeButtonState.setIsGasInputOpen(!feeButtonState.isGasInputOpen);
             }}
           >
+            {/* XXX: In fact, it is not only set gas, but fee currency can also be set depending on the option. */}
             {!feeButtonState.isGasInputOpen
               ? intl.formatMessage({
                   id: "input.fee.toggle.set-gas",

--- a/packages/extension/src/components/form/fee-buttons/fee-buttons.tsx
+++ b/packages/extension/src/components/form/fee-buttons/fee-buttons.tsx
@@ -283,7 +283,11 @@ export const FeeButtonsInner: FunctionComponent<
                 "text-muted": feeConfig.feeType !== "low",
               })}
             >
-              {lowFee.trim(true).toString()}
+              {
+                // Hide ibc metadata because there is no space to display the ibc metadata.
+                // Generally, user can distinguish the ibc metadata because the ibc metadata should be shown in the fee currency selector.
+                lowFee.hideIBCMetadata(true).trim(true).toString()
+              }
             </div>
           </Button>
           <Button
@@ -312,7 +316,7 @@ export const FeeButtonsInner: FunctionComponent<
                 "text-muted": feeConfig.feeType !== "average",
               })}
             >
-              {feeConfig.getFeeTypePretty("average").trim(true).toString()}
+              {averageFee.hideIBCMetadata(true).trim(true).toString()}
             </div>
           </Button>
           <Button
@@ -339,7 +343,7 @@ export const FeeButtonsInner: FunctionComponent<
                 "text-muted": feeConfig.feeType !== "high",
               })}
             >
-              {feeConfig.getFeeTypePretty("high").trim(true).toString()}
+              {highFee.hideIBCMetadata(true).trim(true).toString()}
             </div>
           </Button>
         </ButtonGroup>

--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -197,13 +197,24 @@ export const EmbedChainInfos: ChainInfo[] = [
         coinMinimalDenom: "uosmo",
         coinDecimals: 6,
         coinGeckoId: "osmosis",
+        gasPriceStep: {
+          low: 0,
+          average: 0.025,
+          high: 0.04,
+        },
+      },
+      {
+        coinDenom: "ION",
+        coinMinimalDenom: "uion",
+        coinDecimals: 6,
+        coinGeckoId: "ion",
+        gasPriceStep: {
+          low: 0,
+          average: 0.000001,
+          high: 0.000004,
+        },
       },
     ],
-    gasPriceStep: {
-      low: 0,
-      average: 0.025,
-      high: 0.04,
-    },
     features: ["ibc-transfer", "ibc-go", "cosmwasm"],
   },
   {
@@ -250,14 +261,14 @@ export const EmbedChainInfos: ChainInfo[] = [
         coinMinimalDenom: "uscrt",
         coinDecimals: 6,
         coinGeckoId: "secret",
+        gasPriceStep: {
+          low: 0.0125,
+          average: 0.1,
+          high: 0.25,
+        },
       },
     ],
     coinType: 529,
-    gasPriceStep: {
-      low: 0.0125,
-      average: 0.1,
-      high: 0.25,
-    },
     features: ["secretwasm", "ibc-go", "ibc-transfer"],
   },
   {
@@ -349,13 +360,13 @@ export const EmbedChainInfos: ChainInfo[] = [
         coinMinimalDenom: "basecro",
         coinDecimals: 8,
         coinGeckoId: "crypto-com-chain",
+        gasPriceStep: {
+          low: 0.025,
+          average: 0.03,
+          high: 0.04,
+        },
       },
     ],
-    gasPriceStep: {
-      low: 0.025,
-      average: 0.03,
-      high: 0.04,
-    },
     features: ["ibc-transfer"],
   },
   {
@@ -397,13 +408,13 @@ export const EmbedChainInfos: ChainInfo[] = [
         coinMinimalDenom: "uiov",
         coinDecimals: 6,
         coinGeckoId: "starname",
+        gasPriceStep: {
+          low: 1,
+          average: 2,
+          high: 3,
+        },
       },
     ],
-    gasPriceStep: {
-      low: 1,
-      average: 2,
-      high: 3,
-    },
     features: ["ibc-transfer"],
   },
   {
@@ -865,13 +876,13 @@ export const EmbedChainInfos: ChainInfo[] = [
         coinMinimalDenom: "rowan",
         coinDecimals: 18,
         coinGeckoId: "sifchain",
+        gasPriceStep: {
+          low: 1000000000000,
+          average: 1500000000000,
+          high: 2000000000000,
+        },
       },
     ],
-    gasPriceStep: {
-      low: 1000000000000,
-      average: 1500000000000,
-      high: 2000000000000,
-    },
     features: [],
   },
   {
@@ -968,13 +979,13 @@ export const EmbedChainInfos: ChainInfo[] = [
         coinMinimalDenom: "uiris",
         coinDecimals: 6,
         coinGeckoId: "iris-network",
+        gasPriceStep: {
+          low: 0.2,
+          average: 0.3,
+          high: 0.4,
+        },
       },
     ],
-    gasPriceStep: {
-      low: 0.2,
-      average: 0.3,
-      high: 0.4,
-    },
     features: ["ibc-transfer", "ibc-go"],
   },
   {
@@ -1016,13 +1027,13 @@ export const EmbedChainInfos: ChainInfo[] = [
         coinMinimalDenom: "uregen",
         coinDecimals: 6,
         coinGeckoId: "regen",
+        gasPriceStep: {
+          low: 0.015,
+          average: 0.025,
+          high: 0.04,
+        },
       },
     ],
-    gasPriceStep: {
-      low: 0.015,
-      average: 0.025,
-      high: 0.04,
-    },
     features: ["ibc-go", "ibc-transfer"],
   },
   {
@@ -1064,13 +1075,13 @@ export const EmbedChainInfos: ChainInfo[] = [
         coinMinimalDenom: "uxprt",
         coinDecimals: 6,
         coinGeckoId: "persistence",
+        gasPriceStep: {
+          low: 0,
+          average: 0.025,
+          high: 0.04,
+        },
       },
     ],
-    gasPriceStep: {
-      low: 0,
-      average: 0.025,
-      high: 0.04,
-    },
     features: ["ibc-transfer", "ibc-go"],
   },
   {
@@ -1112,13 +1123,13 @@ export const EmbedChainInfos: ChainInfo[] = [
         coinMinimalDenom: "udvpn",
         coinDecimals: 6,
         coinGeckoId: "sentinel",
+        gasPriceStep: {
+          low: 0.1,
+          average: 0.25,
+          high: 0.4,
+        },
       },
     ],
-    gasPriceStep: {
-      low: 0.1,
-      average: 0.25,
-      high: 0.4,
-    },
     features: ["ibc-transfer"],
   },
   {
@@ -1196,13 +1207,13 @@ export const EmbedChainInfos: ChainInfo[] = [
         coinMinimalDenom: "ukava",
         coinDecimals: 6,
         coinGeckoId: "kava",
+        gasPriceStep: {
+          low: 0.05,
+          average: 0.1,
+          high: 0.25,
+        },
       },
     ],
-    gasPriceStep: {
-      low: 0.05,
-      average: 0.1,
-      high: 0.25,
-    },
     coinType: 459,
     beta: true,
   },
@@ -1311,13 +1322,13 @@ export const EmbedChainInfos: ChainInfo[] = [
         coinMinimalDenom: "ungm",
         coinDecimals: 6,
         coinGeckoId: "e-money",
+        gasPriceStep: {
+          low: 1,
+          average: 1,
+          high: 1,
+        },
       },
     ],
-    gasPriceStep: {
-      low: 1,
-      average: 1,
-      high: 1,
-    },
     features: ["ibc-transfer"],
   },
   {
@@ -1363,13 +1374,13 @@ export const EmbedChainInfos: ChainInfo[] = [
         coinDenom: "IST",
         coinMinimalDenom: "uist",
         coinDecimals: 6,
+        gasPriceStep: {
+          low: 0,
+          average: 0,
+          high: 0,
+        },
       },
     ],
-    gasPriceStep: {
-      low: 0,
-      average: 0,
-      high: 0,
-    },
     features: ["ibc-go"],
   },
   {
@@ -1428,13 +1439,13 @@ export const EmbedChainInfos: ChainInfo[] = [
         coinDenom: "BOOT",
         coinMinimalDenom: "boot",
         coinDecimals: 0,
+        gasPriceStep: {
+          low: 0,
+          average: 0,
+          high: 0.01,
+        },
       },
     ],
-    gasPriceStep: {
-      low: 0,
-      average: 0,
-      high: 0.01,
-    },
     features: ["ibc-transfer", "cosmwasm", "ibc-go"],
   },
   {
@@ -1476,13 +1487,13 @@ export const EmbedChainInfos: ChainInfo[] = [
         coinMinimalDenom: "ujuno",
         coinDecimals: 6,
         coinGeckoId: "juno-network",
+        gasPriceStep: {
+          low: 0.001,
+          average: 0.0025,
+          high: 0.004,
+        },
       },
     ],
-    gasPriceStep: {
-      low: 0.001,
-      average: 0.0025,
-      high: 0.004,
-    },
     features: ["cosmwasm", "ibc-transfer", "ibc-go", "wasmd_0.24+"],
   },
   {
@@ -1672,13 +1683,13 @@ export const EmbedChainInfos: ChainInfo[] = [
         coinDenom: "AXL",
         coinMinimalDenom: "uaxl",
         coinDecimals: 6,
+        gasPriceStep: {
+          low: 0.007,
+          average: 0.007,
+          high: 0.01,
+        },
       },
     ],
-    gasPriceStep: {
-      low: 0.007,
-      average: 0.007,
-      high: 0.01,
-    },
     features: ["ibc-transfer", "ibc-go", "axelar-evm-bridge"],
   },
   {
@@ -1832,13 +1843,13 @@ export const EmbedChainInfos: ChainInfo[] = [
         coinDenom: "TGD",
         coinMinimalDenom: "utgd",
         coinDecimals: 6,
+        gasPriceStep: {
+          low: 0.05,
+          average: 0.05,
+          high: 0.075,
+        },
       },
     ],
-    gasPriceStep: {
-      low: 0.05,
-      average: 0.05,
-      high: 0.075,
-    },
     features: ["cosmwasm", "ibc-transfer", "ibc-go", "wasmd_0.24+"],
   },
   {
@@ -1887,13 +1898,13 @@ export const EmbedChainInfos: ChainInfo[] = [
         coinDenom: "STRD",
         coinMinimalDenom: "ustrd",
         coinDecimals: 6,
+        gasPriceStep: {
+          low: 0,
+          average: 0,
+          high: 0.04,
+        },
       },
     ],
-    gasPriceStep: {
-      low: 0,
-      average: 0,
-      high: 0.04,
-    },
     features: ["ibc-transfer", "ibc-go"],
   },
   {
@@ -1935,13 +1946,13 @@ export const EmbedChainInfos: ChainInfo[] = [
         coinMinimalDenom: "aevmos",
         coinDecimals: 18,
         coinGeckoId: "evmos",
+        gasPriceStep: {
+          low: 25000000000,
+          average: 25000000000,
+          high: 40000000000,
+        },
       },
     ],
-    gasPriceStep: {
-      low: 25000000000,
-      average: 25000000000,
-      high: 40000000000,
-    },
     features: ["ibc-transfer", "ibc-go", "eth-address-gen", "eth-key-sign"],
     beta: true,
   },

--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -215,7 +215,7 @@ export const EmbedChainInfos: ChainInfo[] = [
         },
       },
     ],
-    features: ["ibc-transfer", "ibc-go", "cosmwasm"],
+    features: ["ibc-transfer", "ibc-go", "cosmwasm", "osmosis-txfees"],
   },
   {
     rpc: SECRET_NETWORK_RPC_ENDPOINT,

--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -203,17 +203,6 @@ export const EmbedChainInfos: ChainInfo[] = [
           high: 0.04,
         },
       },
-      {
-        coinDenom: "ION",
-        coinMinimalDenom: "uion",
-        coinDecimals: 6,
-        coinGeckoId: "ion",
-        gasPriceStep: {
-          low: 0,
-          average: 0.000001,
-          high: 0.000004,
-        },
-      },
     ],
     features: ["ibc-transfer", "ibc-go", "cosmwasm", "osmosis-txfees"],
   },

--- a/packages/extension/src/languages/en.json
+++ b/packages/extension/src/languages/en.json
@@ -297,6 +297,7 @@
   "input.fee.error.insufficient": "Insufficient available balance for transaction fee",
   "input.fee.toggle.set-gas": "Advanced",
   "input.fee.toggle.set-gas.close": "Close",
+  "input.fee.selector.fee-currency": "Fee Token",
 
   "confirm.yes": "Yes",
   "confirm.no": "No",

--- a/packages/extension/src/languages/en.json
+++ b/packages/extension/src/languages/en.json
@@ -295,7 +295,7 @@
   "input.amount.error.is-negative": "Amount should be positive",
   "input.amount.error.insufficient": "Insufficient asset",
   "input.fee.error.insufficient": "Insufficient available balance for transaction fee",
-  "input.fee.toggle.set-gas": "Set Gas",
+  "input.fee.toggle.set-gas": "Advanced",
   "input.fee.toggle.set-gas.close": "Close",
 
   "confirm.yes": "Yes",

--- a/packages/extension/src/languages/ko.json
+++ b/packages/extension/src/languages/ko.json
@@ -275,7 +275,7 @@
   "input.amount.error.is-negative": "양수여야 합니다",
   "input.amount.error.insufficient": "자산이 부족합니다",
   "input.fee.error.insufficient": "수수료를 낼 충분한 잔고가 없습니다",
-  "input.fee.toggle.set-gas": "가스 설정",
+  "input.fee.toggle.set-gas": "고급",
   "input.fee.toggle.set-gas.close": "닫기",
 
   "confirm.yes": "예",

--- a/packages/extension/src/languages/ko.json
+++ b/packages/extension/src/languages/ko.json
@@ -277,6 +277,7 @@
   "input.fee.error.insufficient": "수수료를 낼 충분한 잔고가 없습니다",
   "input.fee.toggle.set-gas": "고급",
   "input.fee.toggle.set-gas.close": "닫기",
+  "input.fee.selector.fee-currency": "수수료 토큰",
 
   "confirm.yes": "예",
   "confirm.no": "아니요",

--- a/packages/extension/src/layouts/header-layout/index.tsx
+++ b/packages/extension/src/layouts/header-layout/index.tsx
@@ -9,6 +9,7 @@ import style from "./style.module.scss";
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface Props extends HeaderProps {
   style?: CSSProperties;
+  innerStyle?: CSSProperties;
 }
 
 export const HeaderLayout: FunctionComponent<Props> = (props) => {
@@ -32,7 +33,9 @@ export const HeaderLayout: FunctionComponent<Props> = (props) => {
     <MenuProvider value={menuContext}>
       <div className={style.container} style={props.style}>
         <Header {...props} isMenuOpen={isMenuOpen} />
-        <div className={style.innerContainer}>{children}</div>
+        <div className={style.innerContainer} style={props.innerStyle}>
+          {children}
+        </div>
       </div>
     </MenuProvider>
   );

--- a/packages/extension/src/pages/ibc-transfer/index.tsx
+++ b/packages/extension/src/pages/ibc-transfer/index.tsx
@@ -275,6 +275,9 @@ export const IBCTransferPageAmount: FunctionComponent<{
 
               onSubmit();
             }}
+            style={{
+              marginTop: "12px",
+            }}
           >
             <FormattedMessage id="ibc.transfer.submit" />
           </Button>

--- a/packages/extension/src/pages/send/index.tsx
+++ b/packages/extension/src/pages/send/index.tsx
@@ -365,6 +365,9 @@ export const SendPage: FunctionComponent = observer(() => {
             block
             data-loading={accountInfo.isSendingMsg === "send"}
             disabled={!accountInfo.isReadyToSendMsgs || !txStateIsValid}
+            style={{
+              marginTop: "12px",
+            }}
           >
             {intl.formatMessage({
               id: "send.button.send",

--- a/packages/extension/src/pages/send/index.tsx
+++ b/packages/extension/src/pages/send/index.tsx
@@ -202,6 +202,7 @@ export const SendPage: FunctionComponent = observer(() => {
     <HeaderLayout
       showChainName
       canChangeChainInfo={false}
+      style={{ height: "auto", minHeight: "100%" }}
       onBackButton={
         isDetachedPage
           ? undefined

--- a/packages/extension/src/pages/sign/adr-36.tsx
+++ b/packages/extension/src/pages/sign/adr-36.tsx
@@ -47,7 +47,7 @@ export const ADR36SignDocDetailsTab: FunctionComponent<{
   }, [signDocWrapper.aminoSignDoc.msgs, isADR36WithString]);
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+    <div style={{ display: "flex", flexDirection: "column", flex: 1 }}>
       <div className={styleDetailsTab.msgContainer} style={{ flex: "none" }}>
         <MsgRender icon="fas fa-pen-nib" title={renderTitleText()}>
           {origin ?? "Unknown"}
@@ -75,6 +75,7 @@ export const ADR36SignDocDetailsTab: FunctionComponent<{
             padding: "20px",
             border: "1px solid #9092B6",
             borderRadius: "8px",
+            maxHeight: "220px",
           }}
         >
           {signValue}
@@ -83,7 +84,7 @@ export const ADR36SignDocDetailsTab: FunctionComponent<{
       <Label for="chain-name" className="form-control-label">
         Requested Network
       </Label>
-      <div id="chain-name" style={{ marginBottom: "8px" }}>
+      <div id="chain-name">
         <div>{chainStore.current.chainName}</div>
       </div>
     </div>

--- a/packages/extension/src/pages/sign/details-tab.module.scss
+++ b/packages/extension/src/pages/sign/details-tab.module.scss
@@ -5,12 +5,14 @@
 }
 
 .container {
-  height: 100%;
+  flex: 1;
   display: flex;
   flex-direction: column;
 }
 
 .msg-container {
+  max-height: 150px;
+
   overflow: auto;
   flex: 1;
 

--- a/packages/extension/src/pages/sign/details-tab.module.scss
+++ b/packages/extension/src/pages/sign/details-tab.module.scss
@@ -11,7 +11,7 @@
 }
 
 .msg-container {
-  max-height: 150px;
+  max-height: 140px;
 
   overflow: auto;
   flex: 1;

--- a/packages/extension/src/pages/sign/details-tab.tsx
+++ b/packages/extension/src/pages/sign/details-tab.tsx
@@ -108,6 +108,7 @@ export const DetailsTab: FunctionComponent<{
         <div id="signing-messages" className={styleDetailsTab.msgContainer}>
           {renderedMsgs}
         </div>
+        <div style={{ flex: 1 }} />
         {!preferNoSetMemo ? (
           <MemoInput
             memoConfig={memoConfig}

--- a/packages/extension/src/pages/sign/details-tab.tsx
+++ b/packages/extension/src/pages/sign/details-tab.tsx
@@ -136,6 +136,7 @@ export const DetailsTab: FunctionComponent<{
             priceStore={priceStore}
             label={intl.formatMessage({ id: "sign.info.fee" })}
             gasLabel={intl.formatMessage({ id: "sign.info.gas" })}
+            showFeeCurrencySelectorUnderSetGas={true}
           />
         ) : (
           <React.Fragment>

--- a/packages/extension/src/pages/sign/index.tsx
+++ b/packages/extension/src/pages/sign/index.tsx
@@ -148,13 +148,18 @@ export const SignPage: FunctionComponent = observer(() => {
     signInteractionStore.waitingData?.data.signOptions.preferNoSetMemo ===
       true || isProcessing;
 
-  const interactionInfo = useInteractionInfo(() => {
-    if (needSetIsProcessing) {
-      setIsProcessing(true);
-    }
+  const interactionInfo = useInteractionInfo(
+    () => {
+      if (needSetIsProcessing) {
+        setIsProcessing(true);
+      }
 
-    signInteractionStore.rejectAll();
-  });
+      signInteractionStore.rejectAll();
+    },
+    {
+      enableScroll: true,
+    }
+  );
 
   const currentChainId = chainStore.current.chainId;
   const currentChainIdentifier = useMemo(
@@ -227,7 +232,8 @@ export const SignPage: FunctionComponent = observer(() => {
             }
           : undefined
       }
-      style={{ background: "white" }}
+      style={{ background: "white", height: "auto", minHeight: "100%" }}
+      innerStyle={{ display: "flex", flexDirection: "column" }}
     >
       {
         /*
@@ -296,7 +302,6 @@ export const SignPage: FunctionComponent = observer(() => {
                 )
               ) : null}
             </div>
-            <div style={{ flex: 1 }} />
             <div className={style.buttons}>
               {keyRingStore.keyRingType === "ledger" &&
               signInteractionStore.isLoading ? (

--- a/packages/extension/src/pages/sign/index.tsx
+++ b/packages/extension/src/pages/sign/index.tsx
@@ -228,6 +228,7 @@ export const SignPage: FunctionComponent = observer(() => {
           : undefined
       }
       style={{ background: "white" }}
+      innerStyle={{ display: "flex", flexDirection: "column" }}
     >
       {
         /*

--- a/packages/extension/src/pages/sign/index.tsx
+++ b/packages/extension/src/pages/sign/index.tsx
@@ -228,7 +228,6 @@ export const SignPage: FunctionComponent = observer(() => {
           : undefined
       }
       style={{ background: "white" }}
-      innerStyle={{ display: "flex", flexDirection: "column" }}
     >
       {
         /*

--- a/packages/extension/src/pages/sign/style.module.scss
+++ b/packages/extension/src/pages/sign/style.module.scss
@@ -30,6 +30,7 @@
 
 .buttons {
   display: flex;
+  margin-top: 12px;
 }
 
 .button {
@@ -37,13 +38,15 @@
 }
 
 .container {
-  height: 100%;
+  flex: 1;
   display: flex;
   flex-direction: column;
 }
 
 .tab-container {
-  height: 400px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
 
   &.data-tab {
     overflow: auto;
@@ -51,6 +54,7 @@
 }
 
 .message {
+  margin-bottom: 0;
   height: 400px;
   font-size: 12px;
   overflow: visible;

--- a/packages/extension/src/stores/root.tsx
+++ b/packages/extension/src/stores/root.tsx
@@ -13,6 +13,7 @@ import {
   CosmosQueries,
   CosmwasmAccount,
   CosmwasmQueries,
+  OsmosisQueries,
   DeferInitialQueryController,
   getKeplrFromWindow,
   IBCChannelStore,
@@ -64,7 +65,13 @@ export class RootStore {
   public readonly chainSuggestStore: ChainSuggestStore;
 
   public readonly queriesStore: QueriesStore<
-    [CosmosQueries, CosmwasmQueries, SecretQueries, KeplrETCQueries]
+    [
+      CosmosQueries,
+      CosmwasmQueries,
+      SecretQueries,
+      OsmosisQueries,
+      KeplrETCQueries
+    ]
   >;
   public readonly accountStore: AccountStore<
     [CosmosAccount, CosmwasmAccount, SecretAccount]
@@ -159,6 +166,7 @@ export class RootStore {
       SecretQueries.use({
         apiGetter: getKeplrFromWindow,
       }),
+      OsmosisQueries.use(),
       KeplrETCQueries.use({
         ethereumURL: EthereumEndpoint,
       })

--- a/packages/hooks/src/interaction/index.ts
+++ b/packages/hooks/src/interaction/index.ts
@@ -5,7 +5,12 @@ import queryString from "querystring";
 import { disableScroll, fitPopupWindow } from "@keplr-wallet/popup";
 import { useEffect, useRef } from "react";
 
-export const useInteractionInfo = (cleanUp?: () => void) => {
+export const useInteractionInfo = (
+  cleanUp?: () => void,
+  options: {
+    enableScroll?: boolean;
+  } = {}
+) => {
   const location = useLocation();
   let search = location.search;
   if (search.startsWith("?")) {
@@ -23,7 +28,9 @@ export const useInteractionInfo = (cleanUp?: () => void) => {
 
   useEffect(() => {
     if (result.interaction && !result.interactionInternal) {
-      disableScroll();
+      if (!options.enableScroll) {
+        disableScroll();
+      }
       fitPopupWindow();
     }
   }, [result.interaction, result.interactionInternal]);

--- a/packages/hooks/src/tx/amount.ts
+++ b/packages/hooks/src/tx/amount.ts
@@ -1,10 +1,6 @@
 import { IAmountConfig, IFeeConfig } from "./types";
 import { TxChainSetter } from "./chain";
-import {
-  ChainGetter,
-  CoinPrimitive,
-  IQueriesStore,
-} from "@keplr-wallet/stores";
+import { ChainGetter, CoinPrimitive } from "@keplr-wallet/stores";
 import { action, computed, makeObservable, observable } from "mobx";
 import { AppCurrency } from "@keplr-wallet/types";
 import {
@@ -16,6 +12,7 @@ import {
 } from "./errors";
 import { Dec, DecUtils } from "@keplr-wallet/unit";
 import { useState } from "react";
+import { QueriesStore } from "./internal";
 
 export class AmountConfig extends TxChainSetter implements IAmountConfig {
   @observable.ref
@@ -35,7 +32,7 @@ export class AmountConfig extends TxChainSetter implements IAmountConfig {
 
   constructor(
     chainGetter: ChainGetter,
-    protected readonly queriesStore: IQueriesStore,
+    protected readonly queriesStore: QueriesStore,
     initialChainId: string,
     sender: string,
     feeConfig: IFeeConfig | undefined
@@ -222,7 +219,7 @@ export class AmountConfig extends TxChainSetter implements IAmountConfig {
 
 export const useAmountConfig = (
   chainGetter: ChainGetter,
-  queriesStore: IQueriesStore,
+  queriesStore: QueriesStore,
   chainId: string,
   sender: string
 ) => {

--- a/packages/hooks/src/tx/chain.ts
+++ b/packages/hooks/src/tx/chain.ts
@@ -1,6 +1,6 @@
 import { action, computed, makeObservable, observable } from "mobx";
 import { ChainGetter } from "@keplr-wallet/stores";
-import { ChainInfo } from "@keplr-wallet/types";
+import { AppCurrency, ChainInfo } from "@keplr-wallet/types";
 import { ITxChainSetter } from "./types";
 
 export class TxChainSetter implements ITxChainSetter {
@@ -17,7 +17,11 @@ export class TxChainSetter implements ITxChainSetter {
   }
 
   @computed
-  get chainInfo(): ChainInfo {
+  get chainInfo(): ChainInfo & {
+    addUnknownCurrencies(...coinMinimalDenoms: string[]): void;
+    findCurrency(coinMinimalDenom: string): AppCurrency | undefined;
+    forceFindCurrency(coinMinimalDenom: string): AppCurrency;
+  } {
     return this.chainGetter.getChain(this.chainId);
   }
 

--- a/packages/hooks/src/tx/delegate-tx.ts
+++ b/packages/hooks/src/tx/delegate-tx.ts
@@ -1,9 +1,4 @@
-import {
-  ChainGetter,
-  IAccountStore,
-  IQueriesStore,
-  MsgOpt,
-} from "@keplr-wallet/stores";
+import { ChainGetter, IAccountStore, MsgOpt } from "@keplr-wallet/stores";
 import {
   AmountConfig,
   GasConfig,
@@ -14,6 +9,7 @@ import {
 import { AppCurrency } from "@keplr-wallet/types";
 import { useState } from "react";
 import { makeObservable, override } from "mobx";
+import { QueriesStore } from "./internal";
 
 export class DelegateAmountConfig extends AmountConfig {
   get sendableCurrencies(): AppCurrency[] {
@@ -52,7 +48,7 @@ export class DelegateGasConfig extends GasConfig {
 
 export const useDelegateAmountConfig = (
   chainGetter: ChainGetter,
-  queriesStore: IQueriesStore,
+  queriesStore: QueriesStore,
   chainId: string,
   sender: string
 ) => {
@@ -93,7 +89,7 @@ export const useDelegateGasConfig = (
 
 export const useDelegateTxConfig = (
   chainGetter: ChainGetter,
-  queriesStore: IQueriesStore,
+  queriesStore: QueriesStore,
   accountStore: IAccountStore<{
     cosmos: {
       readonly msgOpts: {

--- a/packages/hooks/src/tx/fee.ts
+++ b/packages/hooks/src/tx/fee.ts
@@ -148,7 +148,19 @@ export class FeeConfig extends TxChainSetter implements IFeeConfig {
       }
     }
 
-    return this.chainInfo.feeCurrencies;
+    const res: FeeCurrency[] = [];
+
+    for (const feeCurrency of this.chainInfo.feeCurrencies) {
+      const cur = this.chainInfo.findCurrency(feeCurrency.coinMinimalDenom);
+      if (cur) {
+        res.push({
+          ...feeCurrency,
+          ...cur,
+        });
+      }
+    }
+
+    return res;
   }
 
   @computed

--- a/packages/hooks/src/tx/internal.ts
+++ b/packages/hooks/src/tx/internal.ts
@@ -1,0 +1,11 @@
+import {
+  CosmosQueriesImpl,
+  IQueriesStore,
+  OsmosisQueries,
+} from "@keplr-wallet/stores";
+
+export type QueriesStore = IQueriesStore<
+  Partial<OsmosisQueries> & {
+    cosmos?: Pick<CosmosQueriesImpl, "queryDelegations">;
+  }
+>;

--- a/packages/hooks/src/tx/redelegate-tx.ts
+++ b/packages/hooks/src/tx/redelegate-tx.ts
@@ -1,10 +1,4 @@
-import {
-  ChainGetter,
-  IQueriesStore,
-  CosmosQueriesImpl,
-  IAccountStore,
-  MsgOpt,
-} from "@keplr-wallet/stores";
+import { ChainGetter, IAccountStore, MsgOpt } from "@keplr-wallet/stores";
 import {
   GasConfig,
   useFeeConfig,
@@ -14,6 +8,7 @@ import {
 import { useStakedAmountConfig } from "./staked-amount";
 import { makeObservable, override } from "mobx";
 import { useState } from "react";
+import { QueriesStore } from "./internal";
 
 export class RedelegateGasConfig extends GasConfig {
   constructor(
@@ -65,9 +60,7 @@ export const useRedelegateGasConfig = (
 
 export const useRedelegateTxConfig = (
   chainGetter: ChainGetter,
-  queriesStore: IQueriesStore<{
-    cosmos: Pick<CosmosQueriesImpl, "queryDelegations">;
-  }>,
+  queriesStore: QueriesStore,
   accountStore: IAccountStore<{
     cosmos: {
       readonly msgOpts: {

--- a/packages/hooks/src/tx/send-tx.ts
+++ b/packages/hooks/src/tx/send-tx.ts
@@ -1,12 +1,13 @@
-import { ChainGetter, IQueriesStore } from "@keplr-wallet/stores";
+import { ChainGetter } from "@keplr-wallet/stores";
 import { useFeeConfig, useMemoConfig, useRecipientConfig } from "./index";
 import { useSendGasConfig } from "./send-gas";
 import { useAmountConfig } from "./amount";
 import { AccountStore } from "./send-types";
+import { QueriesStore } from "./internal";
 
 export const useSendTxConfig = (
   chainGetter: ChainGetter,
-  queriesStore: IQueriesStore,
+  queriesStore: QueriesStore,
   accountStore: AccountStore,
   chainId: string,
   sender: string,

--- a/packages/hooks/src/tx/types.ts
+++ b/packages/hooks/src/tx/types.ts
@@ -27,6 +27,8 @@ export interface IGasConfig extends ITxChainSetter {
 }
 
 export interface IFeeConfig extends ITxChainSetter {
+  sender: string;
+  setSender(sender: string): void;
   feeType: FeeType | undefined;
   setFeeType(feeType: FeeType | undefined): void;
   setAutoFeeCoinMinimalDenom(denom: string | undefined): void;

--- a/packages/hooks/src/tx/types.ts
+++ b/packages/hooks/src/tx/types.ts
@@ -1,4 +1,4 @@
-import { AppCurrency, Currency } from "@keplr-wallet/types";
+import { AppCurrency, Currency, FeeCurrency } from "@keplr-wallet/types";
 import { StdFee } from "@cosmjs/launchpad";
 import { CoinPretty } from "@keplr-wallet/unit";
 import { CoinPrimitive } from "@keplr-wallet/stores";
@@ -37,6 +37,10 @@ export interface IFeeConfig extends ITxChainSetter {
   toStdFee(): StdFee;
   fee: CoinPretty | undefined;
   getFeeTypePretty(feeType: FeeType): CoinPretty;
+  getFeeTypePrettyForFeeCurrency(
+    feeCurrency: FeeCurrency,
+    feeType: FeeType
+  ): CoinPretty;
   getFeePrimitive(): CoinPrimitive | undefined;
   isManual: boolean;
   error: Error | undefined;

--- a/packages/hooks/src/tx/types.ts
+++ b/packages/hooks/src/tx/types.ts
@@ -29,6 +29,7 @@ export interface IGasConfig extends ITxChainSetter {
 export interface IFeeConfig extends ITxChainSetter {
   feeType: FeeType | undefined;
   setFeeType(feeType: FeeType | undefined): void;
+  setAutoFeeCoinMinimalDenom(denom: string | undefined): void;
   feeCurrencies: Currency[];
   feeCurrency: Currency | undefined;
   toStdFee(): StdFee;

--- a/packages/hooks/src/tx/undelegate-tx.ts
+++ b/packages/hooks/src/tx/undelegate-tx.ts
@@ -1,10 +1,4 @@
-import {
-  ChainGetter,
-  IQueriesStore,
-  CosmosQueriesImpl,
-  IAccountStore,
-  MsgOpt,
-} from "@keplr-wallet/stores";
+import { ChainGetter, IAccountStore, MsgOpt } from "@keplr-wallet/stores";
 import {
   GasConfig,
   useFeeConfig,
@@ -14,6 +8,7 @@ import {
 import { useStakedAmountConfig } from "./staked-amount";
 import { makeObservable, override } from "mobx";
 import { useState } from "react";
+import { QueriesStore } from "./internal";
 
 export class UndelegateGasConfig extends GasConfig {
   constructor(
@@ -65,9 +60,7 @@ export const useUndelegateGasConfig = (
 
 export const useUndelegateTxConfig = (
   chainGetter: ChainGetter,
-  queriesStore: IQueriesStore<{
-    cosmos: Pick<CosmosQueriesImpl, "queryDelegations">;
-  }>,
+  queriesStore: QueriesStore,
   accountStore: IAccountStore<{
     cosmos: {
       readonly msgOpts: {

--- a/packages/provider/src/core.ts
+++ b/packages/provider/src/core.ts
@@ -63,7 +63,36 @@ export class Keplr implements IKeplr {
     );
   }
 
-  async experimentalSuggestChain(chainInfo: ChainInfo): Promise<void> {
+  async experimentalSuggestChain(
+    chainInfo: ChainInfo & {
+      // Legacy
+      gasPriceStep?: {
+        readonly low: number;
+        readonly average: number;
+        readonly high: number;
+      };
+    }
+  ): Promise<void> {
+    if (chainInfo.gasPriceStep) {
+      // Gas price step in ChainInfo is legacy format.
+      // Try to change the recent format for backward-compatibility.
+      const gasPriceStep = { ...chainInfo.gasPriceStep };
+      for (const feeCurrency of chainInfo.feeCurrencies) {
+        if (!feeCurrency.gasPriceStep) {
+          (feeCurrency as {
+            gasPriceStep?: {
+              readonly low: number;
+              readonly average: number;
+              readonly high: number;
+            };
+          }).gasPriceStep = gasPriceStep;
+        }
+      }
+      delete chainInfo.gasPriceStep;
+
+      console.log("TODO: Describe something");
+    }
+
     const msg = new SuggestChainInfoMsg(chainInfo);
     await this.requester.sendMessage(BACKGROUND_PORT, msg);
   }

--- a/packages/provider/src/core.ts
+++ b/packages/provider/src/core.ts
@@ -90,7 +90,7 @@ export class Keplr implements IKeplr {
       }
       delete chainInfo.gasPriceStep;
 
-      console.log("TODO: Describe something");
+      console.warn("TODO: Describe something");
     }
 
     const msg = new SuggestChainInfoMsg(chainInfo);

--- a/packages/provider/src/inject.ts
+++ b/packages/provider/src/inject.ts
@@ -255,7 +255,7 @@ export class InjectedKeplr implements IKeplr {
       chainInfo.features?.includes("stargate") ||
       chainInfo.features?.includes("no-legacy-stdTx")
     ) {
-      console.log(
+      console.warn(
         "“stargate”, “no-legacy-stdTx” feature has been deprecated. The launchpad is no longer supported, thus works without the two features. We would keep the aforementioned two feature for a while, but the upcoming update would potentially cause errors. Remove the two feature."
       );
     }
@@ -273,7 +273,7 @@ export class InjectedKeplr implements IKeplr {
     mode: BroadcastMode
   ): Promise<Uint8Array> {
     if (!("length" in tx)) {
-      console.log(
+      console.warn(
         "Do not send legacy std tx via `sendTx` API. We now only support protobuf tx. The usage of legeacy std tx would throw an error in the near future."
       );
     }

--- a/packages/stores/src/chain/index.ts
+++ b/packages/stores/src/chain/index.ts
@@ -12,6 +12,7 @@ import {
   BIP44,
   ChainInfo,
   Currency,
+  FeeCurrency,
 } from "@keplr-wallet/types";
 import { ChainGetter } from "../common";
 import { ChainIdHelper } from "@keplr-wallet/cosmos";
@@ -248,14 +249,8 @@ export class ChainInfoInner<C extends ChainInfo = ChainInfo>
     return this.raw.features;
   }
 
-  get feeCurrencies(): Currency[] {
+  get feeCurrencies(): FeeCurrency[] {
     return this.raw.feeCurrencies;
-  }
-
-  get gasPriceStep():
-    | { low: number; average: number; high: number }
-    | undefined {
-    return this.raw.gasPriceStep;
   }
 
   get rest(): string {

--- a/packages/stores/src/query/index.ts
+++ b/packages/stores/src/query/index.ts
@@ -5,3 +5,4 @@ export * from "./balances";
 export * from "./cosmos";
 export * from "./cosmwasm";
 export * from "./secret-wasm";
+export * from "./osmosis";

--- a/packages/stores/src/query/osmosis/index.ts
+++ b/packages/stores/src/query/osmosis/index.ts
@@ -1,5 +1,9 @@
 export * from "./txfees/fee-tokens";
+export * from "./txfees/spot-price-by-denom";
+export * from "./txfees/base-denom";
 
-export * as FeeTokens from "./txfees/fee-tokens/types";
+export * as TxFeesFeeTokens from "./txfees/fee-tokens/types";
+export * as TxFeesSpotPriceByDenom from "./txfees/spot-price-by-denom/types";
+export * as TxFeesBaseDenom from "./txfees/base-denom/types";
 
 export * from "./queries";

--- a/packages/stores/src/query/osmosis/index.ts
+++ b/packages/stores/src/query/osmosis/index.ts
@@ -1,0 +1,5 @@
+export * from "./txfees/fee-tokens";
+
+export * as FeeTokens from "./txfees/fee-tokens/types";
+
+export * from "./queries";

--- a/packages/stores/src/query/osmosis/queries.ts
+++ b/packages/stores/src/query/osmosis/queries.ts
@@ -4,6 +4,7 @@ import { ChainGetter } from "../../common";
 import { DeepReadonly } from "utility-types";
 import { ObservableQueryTxFeesFeeTokens } from "./txfees/fee-tokens";
 import { ObservableQueryTxFeesSpotPriceByDenom } from "./txfees/spot-price-by-denom";
+import { ObservableQueryTxFeesBaseDenom } from "./txfees/base-denom";
 
 export interface OsmosisQueries {
   osmosis: OsmosisQueriesImpl;
@@ -37,6 +38,7 @@ export const OsmosisQueries = {
 export class OsmosisQueriesImpl {
   public readonly queryTxFeesFeeTokens: DeepReadonly<ObservableQueryTxFeesFeeTokens>;
   public readonly queryTxFeesSpotPriceByDenom: DeepReadonly<ObservableQueryTxFeesSpotPriceByDenom>;
+  public readonly queryTxFeesBaseDenom: DeepReadonly<ObservableQueryTxFeesBaseDenom>;
 
   constructor(
     _: QueriesSetBase,
@@ -50,6 +52,11 @@ export class OsmosisQueriesImpl {
       chainGetter
     );
     this.queryTxFeesSpotPriceByDenom = new ObservableQueryTxFeesSpotPriceByDenom(
+      kvStore,
+      chainId,
+      chainGetter
+    );
+    this.queryTxFeesBaseDenom = new ObservableQueryTxFeesBaseDenom(
       kvStore,
       chainId,
       chainGetter

--- a/packages/stores/src/query/osmosis/queries.ts
+++ b/packages/stores/src/query/osmosis/queries.ts
@@ -1,0 +1,51 @@
+import { QueriesSetBase } from "../queries";
+import { KVStore } from "@keplr-wallet/common";
+import { ChainGetter } from "../../common";
+import { DeepReadonly } from "utility-types";
+import { ObservableQueryTxFeesFeeTokens } from "./txfees/fee-tokens";
+
+export interface OsmosisQueries {
+  osmosis: OsmosisQueriesImpl;
+}
+
+export const OsmosisQueries = {
+  use(): (
+    queriesSetBase: QueriesSetBase,
+    kvStore: KVStore,
+    chainId: string,
+    chainGetter: ChainGetter
+  ) => OsmosisQueries {
+    return (
+      queriesSetBase: QueriesSetBase,
+      kvStore: KVStore,
+      chainId: string,
+      chainGetter: ChainGetter
+    ) => {
+      return {
+        osmosis: new OsmosisQueriesImpl(
+          queriesSetBase,
+          kvStore,
+          chainId,
+          chainGetter
+        ),
+      };
+    };
+  },
+};
+
+export class OsmosisQueriesImpl {
+  public readonly queryTxFeesFeeTokens: DeepReadonly<ObservableQueryTxFeesFeeTokens>;
+
+  constructor(
+    _: QueriesSetBase,
+    kvStore: KVStore,
+    chainId: string,
+    chainGetter: ChainGetter
+  ) {
+    this.queryTxFeesFeeTokens = new ObservableQueryTxFeesFeeTokens(
+      kvStore,
+      chainId,
+      chainGetter
+    );
+  }
+}

--- a/packages/stores/src/query/osmosis/queries.ts
+++ b/packages/stores/src/query/osmosis/queries.ts
@@ -3,6 +3,7 @@ import { KVStore } from "@keplr-wallet/common";
 import { ChainGetter } from "../../common";
 import { DeepReadonly } from "utility-types";
 import { ObservableQueryTxFeesFeeTokens } from "./txfees/fee-tokens";
+import { ObservableQueryTxFeesSpotPriceByDenom } from "./txfees/spot-price-by-denom";
 
 export interface OsmosisQueries {
   osmosis: OsmosisQueriesImpl;
@@ -35,6 +36,7 @@ export const OsmosisQueries = {
 
 export class OsmosisQueriesImpl {
   public readonly queryTxFeesFeeTokens: DeepReadonly<ObservableQueryTxFeesFeeTokens>;
+  public readonly queryTxFeesSpotPriceByDenom: DeepReadonly<ObservableQueryTxFeesSpotPriceByDenom>;
 
   constructor(
     _: QueriesSetBase,
@@ -43,6 +45,11 @@ export class OsmosisQueriesImpl {
     chainGetter: ChainGetter
   ) {
     this.queryTxFeesFeeTokens = new ObservableQueryTxFeesFeeTokens(
+      kvStore,
+      chainId,
+      chainGetter
+    );
+    this.queryTxFeesSpotPriceByDenom = new ObservableQueryTxFeesSpotPriceByDenom(
       kvStore,
       chainId,
       chainGetter

--- a/packages/stores/src/query/osmosis/txfees/base-denom/index.ts
+++ b/packages/stores/src/query/osmosis/txfees/base-denom/index.ts
@@ -1,0 +1,17 @@
+import { ObservableChainQuery } from "../../../chain-query";
+import { KVStore } from "@keplr-wallet/common";
+import { ChainGetter } from "../../../../common";
+import { makeObservable } from "mobx";
+import { BaseDenom } from "./types";
+
+export class ObservableQueryTxFeesBaseDenom extends ObservableChainQuery<BaseDenom> {
+  constructor(kvStore: KVStore, chainId: string, chainGetter: ChainGetter) {
+    super(kvStore, chainId, chainGetter, "/osmosis/txfees/v1beta1/base_denom");
+
+    makeObservable(this);
+  }
+
+  get baseDenom(): string {
+    return this.response?.data.base_denom ?? "";
+  }
+}

--- a/packages/stores/src/query/osmosis/txfees/base-denom/types.ts
+++ b/packages/stores/src/query/osmosis/txfees/base-denom/types.ts
@@ -1,0 +1,3 @@
+export type BaseDenom = {
+  base_denom: string;
+};

--- a/packages/stores/src/query/osmosis/txfees/fee-tokens/index.ts
+++ b/packages/stores/src/query/osmosis/txfees/fee-tokens/index.ts
@@ -1,0 +1,41 @@
+import { ObservableChainQuery } from "../../../chain-query";
+import { KVStore } from "@keplr-wallet/common";
+import { ChainGetter, QueryResponse } from "../../../../common";
+import { computed, makeObservable } from "mobx";
+import { FeeTokens } from "./types";
+import { FeeCurrency } from "@keplr-wallet/types";
+
+export class ObservableQueryTxFeesFeeTokens extends ObservableChainQuery<FeeTokens> {
+  constructor(kvStore: KVStore, chainId: string, chainGetter: ChainGetter) {
+    super(kvStore, chainId, chainGetter, "/osmosis/txfees/v1beta1/fee_tokens");
+
+    makeObservable(this);
+  }
+
+  protected setResponse(response: Readonly<QueryResponse<FeeTokens>>) {
+    super.setResponse(response);
+
+    const chainInfo = this.chainGetter.getChain(this.chainId);
+    const denoms = response.data.fee_tokens.map((token) => token.denom);
+    chainInfo.addUnknownCurrencies(...denoms);
+  }
+
+  @computed
+  get feeCurrencies(): FeeCurrency[] {
+    if (!this.response) {
+      return [];
+    }
+
+    const res: FeeCurrency[] = [];
+
+    const chainInfo = this.chainGetter.getChain(this.chainId);
+    for (const token of this.response.data.fee_tokens) {
+      const currency = chainInfo.findCurrency(token.denom);
+      if (currency) {
+        res.push(currency);
+      }
+    }
+
+    return res;
+  }
+}

--- a/packages/stores/src/query/osmosis/txfees/fee-tokens/types.ts
+++ b/packages/stores/src/query/osmosis/txfees/fee-tokens/types.ts
@@ -1,0 +1,6 @@
+export type FeeTokens = {
+  fee_tokens: {
+    denom: string;
+    poolID: string;
+  }[];
+};

--- a/packages/stores/src/query/osmosis/txfees/spot-price-by-denom/index.ts
+++ b/packages/stores/src/query/osmosis/txfees/spot-price-by-denom/index.ts
@@ -1,0 +1,65 @@
+import {
+  ObservableChainQuery,
+  ObservableChainQueryMap,
+} from "../../../chain-query";
+import { KVStore } from "@keplr-wallet/common";
+import { ChainGetter } from "../../../../common";
+import { computed, makeObservable } from "mobx";
+import { SpotPriceByDenom } from "./types";
+import { Dec } from "@keplr-wallet/unit";
+
+export class ObservableQueryTxFeesSpotPriceByDenomInner extends ObservableChainQuery<SpotPriceByDenom> {
+  constructor(
+    kvStore: KVStore,
+    chainId: string,
+    chainGetter: ChainGetter,
+    denom: string
+  ) {
+    super(
+      kvStore,
+      chainId,
+      chainGetter,
+      `osmosis/txfees/v1beta1/spot_price_by_denom?denom=${denom}`
+    );
+
+    makeObservable(this);
+  }
+
+  get poolId(): string {
+    if (!this.response) {
+      return "";
+    }
+
+    return this.response.data.poolID;
+  }
+
+  @computed
+  get spotPriceDec(): Dec {
+    if (!this.response) {
+      return new Dec(0);
+    }
+
+    return new Dec(this.response.data.spot_price);
+  }
+}
+
+export class ObservableQueryTxFeesSpotPriceByDenom extends ObservableChainQueryMap<SpotPriceByDenom> {
+  constructor(
+    protected readonly kvStore: KVStore,
+    protected readonly chainId: string,
+    protected readonly chainGetter: ChainGetter
+  ) {
+    super(kvStore, chainId, chainGetter, (denom: string) => {
+      return new ObservableQueryTxFeesSpotPriceByDenomInner(
+        this.kvStore,
+        this.chainId,
+        this.chainGetter,
+        denom
+      );
+    });
+  }
+
+  getQueryDenom(denom: string): ObservableQueryTxFeesSpotPriceByDenomInner {
+    return this.get(denom) as ObservableQueryTxFeesSpotPriceByDenomInner;
+  }
+}

--- a/packages/stores/src/query/osmosis/txfees/spot-price-by-denom/types.ts
+++ b/packages/stores/src/query/osmosis/txfees/spot-price-by-denom/types.ts
@@ -1,0 +1,5 @@
+export type SpotPriceByDenom = {
+  poolID: string;
+  // Dec
+  spot_price: string;
+};

--- a/packages/types/src/chain-info.ts
+++ b/packages/types/src/chain-info.ts
@@ -1,4 +1,4 @@
-import { Currency, AppCurrency } from "./currency";
+import { Currency, AppCurrency, FeeCurrency } from "./currency";
 import { BIP44 } from "./bip44";
 import { AxiosRequestConfig } from "axios";
 import { Bech32Config } from "./bech32";
@@ -26,7 +26,7 @@ export interface ChainInfo {
    * This indicates which coin or token can be used for fee to send transaction.
    * You can get actual currency information from Currencies.
    */
-  readonly feeCurrencies: Currency[];
+  readonly feeCurrencies: FeeCurrency[];
   /**
    * This is the coin type in slip-044.
    * This is used for fetching address from ENS if this field is set.
@@ -36,17 +36,6 @@ export interface ChainInfo {
    * @deprecated This field is likely to be changed. ENS will continue to be supported, but will change in the future to use other methods than this field. Because of the low usage of the ENS feature, the change is a low priority and it is not yet clear how it will change.
    */
   readonly coinType?: number;
-
-  /**
-   * This is used to set the fee of the transaction.
-   * If this field is empty, it just use the default gas price step (low: 0.01, average: 0.025, high: 0.04).
-   * And, set field's type as primitive number because it is hard to restore the prototype after deserialzing if field's type is `Dec`.
-   */
-  readonly gasPriceStep?: {
-    low: number;
-    average: number;
-    high: number;
-  };
 
   /**
    * Indicate the features supported by this chain. Ex) cosmwasm, secretwasm ...

--- a/packages/types/src/currency.ts
+++ b/packages/types/src/currency.ts
@@ -66,3 +66,18 @@ export interface FiatCurrency {
   readonly maxDecimals: number;
   readonly locale: string;
 }
+
+export type WithGasPriceStep<T> = T & {
+  /**
+   * This is used to set the fee of the transaction.
+   * If this field is empty, it just use the default gas price step (low: 0.01, average: 0.025, high: 0.04).
+   * And, set field's type as primitive number because it is hard to restore the prototype after deserialzing if field's type is `Dec`.
+   */
+  readonly gasPriceStep?: {
+    readonly low: number;
+    readonly average: number;
+    readonly high: number;
+  };
+};
+
+export type FeeCurrency = WithGasPriceStep<AppCurrency>;

--- a/packages/unit/src/coin-pretty.spec.ts
+++ b/packages/unit/src/coin-pretty.spec.ts
@@ -515,4 +515,80 @@ describe("Test CoinPretty", () => {
       expect(test.pre(test.base).toString()).toBe(test.res);
     }
   });
+
+  it("Test CoinPretty's toString() with hideIBCMetadata", () => {
+    const tests: {
+      base: CoinPretty;
+      pre: (pretty: CoinPretty) => CoinPretty;
+      res: string;
+    }[] = [
+      {
+        base: new CoinPretty(
+          {
+            coinDenom: "ATOM",
+            coinMinimalDenom: "uatom",
+            coinDecimals: 6,
+          },
+          new Int("12345600")
+        ),
+        pre: (pretty) => pretty.hideIBCMetadata(true),
+        res: "12.345600 ATOM",
+      },
+      {
+        base: new CoinPretty(
+          {
+            originCurrency: {
+              coinDenom: "ATOM",
+              coinMinimalDenom: "uatom",
+              coinDecimals: 6,
+            },
+            coinDenom: "ATOM (Cosmos Hun/channel-0)",
+            coinMinimalDenom: "ibc/aaaa",
+            coinDecimals: 6,
+          },
+          new Int("12345600")
+        ),
+        pre: (pretty) => pretty,
+        res: "12.345600 ATOM (Cosmos Hun/channel-0)",
+      },
+      {
+        base: new CoinPretty(
+          {
+            originCurrency: {
+              coinDenom: "ATOM",
+              coinMinimalDenom: "uatom",
+              coinDecimals: 6,
+            },
+            coinDenom: "ATOM (Cosmos Hun/channel-0)",
+            coinMinimalDenom: "ibc/aaaa",
+            coinDecimals: 6,
+          },
+          new Int("12345600")
+        ),
+        pre: (pretty) => pretty.hideIBCMetadata(true),
+        res: "12.345600 ATOM",
+      },
+      {
+        base: new CoinPretty(
+          {
+            originCurrency: {
+              coinDenom: "ATOM",
+              coinMinimalDenom: "uatom",
+              coinDecimals: 6,
+            },
+            coinDenom: "ATOM (Cosmos Hun/channel-0)",
+            coinMinimalDenom: "ibc/aaaa",
+            coinDecimals: 6,
+          },
+          new Int("12345600")
+        ),
+        pre: (pretty) => pretty.hideIBCMetadata(true).hideDenom(true),
+        res: "12.345600",
+      },
+    ];
+
+    for (const test of tests) {
+      expect(test.pre(test.base).toString()).toBe(test.res);
+    }
+  });
 });

--- a/packages/unit/src/coin-pretty.ts
+++ b/packages/unit/src/coin-pretty.ts
@@ -10,6 +10,7 @@ export type CoinPrettyOptions = {
   upperCase: boolean;
   lowerCase: boolean;
   hideDenom: boolean;
+  hideIBCMetadata: boolean;
 };
 
 export class CoinPretty {
@@ -20,6 +21,7 @@ export class CoinPretty {
     upperCase: false,
     lowerCase: false,
     hideDenom: false,
+    hideIBCMetadata: false,
   };
 
   constructor(
@@ -86,6 +88,12 @@ export class CoinPretty {
   hideDenom(bool: boolean): CoinPretty {
     const pretty = this.clone();
     pretty._options.hideDenom = bool;
+    return pretty;
+  }
+
+  hideIBCMetadata(bool: boolean): CoinPretty {
+    const pretty = this.clone();
+    pretty._options.hideIBCMetadata = bool;
     return pretty;
   }
 
@@ -260,6 +268,13 @@ export class CoinPretty {
 
   toString(): string {
     let denom = this.denom;
+    if (
+      this._options.hideIBCMetadata &&
+      "originCurrency" in this.currency &&
+      this.currency.originCurrency
+    ) {
+      denom = this.currency.originCurrency.coinDenom;
+    }
     if (this._options.upperCase) {
       denom = denom.toUpperCase();
     }


### PR DESCRIPTION
This will makes the breaking change to `ChainInfo`.
It was mistake to put the `gasPriceStep` field to `ChainInfo` because it is inappropriate for all fee currencies to have same gas price step.

So, move `gasPriceStep` field to each `FeeCurreny`s and each fee currency has its gas price step.

Additionally, the txfees feature on osmosis is implemented too. 

However, it is uncertain how to determined the gas price step from the fee currencies with different valuations. This is fairly hard because there is no solution in cosmos-based chain yet except for osmosis. We expect that the validators and community of each chain will figure it out on their own.