### PR TITLE
changes to add qSTARS to quicksilver currencies

### DIFF
--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -1987,6 +1987,11 @@ export const EmbedChainInfos: ChainInfo[] = [
         coinMinimalDenom: "uqck",
         coinDecimals: 6,
       },
+      {
+        coinDenom: "qSTARS",
+        coinMinimalDenom: "uqstars",
+        coinDecimals: 6,
+    },
     ],
     feeCurrencies: [
       {


### PR DESCRIPTION
The quicksilver team is onboarding Stargaze zone this week. This PR adds qSTARS to the quicksilver currencies array to display users' qSTARS balance in the extension.