### PR TITLE
Add "algo" parameter to adr36 functions to handle "ethsecp256k1"

### DIFF
--- a/packages/background/src/keyring/service.ts
+++ b/packages/background/src/keyring/service.ts
@@ -842,7 +842,8 @@ Salt: ${salt}`;
       bech32Prefix,
       signDoc,
       Buffer.from(signature.pub_key.value, "base64"),
-      Buffer.from(signature.signature, "base64")
+      Buffer.from(signature.signature, "base64"),
+      ethereumKeyFeatures.address ? "ethsecp256k1" : "secp256k1"
     );
   }
 

--- a/packages/cosmos/src/adr-36/amino.spec.ts
+++ b/packages/cosmos/src/adr-36/amino.spec.ts
@@ -5,7 +5,7 @@ import {
   verifyADR36AminoSignDoc,
 } from "./amino";
 import { serializeSignDoc } from "../signing";
-import { PrivKeySecp256k1 } from "@keplr-wallet/crypto";
+import { Hash, PrivKeySecp256k1 } from "@keplr-wallet/crypto";
 import { Bech32Address } from "../bech32";
 
 describe("Test ADR-36 Amino Sign Doc", () => {
@@ -578,6 +578,84 @@ describe("Test ADR-36 Amino Sign Doc", () => {
         new Uint8Array([1, 2]),
         pubKey.toBytes(),
         signature
+      )
+    ).toBe(false);
+  });
+
+  it("Verify ADR-36 Amino sign doc with ethsecp256k1", () => {
+    const privKey = PrivKeySecp256k1.generateRandomKey();
+    const pubKey = privKey.getPubKey();
+    const signer = new Bech32Address(pubKey.getEthAddress()).toBech32("eth");
+
+    const signDoc = makeADR36AminoSignDoc(signer, new Uint8Array([1, 2, 3]));
+
+    const msg = serializeSignDoc(signDoc);
+
+    const signature = privKey.signDigest32(Hash.keccak256(msg));
+
+    expect(
+      verifyADR36AminoSignDoc(
+        "eth",
+        signDoc,
+        pubKey.toBytes(),
+        signature,
+        "ethsecp256k1"
+      )
+    ).toBe(true);
+
+    expect(
+      verifyADR36Amino(
+        "eth",
+        signer,
+        new Uint8Array([1, 2, 3]),
+        pubKey.toBytes(),
+        signature,
+        "ethsecp256k1"
+      )
+    ).toBe(true);
+
+    expect(() =>
+      verifyADR36Amino(
+        "eth",
+        // Unmatched signer
+        new Bech32Address(pubKey.getAddress()).toBech32("eth"),
+        new Uint8Array([1, 2, 3]),
+        pubKey.toBytes(),
+        signature,
+        "ethsecp256k1"
+      )
+    ).toThrow();
+
+    expect(() =>
+      verifyADR36Amino(
+        "eth",
+        // Invalid signer
+        "invalid1ymk637a7wljvt4w7q9lnrw95mg9sr37yatxd9h",
+        new Uint8Array([1, 2, 3]),
+        pubKey.toBytes(),
+        signature,
+        "ethsecp256k1"
+      )
+    ).toThrow();
+
+    expect(
+      verifyADR36AminoSignDoc(
+        "eth",
+        signDoc,
+        pubKey.toBytes(),
+        signature.slice().map((b) => (Math.random() > 0.5 ? 0 : b)),
+        "ethsecp256k1"
+      )
+    ).toBe(false);
+
+    expect(
+      verifyADR36Amino(
+        "eth",
+        signer,
+        new Uint8Array([1, 2]),
+        pubKey.toBytes(),
+        signature,
+        "ethsecp256k1"
       )
     ).toBe(false);
   });

--- a/packages/cosmos/src/adr-36/amino.ts
+++ b/packages/cosmos/src/adr-36/amino.ts
@@ -2,7 +2,7 @@ import { StdSignDoc } from "@keplr-wallet/types";
 import { serializeSignDoc } from "../signing";
 import { Bech32Address } from "../bech32";
 import { Buffer } from "buffer/";
-import { PubKeySecp256k1 } from "@keplr-wallet/crypto";
+import { Hash, PubKeySecp256k1 } from "@keplr-wallet/crypto";
 
 /**
  * Check the sign doc is for ADR-36.
@@ -120,16 +120,24 @@ export function verifyADR36AminoSignDoc(
   bech32PrefixAccAddr: string,
   signDoc: StdSignDoc,
   pubKey: Uint8Array,
-  signature: Uint8Array
+  signature: Uint8Array,
+  algo: "secp256k1" | "ethsecp256k1" = "secp256k1"
 ): boolean {
   if (!checkAndValidateADR36AminoSignDoc(signDoc, bech32PrefixAccAddr)) {
     throw new Error("Invalid sign doc for ADR-36");
   }
 
   const cryptoPubKey = new PubKeySecp256k1(pubKey);
-  const expectedSigner = new Bech32Address(cryptoPubKey.getAddress()).toBech32(
-    bech32PrefixAccAddr
-  );
+  const expectedSigner = (() => {
+    if (algo === "ethsecp256k1") {
+      return new Bech32Address(cryptoPubKey.getEthAddress()).toBech32(
+        bech32PrefixAccAddr
+      );
+    }
+    return new Bech32Address(cryptoPubKey.getAddress()).toBech32(
+      bech32PrefixAccAddr
+    );
+  })();
   const signer = signDoc.msgs[0].value.signer;
   if (expectedSigner !== signer) {
     throw new Error("Unmatched signer");
@@ -137,7 +145,15 @@ export function verifyADR36AminoSignDoc(
 
   const msg = serializeSignDoc(signDoc);
 
-  return cryptoPubKey.verify(msg, signature);
+  return cryptoPubKey.verifyDigest32(
+    (() => {
+      if (algo === "ethsecp256k1") {
+        return Hash.keccak256(msg);
+      }
+      return Hash.sha256(msg);
+    })(),
+    signature
+  );
 }
 
 export function verifyADR36Amino(
@@ -145,7 +161,8 @@ export function verifyADR36Amino(
   signer: string,
   data: string | Uint8Array,
   pubKey: Uint8Array,
-  signature: Uint8Array
+  signature: Uint8Array,
+  algo: "secp256k1" | "ethsecp256k1" = "secp256k1"
 ): boolean {
   const signDoc = makeADR36AminoSignDoc(signer, data);
 
@@ -153,6 +170,7 @@ export function verifyADR36Amino(
     bech32PrefixAccAddr,
     signDoc,
     pubKey,
-    signature
+    signature,
+    algo
   );
 }


### PR DESCRIPTION
#653

Chains like evmos/injective differ in how address is calculated from public key. So far, adr36 has not handled this. Since it is impossible to distinguish them by looking at the public key itself, this is solved by adding an "algo" parameter.