### PR TITLE
[Extension] Fix viewing key bug

### DIFF
--- a/packages/extension/src/pages/setting/token/add/index.tsx
+++ b/packages/extension/src/pages/setting/token/add/index.tsx
@@ -81,16 +81,16 @@ export const AddTokenPage: FunctionComponent = observer(() => {
 
   const queryContractInfo = (() => {
     switch (tokenType) {
-      case "cosmwasm":
-        return queries.cosmwasm.querycw20ContractInfo.getQueryContract(
-          contractAddress
-        );
       case "secretwasm":
         return queries.secret.querySecret20ContractInfo.getQueryContract(
           contractAddress
         );
       case "erc20":
         return queries.erc20.queryERC20ContractInfo.getQueryContract(
+          contractAddress
+        );
+      default:
+        return queries.cosmwasm.querycw20ContractInfo.getQueryContract(
           contractAddress
         );
     }


### PR DESCRIPTION
It is original source.
If It is not `secret-20`, It will be `cosmwasm` contract information.

```
const query = isSecret20
    ? queries.secret.querySecret20ContractInfo
    : queries.cosmwasm.querycw20ContractInfo;
  const queryContractInfo = query.getQueryContract(contractAddress);
  ```

This source has bug.
Because If `tokenType` is undefined, It will be `cosmwasm` contract information.
  ```
  const queryContractInfo = (() => {
    switch (tokenType) {
      case "cosmwasm":
        return queries.cosmwasm.querycw20ContractInfo.getQueryContract(
          contractAddress
        );
      case "secretwasm":
        return queries.secret.querySecret20ContractInfo.getQueryContract(
          contractAddress
        );
      case "erc20":
        return queries.erc20.queryERC20ContractInfo.getQueryContract(
          contractAddress
        );
    }
  })();
```