### PR TITLE
fix: add coinGeckoId for IST

### DIFF
--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -1194,6 +1194,7 @@ export const EmbedChainInfos: ChainInfo[] = [
         coinDenom: "IST",
         coinMinimalDenom: "uist",
         coinDecimals: 6,
+        coinGeckoId: "inter-stable-token",
       },
     ],
     feeCurrencies: [
@@ -1212,6 +1213,7 @@ export const EmbedChainInfos: ChainInfo[] = [
         coinDenom: "IST",
         coinMinimalDenom: "uist",
         coinDecimals: 6,
+        coinGeckoId: "inter-stable-token",
         gasPriceStep: {
           low: 0.0034,
           average: 0.007,

--- a/packages/mobile/src/config.ts
+++ b/packages/mobile/src/config.ts
@@ -1136,6 +1136,7 @@ export const EmbedChainInfos: AppChainInfo[] = [
         coinDenom: "IST",
         coinMinimalDenom: "uist",
         coinDecimals: 6,
+        coinGeckoId: "inter-stable-token",
       },
     ],
     feeCurrencies: [
@@ -1154,6 +1155,7 @@ export const EmbedChainInfos: AppChainInfo[] = [
         coinDenom: "IST",
         coinMinimalDenom: "uist",
         coinDecimals: 6,
+        coinGeckoId: "inter-stable-token",
         gasPriceStep: {
           low: 0.0034,
           average: 0.007,


### PR DESCRIPTION
- adds `coinGeckoId` for IST token.

Will this ensure the token shows up under `💰 Available Balance` on the wallet dashboard?