### PR TITLE
Corrected a misspelled word

### DIFF
--- a/packages/background/src/chains/service.ts
+++ b/packages/background/src/chains/service.ts
@@ -275,7 +275,7 @@ export class ChainsService {
   getChainInfoOrThrow(chainId: string): ChainInfo {
     const chainInfo = this.getChainInfo(chainId);
     if (!chainInfo) {
-      throw new Error(`There in no chain info for ${chainId}`);
+      throw new Error(`There is no chain info for ${chainId}`);
     }
     return chainInfo;
   }


### PR DESCRIPTION
I am a dev of joltify.io
We check if a chain is added to keplr by the expression "There is no chain info for" in the past
but we found it became "There in no chain info for" in the new published version of keplr and we failed to check if a  chain added to keplr, so I submit this PR.