### PR TITLE
[Extension] Add `window.keplr.changeKeyRingName` API

### DIFF
--- a/packages/background/src/keyring/handler.ts
+++ b/packages/background/src/keyring/handler.ts
@@ -446,15 +446,21 @@ const handleInitNonDefaultLedgerAppMsg: (
   };
 };
 
-// FIXME : add index in msg
-// InternalHandler<UpdateNameKeyRingMsg>
 const handleChangeKeyNameMsg: (
   service: KeyRingService
 ) => InternalHandler<ChangeKeyRingNameMsg> = (service) => {
   return async (env, msg) => {
+    let index = 0;
+    service.getMultiKeyStoreInfo().forEach(({ selected }, idx) => {
+      if (selected) {
+        index = idx;
+      }
+    });
+
     return await service.changeKeyRingName(env, {
       defaultName: msg.defaultName,
       editable: msg.editable,
+      index,
     });
   };
 };

--- a/packages/background/src/keyring/handler.ts
+++ b/packages/background/src/keyring/handler.ts
@@ -30,6 +30,7 @@ import {
   RequestVerifyADR36AminoSignDoc,
   RequestSignEIP712CosmosTxMsg_v0,
   InitNonDefaultLedgerAppMsg,
+  ChangeKeyRingNameMsg,
 } from "./messages";
 import { KeyRingService } from "./service";
 import { Bech32Address } from "@keplr-wallet/cosmos";
@@ -126,6 +127,11 @@ export const getHandler: (service: KeyRingService) => Handler = (
         return handleInitNonDefaultLedgerAppMsg(service)(
           env,
           msg as InitNonDefaultLedgerAppMsg
+        );
+      case ChangeKeyRingNameMsg:
+        return handleChangeKeyNameMsg(service)(
+          env,
+          msg as ChangeKeyRingNameMsg
         );
       default:
         throw new KeplrError("keyring", 221, "Unknown msg type");
@@ -437,5 +443,18 @@ const handleInitNonDefaultLedgerAppMsg: (
 ) => InternalHandler<InitNonDefaultLedgerAppMsg> = (service) => {
   return async (env, msg) => {
     await service.initializeNonDefaultLedgerApp(env, msg.ledgerApp);
+  };
+};
+
+// FIXME : add index in msg
+// InternalHandler<UpdateNameKeyRingMsg>
+const handleChangeKeyNameMsg: (
+  service: KeyRingService
+) => InternalHandler<ChangeKeyRingNameMsg> = (service) => {
+  return async (env, msg) => {
+    return await service.changeKeyRingName(env, {
+      defaultName: msg.defaultName,
+      editable: msg.editable,
+    });
   };
 };

--- a/packages/background/src/keyring/handler.ts
+++ b/packages/background/src/keyring/handler.ts
@@ -450,12 +450,16 @@ const handleChangeKeyNameMsg: (
   service: KeyRingService
 ) => InternalHandler<ChangeKeyRingNameMsg> = (service) => {
   return async (env, msg) => {
-    let index = 0;
+    let index = -1;
     service.getMultiKeyStoreInfo().forEach(({ selected }, idx) => {
       if (selected) {
         index = idx;
       }
     });
+
+    if (index === -1) {
+      throw new Error("No account selected");
+    }
 
     return await service.changeKeyRingName(env, {
       defaultName: msg.defaultName,

--- a/packages/background/src/keyring/init.ts
+++ b/packages/background/src/keyring/init.ts
@@ -24,6 +24,7 @@ import {
   RequestVerifyADR36AminoSignDoc,
   RequestSignEIP712CosmosTxMsg_v0,
   InitNonDefaultLedgerAppMsg,
+  ChangeKeyRingNameMsg,
 } from "./messages";
 import { ROUTE } from "./constants";
 import { getHandler } from "./handler";
@@ -54,6 +55,7 @@ export function init(router: Router, service: KeyRingService): void {
   router.registerMessage(ExportKeyRingDatasMsg);
   router.registerMessage(RequestSignEIP712CosmosTxMsg_v0);
   router.registerMessage(InitNonDefaultLedgerAppMsg);
+  router.registerMessage(ChangeKeyRingNameMsg);
 
   router.addHandler(ROUTE, getHandler(service));
 }

--- a/packages/background/src/keyring/messages.ts
+++ b/packages/background/src/keyring/messages.ts
@@ -964,3 +964,35 @@ export class InitNonDefaultLedgerAppMsg extends Message<void> {
     return InitNonDefaultLedgerAppMsg.type();
   }
 }
+
+export class ChangeKeyRingNameMsg extends Message<string> {
+  public static type() {
+    return "change-keyring-name-msg";
+  }
+
+  constructor(
+    public readonly defaultName: string,
+    public readonly editable: boolean
+  ) {
+    super();
+  }
+
+  validateBasic(): void {
+    // Not allow empty name.
+    if (!this.defaultName) {
+      throw new Error("default name not set");
+    }
+  }
+
+  approveExternal(): boolean {
+    return true;
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return ChangeKeyRingNameMsg.type();
+  }
+}

--- a/packages/background/src/keyring/service.ts
+++ b/packages/background/src/keyring/service.ts
@@ -726,14 +726,17 @@ export class KeyRingService {
     return await this.keyRing.initializeNonDefaultLedgerApp(env, ledgerApp);
   }
 
-  // FIXME : get index
   async changeKeyRingName(
     env: Env,
-    { defaultName, editable }: { defaultName: string; editable: boolean }
+    {
+      defaultName,
+      editable,
+      index,
+    }: { defaultName: string; editable: boolean; index: number }
   ) {
     return (await this.interactionService.waitApprove(
       env,
-      "/setting/keyring/change/name/0",
+      `/setting/keyring/change/name/${index}`,
       "change-keyring-name",
       { defaultName, editable }
     )) as string;

--- a/packages/background/src/keyring/service.ts
+++ b/packages/background/src/keyring/service.ts
@@ -725,4 +725,17 @@ export class KeyRingService {
   async initializeNonDefaultLedgerApp(env: Env, ledgerApp: LedgerApp) {
     return await this.keyRing.initializeNonDefaultLedgerApp(env, ledgerApp);
   }
+
+  // FIXME : get index
+  async changeKeyRingName(
+    env: Env,
+    { defaultName, editable }: { defaultName: string; editable: boolean }
+  ) {
+    return (await this.interactionService.waitApprove(
+      env,
+      "/setting/keyring/change/name/0",
+      "change-keyring-name",
+      { defaultName, editable }
+    )) as string;
+  }
 }

--- a/packages/provider-mock/src/mock.ts
+++ b/packages/provider-mock/src/mock.ts
@@ -264,4 +264,11 @@ export class MockKeplr implements Keplr {
   ): Promise<AminoSignResponse> {
     throw new Error("Not yet implemented");
   }
+
+  changeKeyRingName(_opts: {
+    defaultName: string;
+    editable?: boolean | undefined;
+  }): Promise<string> {
+    throw new Error("Not yet implemented");
+  }
 }

--- a/packages/provider/src/core.ts
+++ b/packages/provider/src/core.ts
@@ -32,6 +32,7 @@ import {
   RequestVerifyADR36AminoSignDoc,
   RequestSignEIP712CosmosTxMsg_v0,
   GetAnalyticsIdMsg,
+  ChangeKeyRingNameMsg,
 } from "./types";
 import { SecretUtils } from "secretjs/types/enigmautils";
 
@@ -368,5 +369,17 @@ export class Keplr implements IKeplr, KeplrCoreTypes {
   __core__getAnalyticsId(): Promise<string> {
     const msg = new GetAnalyticsIdMsg();
     return this.requester.sendMessage(BACKGROUND_PORT, msg);
+  }
+
+  async changeKeyRingName({
+    defaultName,
+    editable = true,
+  }: {
+    defaultName: string;
+    editable?: boolean;
+  }): Promise<string> {
+    const msg = new ChangeKeyRingNameMsg(defaultName, editable);
+
+    return await this.requester.sendMessage(BACKGROUND_PORT, msg);
   }
 }

--- a/packages/provider/src/inject.ts
+++ b/packages/provider/src/inject.ts
@@ -571,4 +571,16 @@ export class InjectedKeplr implements IKeplr, KeplrCoreTypes {
   __core__getAnalyticsId(): Promise<string> {
     return this.requestMethod("__core__getAnalyticsId", []);
   }
+
+  async changeKeyRingName({
+    defaultName,
+    editable = true,
+  }: {
+    defaultName: string;
+    editable?: boolean;
+  }): Promise<string> {
+    return await this.requestMethod("changeKeyRingName", [
+      { defaultName, editable },
+    ]);
+  }
 }

--- a/packages/provider/src/types/msgs.ts
+++ b/packages/provider/src/types/msgs.ts
@@ -571,3 +571,31 @@ export class GetAnalyticsIdMsg extends Message<string> {
     return GetAnalyticsIdMsg.type();
   }
 }
+
+export class ChangeKeyRingNameMsg extends Message<string> {
+  public static type() {
+    return "change-keyring-name-msg";
+  }
+
+  constructor(
+    public readonly defaultName: string,
+    public readonly editable: boolean
+  ) {
+    super();
+  }
+
+  validateBasic(): void {
+    // Not allow empty name.
+    if (!this.defaultName) {
+      throw new Error("default name not set");
+    }
+  }
+
+  route(): string {
+    return "keyring";
+  }
+
+  type(): string {
+    return ChangeKeyRingNameMsg.type();
+  }
+}

--- a/packages/stores/src/core/keyring.ts
+++ b/packages/stores/src/core/keyring.ts
@@ -148,6 +148,18 @@ export class KeyRingStore {
     this.restore();
   }
 
+  get waitingNameData() {
+    const data = this.interactionStore.getDatas<{
+      defaultName: string;
+      editable: boolean;
+      isExternal: boolean;
+    }>("change-keyring-name");
+
+    if (data.length > 0) {
+      return data[0];
+    }
+  }
+
   @computed
   get keyRingType(): string {
     const keyStore = this.multiKeyStoreInfo.find(
@@ -159,6 +171,20 @@ export class KeyRingStore {
     } else {
       return KeyRing.getTypeOfKeyStore(keyStore);
     }
+  }
+
+  @flow
+  *approveChangeName(changedName: string) {
+    const data = this.interactionStore.getDatas("change-keyring-name")[0];
+
+    yield this.interactionStore.approve(
+      "change-keyring-name",
+      data.id,
+      changedName
+    );
+
+    this.dispatchKeyStoreChangeEvent();
+    this.selectablesMap.forEach((selectables) => selectables.refresh());
   }
 
   @flow

--- a/packages/types/src/wallet/keplr.ts
+++ b/packages/types/src/wallet/keplr.ts
@@ -160,4 +160,10 @@ export interface Keplr {
     signDoc: StdSignDoc,
     signOptions?: KeplrSignOptions
   ): Promise<AminoSignResponse>;
+
+  /** Change wallet extension user name **/
+  changeKeyRingName(opts: {
+    defaultName: string;
+    editable?: boolean;
+  }): Promise<string>;
 }

--- a/packages/wc-client/src/index.ts
+++ b/packages/wc-client/src/index.ts
@@ -497,7 +497,6 @@ export class KeplrWalletConnectV1 implements Keplr {
     throw new Error("Not yet implemented");
   }
 
-  // FIXME : ask @Heesung
   changeKeyRingName(_opts: {
     defaultName: string;
     editable?: boolean | undefined;

--- a/packages/wc-client/src/index.ts
+++ b/packages/wc-client/src/index.ts
@@ -496,4 +496,12 @@ export class KeplrWalletConnectV1 implements Keplr {
   ): Promise<AminoSignResponse> {
     throw new Error("Not yet implemented");
   }
+
+  // FIXME : ask @Heesung
+  changeKeyRingName(_opts: {
+    defaultName: string;
+    editable?: boolean | undefined;
+  }): Promise<string> {
+    throw new Error("Not yet implemented");
+  }
 }


### PR DESCRIPTION
- Provide `window.keplr.changeKeyRingName` method for the web app.

TODO 
--- 
1. Prevent flick when the extension popup opens. -> `unlock` popup has the same issue
2. Support to `wc-client` Keplr instance?

