### PR TITLE
Dispatch event on keyring store lock/unlock

### DIFF
--- a/packages/stores/src/core/keyring.ts
+++ b/packages/stores/src/core/keyring.ts
@@ -273,6 +273,8 @@ export class KeyRingStore {
       this.requester.sendMessage(BACKGROUND_PORT, msg)
     );
     this._status = result.status;
+
+    this.eventDispatcher.dispatchEvent("keplr_keystorelock");
   }
 
   @flow
@@ -290,6 +292,8 @@ export class KeyRingStore {
       this._keyInfos = result.keyInfos;
 
       this._needMigration = false;
+
+      this.eventDispatcher.dispatchEvent("keplr_keystoreunlock");
     } finally {
       // Set the flag to false even if the migration is failed.
       this._isMigrating = false;


### PR DESCRIPTION
Emitting an event on keystore lock/unlock to make it easier for dApp developers to detect when the user locks/unlocks their wallet and perform necessary actions (e.g disconnect the wallet from the dApp when the wallet gets locked).

Named events `"keplr_keystorelock"` and `"keplr_keystoreunlock"` to make it easier for event listeners to determine the proper action to perform.