### PR TITLE
Add `approxRoot()` to `Dec`

### DIFF
--- a/packages/unit/src/decimal.spec.ts
+++ b/packages/unit/src/decimal.spec.ts
@@ -198,6 +198,32 @@ describe("Test decimals", () => {
     }
   });
 
+  // from: https://github.com/osmosis-labs/cosmos-sdk/blob/5b0f9cfa4331ad3c64d9690318e4621b569b9a50/types/decimal_test.go#L372
+  it("Test Dec approxRoot", () => {
+    const tests: { d: Dec; r: number; res: Dec }[] = [
+      { d: new Dec(1), r: 10, res: new Dec(1) }, // 1.0 ^ (0.1) => 1.0
+      { d: new Dec(25, 2), r: 2, res: new Dec(5, 1) }, // 0.25 ^ (0.5) => 0.5,
+      { d: new Dec(4, 2), r: 2, res: new Dec(2, 1) }, // 0.04 ^ (0.5) => 0.2
+      { d: new Dec(27), r: 3, res: new Dec(3) }, // 27 ^ (1/3) => 3
+      { d: new Dec(-81), r: 4, res: new Dec(-3) }, // -81 ^ (0.25) => -3
+      { d: new Dec(2), r: 2, res: new Dec("1414213562373095049", 18) }, // 2 ^ (0.5) => 1.414213562373095049
+      {
+        d: new Dec(1005, 3),
+        r: 31536000,
+        res: new Dec("1.000000000158153904"),
+      }, // 1.005 ^ (1/31536000) ≈ 1.00000000016
+      { d: Dec.smallestDec, r: 2, res: new Dec(1, 9) }, // 1e-18 ^ (0.5) => 1e-9
+      { d: Dec.smallestDec, r: 3, res: new Dec("0.000000999999999997") }, // 1e-18 ^ (1/3) => 1e-6
+      { d: new Dec(1, 8), r: 3, res: new Dec("0.002154434690031900") }, // 1e-8 ^ (1/3) ≈ 0.00215443469
+    ];
+
+    for (const test of tests) {
+      const res = test.d.approxRoot(test.r);
+
+      expect(res.toString()).toBe(test.res.toString());
+    }
+  });
+
   it("dec should be caculated properly", () => {
     const tests: {
       d1: Dec;

--- a/packages/unit/src/decimal.ts
+++ b/packages/unit/src/decimal.ts
@@ -19,9 +19,14 @@ export class Dec {
     "133499189745056880149688856635597007162669032647290798121690100488888732861290034376435130433535"
   );
 
-  protected static readonly precisionMultipliers: {
-    [key: string]: bigInteger.BigInteger | undefined;
-  } = {};
+  static readonly zero = new Dec(0);
+  /** Smallest `Dec` with current precision. */
+  static readonly smallestDec = new Dec("1", Dec.precision);
+  static readonly one = new Dec(1);
+
+  protected static precisionMultipliers:
+    | Map<string, bigInteger.BigInteger>
+    | undefined;
   protected static calcPrecisionMultiplier(
     prec: number
   ): bigInteger.BigInteger {
@@ -31,14 +36,19 @@ export class Dec {
     if (prec > Dec.precision) {
       throw new Error("Too much precision");
     }
-    if (Dec.precisionMultipliers[prec.toString()]) {
+    const key = prec.toString();
+    if (!Dec.precisionMultipliers) {
+      Dec.precisionMultipliers = new Map();
+    }
+    const cached = Dec.precisionMultipliers.get(key);
+    if (cached) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      return Dec.precisionMultipliers[prec.toString()]!;
+      return cached;
     }
 
     const zerosToAdd = Dec.precision - prec;
     const multiplier = bigInteger(10).pow(zerosToAdd);
-    Dec.precisionMultipliers[prec.toString()] = multiplier;
+    Dec.precisionMultipliers.set(key, multiplier);
     return multiplier;
   }
 
@@ -211,6 +221,39 @@ export class Dec {
     }
 
     return base.mul(tmp);
+  }
+
+  public approxSqrt(): Dec {
+    return this.approxRoot(2);
+  }
+
+  public approxRoot(root: number, maxIters = 300): Dec {
+    if (this.isNegative()) {
+      return this.neg().approxRoot(root).neg();
+    }
+
+    if (root === 1 || this.isZero() || this.equals(Dec.one)) {
+      return this;
+    }
+
+    if (root === 0) {
+      return Dec.one;
+    }
+
+    let [guess, delta] = [Dec.one, Dec.one];
+    for (let i = 0; delta.abs().gt(Dec.smallestDec) && i < maxIters; i++) {
+      let prev = guess.pow(new Int(root - 1));
+      if (prev.isZero()) {
+        prev = Dec.smallestDec;
+      }
+      delta = this.quo(prev);
+      delta = delta.sub(guess);
+      delta = delta.quoTruncate(new Dec(root));
+
+      guess = guess.add(delta);
+    }
+
+    return guess;
   }
 
   public mul(d2: Dec): Dec {


### PR DESCRIPTION
### Changes
* Add `approxRoot(..)` to Dec. Inspired by Cosmos SDK [Decimal](https://github.com/osmosis-labs/cosmos-sdk/blob/5b0f9cfa4331ad3c64d9690318e4621b569b9a50/types/decimal.go#L419). Useful for calculating square root prices for concentrated liquidity simulations.
* Add convenience static members: `Dec.smallestDec`, `Dec.one`, `Dec.zero`. (Inspired by Apple's core graphics primitives)

### Testing

From packages/unit, run `yarn test decimal` to confirm correctness.