### PR TITLE
Adjust newer response format of tendermint

### DIFF
--- a/packages/chain-validator/src/connection.ts
+++ b/packages/chain-validator/src/connection.ts
@@ -24,23 +24,24 @@ export async function checkRPCConnectivity(
     baseURL: rpc,
   });
 
-  let resultStatus: AxiosResponse<{
-    result: {
-      node_info: {
-        network: string;
-      };
-    };
-  }>;
-
-  try {
-    // Get the status to get the chain id.
-    resultStatus = await rpcInstance.get<{
-      result: {
+  let resultStatus: AxiosResponse<
+    | {
+        result: {
+          node_info: {
+            network: string;
+          };
+        };
+      }
+    | {
         node_info: {
           network: string;
         };
-      };
-    }>("/status");
+      }
+  >;
+
+  try {
+    // Get the status to get the chain id.
+    resultStatus = await rpcInstance.get("/status");
   } catch (e) {
     console.log(e);
     throw new Error("Failed to get response /status from rpc endpoint");
@@ -48,20 +49,27 @@ export async function checkRPCConnectivity(
 
   const version = ChainIdHelper.parse(chainId);
 
+  const statusResult = (() => {
+    if ("result" in resultStatus.data) {
+      return resultStatus.data.result;
+    }
+    return resultStatus.data;
+  })();
+
   const versionFromRPCStatus = ChainIdHelper.parse(
-    resultStatus.data.result.node_info.network
+    statusResult.node_info.network
   );
 
   if (versionFromRPCStatus.identifier !== version.identifier) {
     throw new Error(
-      `RPC endpoint has different chain id (expected: ${chainId}, actual: ${resultStatus.data.result.node_info.network})`
+      `RPC endpoint has different chain id (expected: ${chainId}, actual: ${statusResult.node_info.network})`
     );
   } else if (versionFromRPCStatus.version !== version.version) {
     // In the form of {chain_identifier}-{chain_version}, if the identifier is the same but the version is different, it is strictly an error,
     // but it is actually the same chain but the chain version of the node is different.
     // In this case, it is possible to treat as a warning and proceed as it is, so this is separated with above error.
     throw new DifferentChainVersionError(
-      `RPC endpoint has different chain id (expected: ${chainId}, actual: ${resultStatus.data.result.node_info.network})`
+      `RPC endpoint has different chain id (expected: ${chainId}, actual: ${statusResult.node_info.network})`
     );
   }
 

--- a/packages/stores/src/query/cosmos/status/index.ts
+++ b/packages/stores/src/query/cosmos/status/index.ts
@@ -3,48 +3,53 @@ import { ChainGetter } from "../../../common";
 import { ObservableChainQueryRPC } from "../../chain-rpc-query";
 import { Int } from "@keplr-wallet/unit";
 
-export class ObservableQueryRPCStatus extends ObservableChainQueryRPC<{
-  jsonrpc: "2.0";
-  id: number;
-  result: {
-    node_info: {
-      protocol_version: {
-        p2p: string;
-        block: string;
-        app: string;
-      };
-      id: string;
-      listen_addr: string;
-      network: string;
-      version: string;
-      channels: string;
-      moniker: string;
-      other: {
-        tx_index: "on" | "off";
-        rpc_address: string;
-      };
+type RPCStatusResult = {
+  node_info: {
+    protocol_version: {
+      p2p: string;
+      block: string;
+      app: string;
     };
-    sync_info: {
-      latest_block_hash: string;
-      latest_app_hash: string;
-      latest_block_height: string;
-      latest_block_time: string;
-      earliest_block_hash: string;
-      earliest_app_hash: string;
-      earliest_block_height: string;
-      earliest_block_time: string;
-      catching_up: boolean;
-    };
-    validator_info: {
-      address: string;
-      pub_key: {
-        type: string;
-        value: string;
-      };
-      voting_power: string;
+    id: string;
+    listen_addr: string;
+    network: string;
+    version: string;
+    channels: string;
+    moniker: string;
+    other: {
+      tx_index: "on" | "off";
+      rpc_address: string;
     };
   };
-}> {
+  sync_info: {
+    latest_block_hash: string;
+    latest_app_hash: string;
+    latest_block_height: string;
+    latest_block_time: string;
+    earliest_block_hash: string;
+    earliest_app_hash: string;
+    earliest_block_height: string;
+    earliest_block_time: string;
+    catching_up: boolean;
+  };
+  validator_info: {
+    address: string;
+    pub_key: {
+      type: string;
+      value: string;
+    };
+    voting_power: string;
+  };
+};
+
+export class ObservableQueryRPCStatus extends ObservableChainQueryRPC<
+  | {
+      jsonrpc: "2.0";
+      id: number;
+      result: RPCStatusResult;
+    }
+  | RPCStatusResult
+> {
   constructor(kvStore: KVStore, chainId: string, chainGetter: ChainGetter) {
     super(kvStore, chainId, chainGetter, "/status");
   }
@@ -54,7 +59,11 @@ export class ObservableQueryRPCStatus extends ObservableChainQueryRPC<{
       return undefined;
     }
 
-    return this.response.data.result.node_info.network;
+    if ("result" in this.response.data) {
+      return this.response.data.result.node_info.network;
+    }
+
+    return this.response.data.node_info.network;
   }
 
   get latestBlockHeight(): Int | undefined {
@@ -62,6 +71,10 @@ export class ObservableQueryRPCStatus extends ObservableChainQueryRPC<{
       return undefined;
     }
 
-    return new Int(this.response.data.result.sync_info.latest_block_height);
+    if ("result" in this.response.data) {
+      return new Int(this.response.data.result.sync_info.latest_block_height);
+    }
+
+    return new Int(this.response.data.sync_info.latest_block_height);
   }
 }


### PR DESCRIPTION
The tendermint changelog doesn't show it exactly, but it looks like the /status rpc response format has changed. The new version doesn't return the jsonrpc form.