### PR TITLE
Make `suggestChain` grant the permission to origin at the same time

### DIFF
--- a/packages/background/src/index.ts
+++ b/packages/background/src/index.ts
@@ -121,7 +121,11 @@ export function init(
     chainsService,
     keyRingService
   );
-  chainsService.init(chainUpdaterService, interactionService);
+  chainsService.init(
+    chainUpdaterService,
+    interactionService,
+    permissionService
+  );
   ledgerService.init(interactionService);
   keyRingService.init(
     interactionService,


### PR DESCRIPTION
For most cases, webpage suggests chain and then requests permission to keplr. There are only a few cases where permission is not required after suggest chain (such as chain list).

Therefore, in order to reduce the required interactions with the user, the permission is given to the requested origin when the suggest chain is passed.