### PR TITLE
Restore EIP712 chain-id validation

### DIFF
--- a/packages/background/src/keyring/messages.ts
+++ b/packages/background/src/keyring/messages.ts
@@ -628,7 +628,7 @@ export class RequestSignEIP712CosmosTxMsg_v0 extends Message<AminoSignResponse> 
       const { ethChainId } = EthermintChainIdHelper.parse(this.chainId);
 
       if (
-        this.eip712.domain.chainId !== ethChainId.toString() &&
+        parseFloat(this.eip712.domain.chainId) !== ethChainId &&
         this.eip712.domain.chainId !== "0x" + ethChainId.toString(16)
       ) {
         throw new Error(


### PR DESCRIPTION
According to the EIP712Domain types, chainId is uint256 type.

Current error when sending chainid as a number:
```
Unmatched chain id for eth (expected: 9001, actual: 9001).
```

was introduced in this commit:
https://github.com/chainapsis/keplr-wallet/commit/ddce66dad4f1b38c76737e97789d370ed538b9ad#diff-8789aac8a9eb58a5f509150ec8f61ea42af532bb6be52998eaa83f1b3b031a39