### PR TITLE
Use background as "page" and apply code split to background bundle

### DIFF
--- a/packages/extension/src/background.html
+++ b/packages/extension/src/background.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Keplr background service</title>
+    <script type="application/javascript" src="browser-polyfill.js"></script>
+  </head>
+</html>

--- a/packages/extension/src/manifest.json
+++ b/packages/extension/src/manifest.json
@@ -15,7 +15,7 @@
     "default_title": "Keplr"
   },
   "background": {
-    "scripts": ["browser-polyfill.js", "background.bundle.js"],
+    "page": "background.html",
     "persistent": true
   },
   "permissions": ["storage", "notifications", "identity", "idle"],

--- a/packages/extension/webpack.config.js
+++ b/packages/extension/webpack.config.js
@@ -97,10 +97,10 @@ const extensionConfig = (env, args) => {
     // In development environment, webpack watch the file changes, and recompile
     watch: isEnvDevelopment,
     entry: {
+      background: ["./src/background/background.ts"],
       popup: ["./src/index.tsx"],
       blocklist: ["./src/pages/blocklist/index.tsx"],
       ledgerGrant: ["./src/pages/ledger-grant/index.tsx"],
-      background: ["./src/background/background.ts"],
       contentScripts: ["./src/content-scripts/content-scripts.ts"],
       injectedScript: ["./src/content-scripts/inject/injected-script.ts"],
     },
@@ -111,11 +111,35 @@ const extensionConfig = (env, args) => {
     optimization: {
       splitChunks: {
         chunks(chunk) {
-          return chunk.name === "popup";
+          if (chunk.name === "reactChartJS") {
+            return false;
+          }
+
+          return (
+            chunk.name !== "contentScripts" && chunk.name !== "injectedScript"
+          );
         },
+
         cacheGroups: {
+          background: {
+            maxSize: 3_000_000,
+            maxInitialRequests: 100,
+            maxAsyncRequests: 100,
+          },
           popup: {
             maxSize: 3_000_000,
+            maxInitialRequests: 100,
+            maxAsyncRequests: 100,
+          },
+          blocklist: {
+            maxSize: 3_000_000,
+            maxInitialRequests: 100,
+            maxAsyncRequests: 100,
+          },
+          ledgerGrant: {
+            maxSize: 3_000_000,
+            maxInitialRequests: 100,
+            maxAsyncRequests: 100,
           },
         },
       },
@@ -146,12 +170,23 @@ const extensionConfig = (env, args) => {
         { copyUnmodified: true }
       ),
       new HtmlWebpackPlugin({
+        template: "./src/background.html",
+        filename: "background.html",
+        excludeChunks: [
+          "popup",
+          "blocklist",
+          "ledgerGrant",
+          "contentScripts",
+          "injectedScript",
+        ],
+      }),
+      new HtmlWebpackPlugin({
         template: "./src/index.html",
         filename: "popup.html",
         excludeChunks: [
+          "background",
           "blocklist",
           "ledgerGrant",
-          "background",
           "contentScripts",
           "injectedScript",
         ],
@@ -160,9 +195,9 @@ const extensionConfig = (env, args) => {
         template: "./src/index.html",
         filename: "blocklist.html",
         excludeChunks: [
+          "background",
           "popup",
           "ledgerGrant",
-          "background",
           "contentScripts",
           "injectedScript",
         ],
@@ -171,9 +206,9 @@ const extensionConfig = (env, args) => {
         template: "./src/index.html",
         filename: "ledger-grant.html",
         excludeChunks: [
+          "background",
           "popup",
           "blocklist",
-          "background",
           "contentScripts",
           "injectedScript",
         ],


### PR DESCRIPTION
#690

There is a problem with the firefox addon store that it rejects to upload js file over 5mb. I briefly tested tree shaking, but it didn't help much to suppress the size below 5mb. To solve this problem, I took a look at metamask and found that I can put html into the background page.
Once I solved the problem in this way. It's not yet clear what to do with service worker when manifest v3 is reached.