### PR TITLE
Escape serialized Amino sign doc

### DIFF
--- a/packages/cosmos/src/signing/encode.ts
+++ b/packages/cosmos/src/signing/encode.ts
@@ -1,6 +1,6 @@
 import { PubKey, StdSignature, StdSignDoc } from "@keplr-wallet/types";
 import { Buffer } from "buffer/";
-import { sortedJsonByKeyStringify } from "@keplr-wallet/common";
+import { escapeHTML, sortedJsonByKeyStringify } from "@keplr-wallet/common";
 
 export function encodeSecp256k1Pubkey(pubkey: Uint8Array): PubKey {
   if (pubkey.length !== 33 || (pubkey[0] !== 0x02 && pubkey[0] !== 0x03)) {
@@ -31,5 +31,5 @@ export function encodeSecp256k1Signature(
 }
 
 export function serializeSignDoc(signDoc: StdSignDoc): Uint8Array {
-  return Buffer.from(sortedJsonByKeyStringify(signDoc));
+  return Buffer.from(escapeHTML(sortedJsonByKeyStringify(signDoc)));
 }


### PR DESCRIPTION
#454 fixed certain character escaping that was causing problems when the memo field contained `&`, `<`, or `>`. Unfortunately, this is still an issue when these characters are included in message content (such as in a wasm execute message field) when in Amino signing contexts.

This was recently fixed in `@cosmjs/amino` in https://github.com/cosmos/cosmjs/pull/1388.

This PR fixes that here as well, properly escaping the stringified Amino sign doc.