### PR TITLE
Implement contract query for ERC20 balance

### DIFF
--- a/packages/stores-etc/package.json
+++ b/packages/stores-etc/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@ethersproject/abi": "^5.6.0",
+    "@ethersproject/bignumber": "^5.7.0",
     "@keplr-wallet/common": "0.11.7",
     "@keplr-wallet/stores": "0.11.7",
     "@keplr-wallet/types": "0.11.7",

--- a/packages/stores-etc/src/queries.ts
+++ b/packages/stores-etc/src/queries.ts
@@ -1,7 +1,7 @@
 import { QueriesSetBase, ChainGetter } from "@keplr-wallet/stores";
 import { KVStore } from "@keplr-wallet/common";
 import { DeepReadonly } from "utility-types";
-import { ObservableQueryERC20Metadata } from "./erc20";
+import { ObservableQueryERC20ContractData } from "./erc20";
 import { ObservableQueryEVMTokenInfo } from "./axelar";
 
 export interface KeplrETCQueries {
@@ -37,7 +37,7 @@ export const KeplrETCQueries = {
 };
 
 export class KeplrETCQueriesImpl {
-  public readonly queryERC20Metadata: DeepReadonly<ObservableQueryERC20Metadata>;
+  public readonly queryERC20Metadata: DeepReadonly<ObservableQueryERC20ContractData>;
   public readonly queryEVMTokenInfo: DeepReadonly<ObservableQueryEVMTokenInfo>;
 
   constructor(
@@ -47,7 +47,7 @@ export class KeplrETCQueriesImpl {
     chainGetter: ChainGetter,
     ethereumURL: string
   ) {
-    this.queryERC20Metadata = new ObservableQueryERC20Metadata(
+    this.queryERC20Metadata = new ObservableQueryERC20ContractData(
       kvStore,
       ethereumURL
     );


### PR DESCRIPTION
Implement the ability to query for a user's balance for a given ERC20 contract. Rename "Metadata" with "ContractData" for better clarity.

This PR supports ERC-20 token capabilities as seen here: https://github.com/chainapsis/keplr-wallet/pull/523.