### PR TITLE
Set Umee gas-price steps

### DIFF
--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -1760,6 +1760,11 @@ export const EmbedChainInfos: ChainInfo[] = [
         coinDenom: "UMEE",
         coinMinimalDenom: "uumee",
         coinDecimals: 6,
+        gasPriceStep: {
+          low: 0.05,
+          average: 0.06,
+          high: 0.1,
+        },
       },
     ],
     features: ["ibc-transfer", "ibc-go"],

--- a/packages/mobile/src/config.ts
+++ b/packages/mobile/src/config.ts
@@ -1092,9 +1092,9 @@ export const EmbedChainInfos: AppChainInfo[] = [
         coinDecimals: 6,
         coinImageUrl: "https://dhj8dql1kzq2v.cloudfront.net/white/umee.png",
         gasPriceStep: {
-          low: 0,
-          average: 0.025,
-          high: 0.04,
+          low: 0.05,
+          average: 0.06,
+          high: 0.1,
         },
       },
     ],


### PR DESCRIPTION
Adding Umee `feeCurrencies.gasPriceStep`.

For the upcoming Umee release we are setting a consensus level minimum gas-price = 0.05uumee. So each validator has to set his minimum gas price to at least `0.05uumee`.