### PR TITLE
Allow numeric value as input for IBC channel-id

### DIFF
--- a/packages/extension/src/components/form/ibc/channel-registrar.tsx
+++ b/packages/extension/src/components/form/ibc/channel-registrar.tsx
@@ -98,7 +98,10 @@ export const IBCChannelRegistrarModal: FunctionComponent<{
             })}
             onChange={(e) => {
               e.preventDefault();
-              setChannelId(e.target.value);
+              const field = e.target.value;
+              setChannelId(
+                isNaN(parseFloat(field)) ? field : `channel-${field}`
+              );
               setError("");
             }}
             error={error}


### PR DESCRIPTION
This PR improves the user experience when adding a new IBC connection. Users may find it intuitive to enter simply the channel-id number—rather than the entire string—and this change allows users to do so, while still accepting the previous method.

Since channel IDs are automatically derived in the form `channel-{N}` according to how many channels were previously present, we can prefix any numeric input with `channel-` to properly format it.

Docs: https://ibc.cosmos.network/main/ibc/overview.html

https://user-images.githubusercontent.com/11379797/210451931-5571f9a9-9e78-43f8-9c54-de7fbb7afc24.mov
https://user-images.githubusercontent.com/11379797/210451940-e19585df-0d9d-4a66-bd6d-cd17d0c39412.mov
