### PR TITLE
`Dec`: add `mulRoundUp()`

### DIFF
--- a/packages/unit/src/decimal.ts
+++ b/packages/unit/src/decimal.ts
@@ -222,6 +222,10 @@ export class Dec {
     return new Dec(this.mulRaw(d2).chopPrecisionAndTruncate(), Dec.precision);
   }
 
+  public mulRoundUp(d2: Dec): Dec {
+    return new Dec(this.mulRaw(d2).chopPrecisionAndRoundUp(), Dec.precision);
+  }
+
   protected mulRaw(d2: Dec): Dec {
     return new Dec(this.int.multiply(d2.int), Dec.precision);
   }


### PR DESCRIPTION
Matches convention of `quoRoundUp()`

Available in Cosmos SDK Dec type.

Needed for Osmosis Concentrated Liquidity calculations/math, may upgrade `@keplr-wallet/unit` in the future.

Targeting 2.0/develop, LMK if it should be targeting normal develop branch.