### PR TITLE
Increases Juno's fees (Prop 297)

### DIFF
--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -1374,9 +1374,9 @@ export const EmbedChainInfos: ChainInfo[] = [
         coinDecimals: 6,
         coinGeckoId: "juno-network",
         gasPriceStep: {
-          low: 0.001,
-          average: 0.0025,
-          high: 0.004,
+          low: 0.075,
+          average: 0.085,
+          high: 0.095,
         },
       },
       {
@@ -1385,9 +1385,9 @@ export const EmbedChainInfos: ChainInfo[] = [
           "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9",
         coinDecimals: 6,
         gasPriceStep: {
-          low: 0.001 * 0.33,
-          average: 0.0025 * 0.33,
-          high: 0.004 * 0.33,
+          low: 0.003 * 0.33,
+          average: 0.0050 * 0.33,
+          high: 0.065 * 0.33,
         },
       },
     ],


### PR DESCRIPTION
Should proposal https://www.mintscan.io/juno/proposals/297 pass / come close to passing, Juno network should implement the new base fees of the network on Keplr.

These are set through gov with GlobalFee. So the minimum is the new low, with steps up incase a network attack was to occur and validators rose fees above temporarily.

```
"subspace":string"globalfee"
"key":string"MinimumGasPricesParam"
"value":string"[{"denom":"ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9","amount":"0.003000000000000000"},{"denom":"ujuno","amount":"0.075000000000000000"}]"
```