### PR TITLE
Make the fee config skip balance check if granter is set

### DIFF
--- a/packages/cosmos/src/stargate/wrapper/index.ts
+++ b/packages/cosmos/src/stargate/wrapper/index.ts
@@ -107,6 +107,14 @@ export class SignDocWrapper {
     return this.aminoSignDoc.fee.amount;
   }
 
+  get granter(): string | undefined {
+    if (this.mode === "direct") {
+      return this.protoSignDoc.authInfo.fee?.granter;
+    }
+
+    return this.aminoSignDoc.fee.granter;
+  }
+
   get gas(): number {
     if (this.mode === "direct") {
       if (this.protoSignDoc.authInfo.fee?.gasLimit) {

--- a/packages/extension/src/pages/sign/index.tsx
+++ b/packages/extension/src/pages/sign/index.tsx
@@ -119,6 +119,12 @@ export const SignPage: FunctionComponent = observer(() => {
       feeConfig.setDisableBalanceCheck(
         !!data.data.signOptions.disableBalanceCheck
       );
+      if (
+        data.data.signDocWrapper.granter &&
+        data.data.signDocWrapper.granter !== data.data.signer
+      ) {
+        feeConfig.setDisableBalanceCheck(true);
+      }
       setSigner(data.data.signer);
     }
   }, [


### PR DESCRIPTION
#697

When fee grant module is used, sign doc includes granter field which pay fees instead of tx sender. However, Keplr blocks "Approve" button if tx sender doesn't have enough balances to send tx. And, it makes using fee grant module confusing.
To fix this problem, make the fee config skip balance check if granter is set.