### PR TITLE
Change `disable()` API interface

### DIFF
--- a/packages/background/src/permission/handler.ts
+++ b/packages/background/src/permission/handler.ts
@@ -78,11 +78,7 @@ const handleDisableAccessMsg: (
   service: PermissionService
 ) => InternalHandler<EnableAccessMsg> = (service) => {
   return async (env, msg) => {
-    return await service.removeBasicAccessPermission(
-      env,
-      msg.chainIds,
-      msg.origin
-    );
+    return await service.disable(env, msg.chainIds, msg.origin);
   };
 };
 

--- a/packages/background/src/permission/messages.ts
+++ b/packages/background/src/permission/messages.ts
@@ -39,7 +39,7 @@ export class DisableAccessMsg extends Message<void> {
   }
 
   validateBasic(): void {
-    if (!this.chainIds || this.chainIds.length === 0) {
+    if (!this.chainIds) {
       throw new KeplrError("permission", 100, "chain id not set");
     }
   }

--- a/packages/background/src/permission/service.ts
+++ b/packages/background/src/permission/service.ts
@@ -92,29 +92,24 @@ export class PermissionService {
     await this.checkBasicAccessPermission(env, chainIds, origin);
   }
 
-  async removeBasicAccessPermission(
-    env: Env,
-    chainIds: string | string[],
-    origin: string
-  ) {
+  async disable(env: Env, chainIds: string | string[], origin: string) {
+    // Delete permissions granted to origin.
+    // If chain ids are specified, only the permissions granted to each chain id are deleted (In this case, permissions such as getChainInfosWithoutEndpoints() are not deleted).
+    // Else, remove all permissions granted to origin (In this case, permissions that are not assigned to each chain, such as getChainInfosWithoutEndpoints(), are also deleted).
+
     await this.keyRingService.enable(env);
 
     if (typeof chainIds === "string") {
       chainIds = [chainIds];
     }
 
-    for (const chainId of chainIds) {
-      const hasPermission = this.hasPermisson(
-        chainId,
-        getBasicAccessPermissionType(),
-        origin
-      );
-
-      if (hasPermission) {
-        await this.removePermission(chainId, getBasicAccessPermissionType(), [
-          origin,
-        ]);
+    if (chainIds.length > 0) {
+      for (const chainId of chainIds) {
+        await this.removeAllTypePermissionToChainId(chainId, [origin]);
       }
+    } else {
+      await this.removeAllTypePermission([origin]);
+      await this.removeAllTypeGlobalPermission([origin]);
     }
   }
 
@@ -415,6 +410,50 @@ export class PermissionService {
     await this.save();
   }
 
+  async removeAllTypePermission(origins: string[]) {
+    for (const identifier of Object.keys(this.permissionMap)) {
+      const permissionsInChain = this.permissionMap[identifier];
+      if (!permissionsInChain) {
+        return;
+      }
+
+      for (const type of Object.keys(permissionsInChain)) {
+        const innerMap = permissionsInChain[type];
+        if (!innerMap) {
+          return;
+        }
+
+        for (const origin of origins) {
+          delete innerMap[origin];
+        }
+      }
+    }
+
+    await this.save();
+  }
+
+  async removeAllTypePermissionToChainId(chainId: string, origins: string[]) {
+    const permissionsInChain = this.permissionMap[
+      ChainIdHelper.parse(chainId).identifier
+    ];
+    if (!permissionsInChain) {
+      return;
+    }
+
+    for (const type of Object.keys(permissionsInChain)) {
+      const innerMap = permissionsInChain[type];
+      if (!innerMap) {
+        return;
+      }
+
+      for (const origin of origins) {
+        delete innerMap[origin];
+      }
+    }
+
+    await this.save();
+  }
+
   async removeGlobalPermission(type: string, origins: string[]) {
     const originMap = {
       ...this.globalPermissionMap[type],
@@ -425,6 +464,22 @@ export class PermissionService {
     }
 
     this.globalPermissionMap[type] = originMap;
+
+    await this.save();
+  }
+
+  async removeAllTypeGlobalPermission(origins: string[]) {
+    for (const type of Object.keys(this.globalPermissionMap)) {
+      const originMap = {
+        ...this.globalPermissionMap[type],
+      };
+
+      for (const origin of origins) {
+        delete originMap[origin];
+      }
+
+      this.globalPermissionMap[type] = originMap;
+    }
 
     await this.save();
   }

--- a/packages/provider-mock/src/mock.ts
+++ b/packages/provider-mock/src/mock.ts
@@ -281,7 +281,7 @@ export class MockKeplr implements Keplr {
     throw new Error("Not yet implemented");
   }
 
-  disable(_chainIds: string | string[]): Promise<void> {
+  disable(_chainIds?: string | string[]): Promise<void> {
     throw new Error("Not yet implemented");
   }
 }

--- a/packages/provider/src/core.ts
+++ b/packages/provider/src/core.ts
@@ -70,14 +70,14 @@ export class Keplr implements IKeplr, KeplrCoreTypes {
     );
   }
 
-  async disable(chainIds: string | string[]): Promise<void> {
+  async disable(chainIds?: string | string[]): Promise<void> {
     if (typeof chainIds === "string") {
       chainIds = [chainIds];
     }
 
     await this.requester.sendMessage(
       BACKGROUND_PORT,
-      new DisableAccessMsg(chainIds)
+      new DisableAccessMsg(chainIds ?? [])
     );
   }
 

--- a/packages/provider/src/inject.ts
+++ b/packages/provider/src/inject.ts
@@ -332,7 +332,7 @@ export class InjectedKeplr implements IKeplr, KeplrCoreTypes {
     await this.requestMethod("enable", [chainIds]);
   }
 
-  async disable(chainIds: string | string[]): Promise<void> {
+  async disable(chainIds?: string | string[]): Promise<void> {
     await this.requestMethod("disable", [chainIds]);
   }
 

--- a/packages/provider/src/types/msgs.ts
+++ b/packages/provider/src/types/msgs.ts
@@ -44,7 +44,7 @@ export class DisableAccessMsg extends Message<void> {
   }
 
   validateBasic(): void {
-    if (!this.chainIds || this.chainIds.length === 0) {
+    if (!this.chainIds) {
       throw new Error("chain id not set");
     }
   }

--- a/packages/types/src/wallet/keplr.ts
+++ b/packages/types/src/wallet/keplr.ts
@@ -61,9 +61,13 @@ export interface Keplr {
   experimentalSuggestChain(chainInfo: ChainInfo): Promise<void>;
   enable(chainIds: string | string[]): Promise<void>;
   /**
+   * Delete permissions granted to origin.
+   * If chain ids are specified, only the permissions granted to each chain id are deleted (In this case, permissions such as getChainInfosWithoutEndpoints() are not deleted).
+   * Else, remove all permissions granted to origin (In this case, permissions that are not assigned to each chain, such as getChainInfosWithoutEndpoints(), are also deleted).
+   *
    * @param chainIds disable(Remove approve domain(s)) target chain ID(s).
    */
-  disable(chainIds: string | string[]): Promise<void>;
+  disable(chainIds?: string | string[]): Promise<void>;
 
   getKey(chainId: string): Promise<Key>;
   signAmino(

--- a/packages/wc-client/src/index.ts
+++ b/packages/wc-client/src/index.ts
@@ -513,7 +513,7 @@ export class KeplrWalletConnectV1 implements Keplr {
     throw new Error("Not yet implemented");
   }
 
-  disable(_chainIds: string | string[]): Promise<void> {
+  disable(_chainIds?: string | string[]): Promise<void> {
     throw new Error("Not yet implemented");
   }
 }


### PR DESCRIPTION
@dongwu-kim 

When the #591 PR was proposed, there was no `getChainInfosWithoutEndpoints()` API.
The problem is that in the case of the `getChainInfosWithoutEndpoints()` API, the global permission is used, not the per-chain permission. However, the old interface is ambiguous to handle such permission because we have to specify the chain id.

To solve this problem, we slightly modify the `disable()` API interface. If chain ids are specified, only the permission of a specific chain is deleted. If undefined or an empty array, all permissions associated with the origin are removed.