### PR TITLE
Remove outdated dependency

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -18,7 +18,6 @@
   },
   "dependencies": {
     "axios": "^0.27.2",
-    "long": "^4.0.0",
-    "secretjs": "0.17.7"
+    "long": "^4.0.0"
   }
 }

--- a/packages/types/src/enigma-utils.ts
+++ b/packages/types/src/enigma-utils.ts
@@ -1,0 +1,37 @@
+export interface SecretUtils {
+  getPubkey: () => Promise<Uint8Array>;
+  decrypt: (ciphertext: Uint8Array, nonce: Uint8Array) => Promise<Uint8Array>;
+  encrypt: (
+    contractCodeHash: string,
+    msg: Record<string, unknown>
+  ) => Promise<Uint8Array>;
+  getTxEncryptionKey: (nonce: Uint8Array) => Promise<Uint8Array>;
+}
+
+export declare class EnigmaUtils implements SecretUtils {
+  private readonly apiUrl;
+  readonly seed: Uint8Array;
+  private readonly privkey;
+  readonly pubkey: Uint8Array;
+  private consensusIoPubKey;
+  constructor(apiUrl: string, seed?: Uint8Array);
+  static GenerateNewKeyPair(): {
+    privkey: Uint8Array;
+    pubkey: Uint8Array;
+  };
+  static GenerateNewSeed(): Uint8Array;
+  static GenerateNewKeyPairFromSeed(
+    seed: Uint8Array
+  ): {
+    privkey: Uint8Array;
+    pubkey: Uint8Array;
+  };
+  private getConsensusIoPubKey;
+  getTxEncryptionKey(nonce: Uint8Array): Promise<Uint8Array>;
+  encrypt(
+    contractCodeHash: string,
+    msg: Record<string, unknown>
+  ): Promise<Uint8Array>;
+  decrypt(ciphertext: Uint8Array, nonce: Uint8Array): Promise<Uint8Array>;
+  getPubkey(): Promise<Uint8Array>;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -6,3 +6,4 @@ export * from "./wallet";
 export * from "./window";
 export * from "./ethereum";
 export * from "./cosmjs";
+export * from "./enigma-utils";

--- a/packages/types/src/wallet/keplr.ts
+++ b/packages/types/src/wallet/keplr.ts
@@ -9,7 +9,7 @@ import {
   DirectSignResponse,
   OfflineDirectSigner,
 } from "../cosmjs";
-import { SecretUtils } from "secretjs/types/enigmautils";
+import { SecretUtils } from "../enigma-utils";
 import Long from "long";
 
 export interface Key {

--- a/packages/types/src/window.ts
+++ b/packages/types/src/window.ts
@@ -1,6 +1,6 @@
 import { Keplr } from "./wallet";
 import { OfflineAminoSigner, OfflineDirectSigner } from "./cosmjs";
-import { SecretUtils } from "secretjs/types/enigmautils";
+import { SecretUtils } from "./enigma-utils";
 
 export interface Window {
   keplr?: Keplr;


### PR DESCRIPTION
The purpose of this PR is to fix a Dependabot alert, which has been around for almost half a year. 

> axios Inefficient Regular Expression Complexity vulnerability 

This `High` level vulnerability exists in the `secretjs` dependency. 
Newer versions of `secretjs` have resolved this issue, but they do not include the relevant TypeScript interfaces. 

Since `secretjs` dropped these interfaces and since these interfaces are the only reason to include this dependency, it makes sense to remove the dependency altogether. 

There are a few more `@keplr-wallet` packages which rely on these newly added `secretjs` interfaces. 
Once the types package has been updated, the other packages can remove `secretjs` and update the import path.

This change will resolve `High` level security vulnerability in many repositories. 
This topic has also been discussed, #539.