### PR TITLE
WIP: overriding gas balance error if granter is set

### DIFF
--- a/packages/hooks/src/tx/fee.ts
+++ b/packages/hooks/src/tx/fee.ts
@@ -481,7 +481,7 @@ export class FeeConfig extends TxChainSetter implements IFeeConfig {
       need = new Coin(fee.denom, new Int(fee.amount));
     }
 
-    if (need.amount.gt(new Int(0))) {
+    if (need.amount.gt(new Int(0)) && !this.granter) {
       const bal = this.queriesStore
         .get(this.chainId)
         .queryBalances.getQueryBech32Address(this._sender)


### PR DESCRIPTION
I tried tracing the types used in this file but couldn't find where the `granter` field would be accessible. I don't know how to build/test this locally so this is a blind change, with some guidance I'm happy to refine this and make any necessary changes. 

Basically I need to be able to sign transactions without gas in the wallet, as long as the `granter` is set.