### PR TITLE
fix: prevent inclusion of mnemonic in memo

### DIFF
--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -33,6 +33,7 @@
     "@keplr-wallet/types": "0.11.13",
     "@keplr-wallet/unit": "0.11.13",
     "axios": "^0.27.2",
+    "bip39": "^3.0.3",
     "buffer": "^6.0.3",
     "long": "^4.0.0",
     "mobx": "^6.1.7",

--- a/packages/hooks/src/tx/memo.ts
+++ b/packages/hooks/src/tx/memo.ts
@@ -3,6 +3,7 @@ import { action, makeObservable, observable } from "mobx";
 import { ChainGetter } from "@keplr-wallet/stores";
 import { TxChainSetter } from "./chain";
 import { useState } from "react";
+import { validateMnemonic } from "bip39";
 
 export class MemoConfig extends TxChainSetter implements IMemoConfig {
   @observable
@@ -23,6 +24,10 @@ export class MemoConfig extends TxChainSetter implements IMemoConfig {
   }
 
   get error(): Error | undefined {
+    // prevent simple inclusion of a valid mnemonic in the memo field
+    if (validateMnemonic(this._memo.trim().toLowerCase())) {
+      return Error("cannot use a valid mnemonic as a memo");
+    }
     return undefined;
   }
 }


### PR DESCRIPTION
This patch prevents simple inclusion of a valid mnemonic in the memo field to prevent from accidental disclosure