### PR TITLE
Implement experimental `signEthereum` API to 2.0

### DIFF
--- a/packages/background/package.json
+++ b/packages/background/package.json
@@ -25,11 +25,8 @@
   "dependencies": {
     "@ethereumjs/common": "^2.6.5",
     "@ethereumjs/tx": "^3.5.2",
-    "@ethersproject/bignumber": "^5.7.0",
-    "@ethersproject/bytes": "^5.7.0",
     "@ethersproject/hash": "^5.7.0",
     "@ethersproject/transactions": "^5.7.0",
-    "@ethersproject/wallet": "^5.7.0",
     "@keplr-wallet/chain-validator": "0.12.5",
     "@keplr-wallet/common": "0.12.5",
     "@keplr-wallet/cosmos": "0.12.5",

--- a/packages/background/src/index.ts
+++ b/packages/background/src/index.ts
@@ -19,6 +19,7 @@ import * as KeyRingMnemonic from "./keyring-mnemonic/internal";
 import * as KeyRingLedger from "./keyring-ledger/internal";
 import * as KeyRingPrivateKey from "./keyring-private-key/internal";
 import * as KeyRingCosmos from "./keyring-cosmos/internal";
+import * as KeyRingEthereum from "./keyring-ethereum/internal";
 import * as PermissionInteractive from "./permission-interactive/internal";
 import * as TokenScan from "./token-scan/internal";
 import * as RecentSendHistory from "./recent-send-history/internal";
@@ -38,6 +39,7 @@ export * from "./permission-interactive";
 export * from "./keyring";
 export * from "./vault";
 export * from "./keyring-cosmos";
+export * from "./keyring-ethereum";
 export * from "./token-scan";
 export * from "./recent-send-history";
 
@@ -146,6 +148,13 @@ export function init(
     interactionService,
     analyticsService
   );
+  const keyRingEthereumService = new KeyRingEthereum.KeyRingEthereumService(
+    chainsService,
+    keyRingV2Service,
+    keyRingCosmosService,
+    interactionService,
+    analyticsService
+  );
   const autoLockAccountService = new AutoLocker.AutoLockAccountService(
     storeCreator("auto-lock-account"),
     keyRingV2Service
@@ -202,6 +211,11 @@ export function init(
     keyRingCosmosService,
     permissionInteractiveService
   );
+  KeyRingEthereum.init(
+    router,
+    keyRingEthereumService,
+    permissionInteractiveService
+  );
   PermissionInteractive.init(router, permissionInteractiveService);
   ChainsUI.init(router, chainsUIService);
   ChainsUpdate.init(router, chainsUpdateService);
@@ -223,6 +237,7 @@ export function init(
       await chainsUpdateService.init();
       await keyRingV2Service.init();
       await keyRingCosmosService.init();
+      await keyRingEthereumService.init();
       await permissionService.init();
       await tokenCW20Service.init();
 

--- a/packages/background/src/keyring-cosmos/eip712.ts
+++ b/packages/background/src/keyring-cosmos/eip712.ts
@@ -1,4 +1,5 @@
 import Joi from "joi";
+import { _TypedDataEncoder as TypedDataEncoder } from "@ethersproject/hash";
 
 // https://eips.ethereum.org/EIPS/eip-712
 
@@ -90,8 +91,6 @@ export const EIP712MessageValidator = Joi.object<{
   domain: Joi.object().required(),
   message: Joi.object().required(),
 });
-
-import { _TypedDataEncoder as TypedDataEncoder } from "@ethersproject/hash";
 
 export const domainHash = (message: {
   types: Record<string, { name: string; type: string }[]>;

--- a/packages/background/src/keyring-cosmos/messages.ts
+++ b/packages/background/src/keyring-cosmos/messages.ts
@@ -14,7 +14,7 @@ import {
   EthermintChainIdHelper,
 } from "@keplr-wallet/cosmos";
 import { SignDoc } from "@keplr-wallet/proto-types/cosmos/tx/v1beta1/tx";
-import { BigNumber } from "@ethersproject/bignumber";
+import { Int } from "@keplr-wallet/unit";
 
 export class GetCosmosKeyMsg extends Message<Key> {
   public static type() {
@@ -475,7 +475,7 @@ export class RequestSignEIP712CosmosTxMsg_v0 extends Message<AminoSignResponse> 
 
       const { ethChainId } = EthermintChainIdHelper.parse(this.chainId);
 
-      if (!BigNumber.from(this.eip712.domain["chainId"]).eq(ethChainId)) {
+      if (!new Int(this.eip712.domain["chainId"]).equals(new Int(ethChainId))) {
         throw new Error(
           `Unmatched chain id for eth (expected: ${ethChainId}, actual: ${this.eip712.domain["chainId"]})`
         );

--- a/packages/background/src/keyring-cosmos/service.ts
+++ b/packages/background/src/keyring-cosmos/service.ts
@@ -250,12 +250,13 @@ export class KeyRingCosmosService {
           }
           signature = res.signature;
         } else {
-          signature = await this.keyRingService.sign(
+          const _sig = await this.keyRingService.sign(
             chainId,
             vaultId,
             serializeSignDoc(newSignDoc),
             isEthermintLike ? "keccak256" : "sha256"
           );
+          signature = new Uint8Array([..._sig.r, ..._sig.s]);
         }
 
         const msgTypes = newSignDoc.msgs
@@ -345,12 +346,13 @@ export class KeyRingCosmosService {
     }
 
     try {
-      const signature = await this.keyRingService.sign(
+      const _sig = await this.keyRingService.sign(
         chainId,
         vaultId,
         serializeSignDoc(signDoc),
         isEthermintLike ? "keccak256" : "sha256"
       );
+      const signature = new Uint8Array([..._sig.r, ..._sig.s]);
 
       this.analyticsService.logEventIgnoreError("tx_signed", {
         chainId,
@@ -456,12 +458,13 @@ export class KeyRingCosmosService {
           }
           signature = res.signature;
         } else {
-          signature = await this.keyRingService.sign(
+          const _sig = await this.keyRingService.sign(
             chainId,
             vaultId,
             serializeSignDoc(newSignDoc),
             isEthermintLike ? "keccak256" : "sha256"
           );
+          signature = new Uint8Array([..._sig.r, ..._sig.s]);
         }
 
         const msgTypes = newSignDoc.msgs
@@ -544,12 +547,13 @@ export class KeyRingCosmosService {
           }
           signature = res.signature;
         } else {
-          signature = await this.keyRingService.sign(
+          const _sig = await this.keyRingService.sign(
             chainId,
             vaultId,
             newSignDocBytes,
             isEthermintLike ? "keccak256" : "sha256"
           );
+          signature = new Uint8Array([..._sig.r, ..._sig.s]);
         }
 
         const msgTypes = TxBody.decode(newSignDoc.bodyBytes).messages.map(
@@ -920,12 +924,13 @@ Salt: ${salt}`;
               data
             );
 
-            const signature = await this.keyRingService.sign(
+            const _sig = await this.keyRingService.sign(
               accountInfo.chainId,
               vaultId,
               serializeSignDoc(signDoc),
               isEthermintLike ? "keccak256" : "sha256"
             );
+            const signature = new Uint8Array([..._sig.r, ..._sig.s]);
 
             r.push({
               chainId: accountInfo.chainId,
@@ -967,7 +972,7 @@ Salt: ${salt}`;
     chainId: string,
     memo: string
   ): Promise<Uint8Array> {
-    return await this.keyRingService.sign(
+    const _sig = await this.keyRingService.sign(
       chainId,
       this.keyRingService.selectedVaultId,
       Buffer.from(
@@ -982,6 +987,7 @@ Salt: ${salt}`;
       ),
       "sha256"
     );
+    return new Uint8Array([..._sig.r, ..._sig.s]);
   }
 
   // XXX: There are other way to handle tx with ethermint on ledger.

--- a/packages/background/src/keyring-ethereum/constants.ts
+++ b/packages/background/src/keyring-ethereum/constants.ts
@@ -1,0 +1,1 @@
+export const ROUTE = "keyring-ethereum";

--- a/packages/background/src/keyring-ethereum/handler.ts
+++ b/packages/background/src/keyring-ethereum/handler.ts
@@ -1,0 +1,55 @@
+import {
+  Env,
+  Handler,
+  InternalHandler,
+  KeplrError,
+  Message,
+} from "@keplr-wallet/router";
+import { RequestSignEthereumMsg } from "./messages";
+import { KeyRingEthereumService } from "./service";
+import { PermissionInteractiveService } from "../permission-interactive";
+
+export const getHandler: (
+  service: KeyRingEthereumService,
+  permissionInteractionService: PermissionInteractiveService
+) => Handler = (
+  service: KeyRingEthereumService,
+  permissionInteractionService
+) => {
+  return (env: Env, msg: Message<unknown>) => {
+    switch (msg.constructor) {
+      case RequestSignEthereumMsg:
+        return handleRequestSignEthereumMsg(
+          service,
+          permissionInteractionService
+        )(env, msg as RequestSignEthereumMsg);
+      default:
+        throw new KeplrError("keyring", 221, "Unknown msg type");
+    }
+  };
+};
+
+const handleRequestSignEthereumMsg: (
+  service: KeyRingEthereumService,
+  permissionInteractionService: PermissionInteractiveService
+) => InternalHandler<RequestSignEthereumMsg> = (
+  service,
+  permissionInteractionService
+) => {
+  return async (env, msg) => {
+    await permissionInteractionService.ensureEnabled(
+      env,
+      [msg.chainId],
+      msg.origin
+    );
+
+    return await service.signEthereumSelected(
+      env,
+      msg.origin,
+      msg.chainId,
+      msg.signer,
+      msg.message,
+      msg.signType
+    );
+  };
+};

--- a/packages/background/src/keyring-ethereum/index.ts
+++ b/packages/background/src/keyring-ethereum/index.ts
@@ -1,0 +1,2 @@
+export * from "./messages";
+export * from "./service";

--- a/packages/background/src/keyring-ethereum/init.ts
+++ b/packages/background/src/keyring-ethereum/init.ts
@@ -1,0 +1,16 @@
+import { Router } from "@keplr-wallet/router";
+import { KeyRingEthereumService } from "./service";
+import { RequestSignEthereumMsg } from "./messages";
+import { ROUTE } from "./constants";
+import { getHandler } from "./handler";
+import { PermissionInteractiveService } from "../permission-interactive";
+
+export function init(
+  router: Router,
+  service: KeyRingEthereumService,
+  permissionInteractionService: PermissionInteractiveService
+): void {
+  router.registerMessage(RequestSignEthereumMsg);
+
+  router.addHandler(ROUTE, getHandler(service, permissionInteractionService));
+}

--- a/packages/background/src/keyring-ethereum/internal.ts
+++ b/packages/background/src/keyring-ethereum/internal.ts
@@ -1,0 +1,2 @@
+export * from "./service";
+export * from "./init";

--- a/packages/background/src/keyring-ethereum/messages.ts
+++ b/packages/background/src/keyring-ethereum/messages.ts
@@ -1,0 +1,48 @@
+import { Bech32Address } from "@keplr-wallet/cosmos";
+import { Message } from "@keplr-wallet/router";
+import { EthSignType } from "@keplr-wallet/types";
+import { ROUTE } from "./constants";
+
+export class RequestSignEthereumMsg extends Message<Uint8Array> {
+  public static type() {
+    return "request-sign-ethereum";
+  }
+
+  constructor(
+    public readonly chainId: string,
+    public readonly signer: string,
+    public readonly message: Uint8Array,
+    public readonly signType: EthSignType
+  ) {
+    super();
+  }
+
+  validateBasic(): void {
+    if (!this.chainId) {
+      throw new Error("chain id not set");
+    }
+
+    if (!this.signer) {
+      throw new Error("signer not set");
+    }
+
+    if (!this.signType) {
+      throw new Error("sign type not set");
+    }
+
+    // Validate bech32 address.
+    Bech32Address.validate(this.signer);
+  }
+
+  override approveExternal(): boolean {
+    return true;
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return RequestSignEthereumMsg.type();
+  }
+}

--- a/packages/background/src/keyring-ethereum/service.ts
+++ b/packages/background/src/keyring-ethereum/service.ts
@@ -1,0 +1,166 @@
+import { ChainsService } from "../chains";
+import { KeyRingService } from "../keyring";
+import { InteractionService } from "../interaction";
+import { AnalyticsService } from "../analytics";
+import { Env } from "@keplr-wallet/router";
+import { EthSignType } from "@keplr-wallet/types";
+import { Bech32Address } from "@keplr-wallet/cosmos";
+import { Buffer } from "buffer/";
+import {
+  domainHash,
+  EIP712MessageValidator,
+  KeyRingCosmosService,
+  messageHash,
+} from "../keyring-cosmos";
+import { hashMessage } from "@ethersproject/hash";
+import { serialize } from "@ethersproject/transactions";
+
+export class KeyRingEthereumService {
+  constructor(
+    protected readonly chainsService: ChainsService,
+    protected readonly keyRingService: KeyRingService,
+    // XXX: 미래에는 cosmos와 분리되어서 ethereum을 다뤄야하는데 현재는 그냥 ethermint 계열에서만 작동하기 때문에
+    //      keyring-cosmos의 기능들도 사용한다.
+    protected readonly keyRingCosmosService: KeyRingCosmosService,
+    protected readonly interactionService: InteractionService,
+    protected readonly analyticsService: AnalyticsService
+  ) {}
+
+  async init() {
+    // TODO: ?
+  }
+
+  async signEthereumSelected(
+    env: Env,
+    origin: string,
+    chainId: string,
+    signer: string,
+    message: Uint8Array,
+    signType: EthSignType
+  ): Promise<Uint8Array> {
+    return await this.signEthereum(
+      env,
+      origin,
+      this.keyRingService.selectedVaultId,
+      chainId,
+      signer,
+      message,
+      signType
+    );
+  }
+
+  async signEthereum(
+    env: Env,
+    origin: string,
+    vaultId: string,
+    chainId: string,
+    signer: string,
+    message: Uint8Array,
+    signType: EthSignType
+  ): Promise<Uint8Array> {
+    const chainInfo = this.chainsService.getChainInfoOrThrow(chainId);
+    const isEthermintLike = KeyRingService.isEthermintLike(chainInfo);
+
+    if (!isEthermintLike) {
+      throw new Error("Not ethermint like chain");
+    }
+
+    const keyInfo = this.keyRingService.getKeyInfo(vaultId);
+    if (!keyInfo) {
+      throw new Error("Null key info");
+    }
+
+    if (keyInfo.type === "ledger") {
+      KeyRingCosmosService.throwErrorIfEthermintWithLedgerButNotSupported(
+        chainId
+      );
+    }
+
+    const key = await this.keyRingCosmosService.getKey(vaultId, chainId);
+    const bech32Prefix =
+      this.chainsService.getChainInfoOrThrow(chainId).bech32Config
+        .bech32PrefixAccAddr;
+    const bech32Address = new Bech32Address(key.address).toBech32(bech32Prefix);
+    if (signer !== bech32Address) {
+      throw new Error("Signer mismatched");
+    }
+
+    return await this.interactionService.waitApproveV2(
+      env,
+      "/sign-ethereum",
+      "request-sign-ethereum",
+      {
+        origin,
+        chainId,
+        signer,
+        message,
+        signType,
+        keyType: keyInfo.type,
+        keyInsensitive: keyInfo.insensitive,
+      },
+      async (res: { signature?: Uint8Array }) => {
+        if (keyInfo.type === "ledger") {
+          if (!res.signature || res.signature.length === 0) {
+            throw new Error("Frontend should provide signature if ledger");
+          }
+          return res.signature;
+        } else {
+          switch (signType) {
+            case EthSignType.MESSAGE: {
+              return await this.keyRingService.sign(
+                chainId,
+                vaultId,
+                Buffer.from(hashMessage(message).replace("0x", ""), "hex"),
+                "keccak256"
+              );
+            }
+            case EthSignType.TRANSACTION: {
+              const tx = JSON.parse(Buffer.from(message).toString());
+              const signature = await this.keyRingService.sign(
+                chainId,
+                vaultId,
+                Buffer.from(serialize(tx).replace("0x", ""), "hex"),
+                "keccak256"
+              );
+              return Buffer.from(
+                serialize(tx, signature).replace("0x", ""),
+                "hex"
+              );
+            }
+            case EthSignType.EIP712: {
+              const data = await EIP712MessageValidator.validateAsync(
+                JSON.parse(Buffer.from(message).toString())
+              );
+              // Since ethermint eip712 tx uses non-standard format, it cannot pass validation of ethersjs.
+              // Therefore, it should be handled at a slightly lower level.
+              const signature = await this.keyRingService.sign(
+                chainId,
+                vaultId,
+                Buffer.concat([
+                  // eth separator
+                  Buffer.from("19", "hex"),
+                  // Version: 1
+                  Buffer.from("01", "hex"),
+                  Buffer.from(domainHash(data).replace("0x", ""), "hex"),
+                  Buffer.from(messageHash(data).replace("0x", ""), "hex"),
+                ]),
+                "keccak256"
+              );
+              // return Buffer.concat([
+              //   Buffer.from(signature.r.replace("0x", ""), "hex"),
+              //   Buffer.from(signature.s.replace("0x", ""), "hex"),
+              //   // The metamask doesn't seem to consider the chain id in this case... (maybe bug on metamask?)
+              //   signature.recoveryParam
+              //     ? Buffer.from("1c", "hex")
+              //     : Buffer.from("1b", "hex"),
+              // ]);
+              return signature;
+            }
+            default:
+              throw new Error(`Unknown sign type: ${signType}`);
+          }
+        }
+      }
+    );
+  }
+}

--- a/packages/background/src/keyring-ethereum/service.ts
+++ b/packages/background/src/keyring-ethereum/service.ts
@@ -146,14 +146,14 @@ export class KeyRingEthereumService {
                 ]),
                 "keccak256"
               );
-              // return Buffer.concat([
-              //   Buffer.from(signature.r.replace("0x", ""), "hex"),
-              //   Buffer.from(signature.s.replace("0x", ""), "hex"),
-              //   // The metamask doesn't seem to consider the chain id in this case... (maybe bug on metamask?)
-              //   signature.recoveryParam
-              //     ? Buffer.from("1c", "hex")
-              //     : Buffer.from("1b", "hex"),
-              // ]);
+              return Buffer.concat([
+                Buffer.from(signature.r.replace("0x", ""), "hex"),
+                Buffer.from(signature.s.replace("0x", ""), "hex"),
+                // The metamask doesn't seem to consider the chain id in this case... (maybe bug on metamask?)
+                signature.recoveryParam
+                  ? Buffer.from("1c", "hex")
+                  : Buffer.from("1b", "hex"),
+              ]);
               return signature;
             }
             default:

--- a/packages/background/src/keyring-ledger/service.ts
+++ b/packages/background/src/keyring-ledger/service.ts
@@ -72,7 +72,11 @@ export class KeyRingLedgerService {
     return new PubKeySecp256k1(bytes);
   }
 
-  sign(): Uint8Array {
+  sign(): {
+    readonly r: Uint8Array;
+    readonly s: Uint8Array;
+    readonly v: number | null;
+  } {
     throw new Error(
       "Ledger can't sign message in background. You should provide the signature from frontend."
     );

--- a/packages/background/src/keyring-mnemonic/service.ts
+++ b/packages/background/src/keyring-mnemonic/service.ts
@@ -101,7 +101,8 @@ export class KeyRingMnemonicService {
         throw new Error(`Unknown digest method: ${digestMethod}`);
     }
 
-    return privKey.signDigest32(digest);
+    const signature = privKey.signDigest32(digest);
+    return new Uint8Array([...signature.r, ...signature.s]);
   }
 
   protected getPrivKey(vault: Vault, coinType: number): PrivKeySecp256k1 {

--- a/packages/background/src/keyring-mnemonic/service.ts
+++ b/packages/background/src/keyring-mnemonic/service.ts
@@ -86,7 +86,11 @@ export class KeyRingMnemonicService {
     coinType: number,
     data: Uint8Array,
     digestMethod: "sha256" | "keccak256"
-  ): Uint8Array {
+  ): {
+    readonly r: Uint8Array;
+    readonly s: Uint8Array;
+    readonly v: number | null;
+  } {
     const privKey = this.getPrivKey(vault, coinType);
 
     let digest = new Uint8Array();
@@ -101,8 +105,7 @@ export class KeyRingMnemonicService {
         throw new Error(`Unknown digest method: ${digestMethod}`);
     }
 
-    const signature = privKey.signDigest32(digest);
-    return new Uint8Array([...signature.r, ...signature.s]);
+    return privKey.signDigest32(digest);
   }
 
   protected getPrivKey(vault: Vault, coinType: number): PrivKeySecp256k1 {

--- a/packages/background/src/keyring-private-key/service.ts
+++ b/packages/background/src/keyring-private-key/service.ts
@@ -49,7 +49,11 @@ export class KeyRingPrivateKeyService {
     _coinType: number,
     data: Uint8Array,
     digestMethod: "sha256" | "keccak256"
-  ): Uint8Array {
+  ): {
+    readonly r: Uint8Array;
+    readonly s: Uint8Array;
+    readonly v: number | null;
+  } {
     const privateKeyText = this.vaultService.decrypt(vault.sensitive)[
       "privateKey"
     ] as string;
@@ -67,7 +71,6 @@ export class KeyRingPrivateKeyService {
         throw new Error(`Unknown digest method: ${digestMethod}`);
     }
 
-    const signature = privateKey.signDigest32(digest);
-    return new Uint8Array([...signature.r, ...signature.s]);
+    return privateKey.signDigest32(digest);
   }
 }

--- a/packages/background/src/keyring-private-key/service.ts
+++ b/packages/background/src/keyring-private-key/service.ts
@@ -67,6 +67,7 @@ export class KeyRingPrivateKeyService {
         throw new Error(`Unknown digest method: ${digestMethod}`);
     }
 
-    return privateKey.signDigest32(digest);
+    const signature = privateKey.signDigest32(digest);
+    return new Uint8Array([...signature.r, ...signature.s]);
   }
 }

--- a/packages/background/src/keyring/service.ts
+++ b/packages/background/src/keyring/service.ts
@@ -824,7 +824,11 @@ export class KeyRingService {
     chainId: string,
     data: Uint8Array,
     digestMethod: "sha256" | "keccak256"
-  ): Promise<Uint8Array> {
+  ): Promise<{
+    readonly r: Uint8Array;
+    readonly s: Uint8Array;
+    readonly v: number | null;
+  }> {
     return this.sign(chainId, this.selectedVaultId, data, digestMethod);
   }
 
@@ -900,7 +904,11 @@ export class KeyRingService {
     vaultId: string,
     data: Uint8Array,
     digestMethod: "sha256" | "keccak256"
-  ): Promise<Uint8Array> {
+  ): Promise<{
+    readonly r: Uint8Array;
+    readonly s: Uint8Array;
+    readonly v: number | null;
+  }> {
     if (this.vaultService.isLocked) {
       throw new Error("KeyRing is locked");
     }
@@ -959,7 +967,11 @@ export class KeyRingService {
     data: Uint8Array,
     digestMethod: "sha256" | "keccak256",
     chainInfo: ChainInfo
-  ): Promise<Uint8Array> {
+  ): Promise<{
+    readonly r: Uint8Array;
+    readonly s: Uint8Array;
+    readonly v: number | null;
+  }> {
     if (this.vaultService.isLocked) {
       throw new Error("KeyRing is locked");
     }

--- a/packages/background/src/keyring/types.ts
+++ b/packages/background/src/keyring/types.ts
@@ -35,5 +35,15 @@ export interface KeyRing {
     data: Uint8Array,
     digestMethod: "sha256" | "keccak256",
     chainInfo: ChainInfo
-  ): Uint8Array | Promise<Uint8Array>;
+  ):
+    | {
+        readonly r: Uint8Array;
+        readonly s: Uint8Array;
+        readonly v: number | null;
+      }
+    | Promise<{
+        readonly r: Uint8Array;
+        readonly s: Uint8Array;
+        readonly v: number | null;
+      }>;
 }

--- a/packages/cosmos/src/adr-36/amino.spec.ts
+++ b/packages/cosmos/src/adr-36/amino.spec.ts
@@ -487,10 +487,15 @@ describe("Test ADR-36 Amino Sign Doc", () => {
 
     const msg = serializeSignDoc(signDoc);
 
-    const signature = privKey.sign(msg);
+    const signature = privKey.signDigest32(Hash.sha256(msg));
 
     expect(
-      verifyADR36AminoSignDoc("osmo", signDoc, pubKey.toBytes(), signature)
+      verifyADR36AminoSignDoc(
+        "osmo",
+        signDoc,
+        pubKey.toBytes(),
+        new Uint8Array([...signature.r, ...signature.s])
+      )
     ).toBe(true);
 
     expect(() =>
@@ -528,7 +533,7 @@ describe("Test ADR-36 Amino Sign Doc", () => {
           memo: "",
         },
         pubKey.toBytes(),
-        signature
+        new Uint8Array([...signature.r, ...signature.s])
       )
     ).toThrow();
 
@@ -538,7 +543,7 @@ describe("Test ADR-36 Amino Sign Doc", () => {
         signer,
         new Uint8Array([1, 2, 3]),
         pubKey.toBytes(),
-        signature
+        new Uint8Array([...signature.r, ...signature.s])
       )
     ).toBe(true);
 
@@ -549,7 +554,7 @@ describe("Test ADR-36 Amino Sign Doc", () => {
         "osmo1ymk637a7wljvt4w7q9lnrw95mg9sr37yatxd9h",
         new Uint8Array([1, 2, 3]),
         pubKey.toBytes(),
-        signature
+        new Uint8Array([...signature.r, ...signature.s])
       )
     ).toThrow();
 
@@ -560,7 +565,7 @@ describe("Test ADR-36 Amino Sign Doc", () => {
         "invalid1ymk637a7wljvt4w7q9lnrw95mg9sr37yatxd9h",
         new Uint8Array([1, 2, 3]),
         pubKey.toBytes(),
-        signature
+        new Uint8Array([...signature.r, ...signature.s])
       )
     ).toThrow();
 
@@ -569,7 +574,10 @@ describe("Test ADR-36 Amino Sign Doc", () => {
         "osmo",
         signDoc,
         pubKey.toBytes(),
-        signature.slice().map((b) => (Math.random() > 0.5 ? 0 : b))
+        new Uint8Array([
+          ...signature.r.map((b) => (Math.random() > 0.5 ? 0 : b)),
+          ...signature.s.map((b) => (Math.random() > 0.5 ? 0 : b)),
+        ])
       )
     ).toBe(false);
 
@@ -579,7 +587,7 @@ describe("Test ADR-36 Amino Sign Doc", () => {
         signer,
         new Uint8Array([1, 2]),
         pubKey.toBytes(),
-        signature
+        new Uint8Array([...signature.r, ...signature.s])
       )
     ).toBe(false);
   });
@@ -600,7 +608,7 @@ describe("Test ADR-36 Amino Sign Doc", () => {
         "eth",
         signDoc,
         pubKey.toBytes(),
-        signature,
+        new Uint8Array([...signature.r, ...signature.s]),
         "ethsecp256k1"
       )
     ).toBe(true);
@@ -611,7 +619,7 @@ describe("Test ADR-36 Amino Sign Doc", () => {
         signer,
         new Uint8Array([1, 2, 3]),
         pubKey.toBytes(),
-        signature,
+        new Uint8Array([...signature.r, ...signature.s]),
         "ethsecp256k1"
       )
     ).toBe(true);
@@ -623,7 +631,7 @@ describe("Test ADR-36 Amino Sign Doc", () => {
         new Bech32Address(pubKey.getAddress()).toBech32("eth"),
         new Uint8Array([1, 2, 3]),
         pubKey.toBytes(),
-        signature,
+        new Uint8Array([...signature.r, ...signature.s]),
         "ethsecp256k1"
       )
     ).toThrow();
@@ -635,7 +643,7 @@ describe("Test ADR-36 Amino Sign Doc", () => {
         "invalid1ymk637a7wljvt4w7q9lnrw95mg9sr37yatxd9h",
         new Uint8Array([1, 2, 3]),
         pubKey.toBytes(),
-        signature,
+        new Uint8Array([...signature.r, ...signature.s]),
         "ethsecp256k1"
       )
     ).toThrow();
@@ -645,7 +653,10 @@ describe("Test ADR-36 Amino Sign Doc", () => {
         "eth",
         signDoc,
         pubKey.toBytes(),
-        signature.slice().map((b) => (Math.random() > 0.5 ? 0 : b)),
+        new Uint8Array([
+          ...signature.r.map((b) => (Math.random() > 0.5 ? 0 : b)),
+          ...signature.s.map((b) => (Math.random() > 0.5 ? 0 : b)),
+        ]),
         "ethsecp256k1"
       )
     ).toBe(false);
@@ -656,7 +667,7 @@ describe("Test ADR-36 Amino Sign Doc", () => {
         signer,
         new Uint8Array([1, 2]),
         pubKey.toBytes(),
-        signature,
+        new Uint8Array([...signature.r, ...signature.s]),
         "ethsecp256k1"
       )
     ).toBe(false);

--- a/packages/crypto/src/key.spec.ts
+++ b/packages/crypto/src/key.spec.ts
@@ -29,10 +29,13 @@ describe("Test priv key", () => {
 
     const data = new Uint8Array([1, 2, 3]);
     const signature = privKey.signDigest32(Hash.sha256(data));
-    expect(signature).toStrictEqual(privKey.sign(data));
 
-    expect(pubKey.verify(data, signature)).toBe(true);
-    expect(pubKey.verifyDigest32(Hash.sha256(data), signature)).toBe(true);
+    expect(
+      pubKey.verifyDigest32(
+        Hash.sha256(data),
+        new Uint8Array([...signature.r, ...signature.s])
+      )
+    ).toBe(true);
   });
 
   it("test assertions", () => {

--- a/packages/crypto/src/key.ts
+++ b/packages/crypto/src/key.ts
@@ -29,15 +29,11 @@ export class PrivKeySecp256k1 {
     );
   }
 
-  /**
-   * @deprecated Use `signDigest32(Hash.sha256(data))` instead.
-   * @param msg
-   */
-  sign(msg: Uint8Array): Uint8Array {
-    return this.signDigest32(Hash.sha256(msg));
-  }
-
-  signDigest32(digest: Uint8Array): Uint8Array {
+  signDigest32(digest: Uint8Array): {
+    readonly r: Uint8Array;
+    readonly s: Uint8Array;
+    readonly v: number | null;
+  } {
     if (digest.length !== 32) {
       throw new Error(`Invalid length of digest to sign: ${digest.length}`);
     }
@@ -49,9 +45,11 @@ export class PrivKeySecp256k1 {
       canonical: true,
     });
 
-    return new Uint8Array(
-      signature.r.toArray("be", 32).concat(signature.s.toArray("be", 32))
-    );
+    return {
+      r: new Uint8Array(signature.r.toArray("be", 32)),
+      s: new Uint8Array(signature.s.toArray("be", 32)),
+      v: signature.recoveryParam,
+    };
   }
 }
 
@@ -113,14 +111,6 @@ export class PubKeySecp256k1 {
       Buffer.from(this.pubKey).toString("hex"),
       "hex"
     );
-  }
-
-  /**
-   * @deprecated Use `verifyDigest32(Hash.sha256(data))` instead.
-   * @param msg
-   */
-  verify(msg: Uint8Array, signature: Uint8Array): boolean {
-    return this.verifyDigest32(Hash.sha256(msg), signature);
   }
 
   verifyDigest32(digest: Uint8Array, signature: Uint8Array): boolean {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -21,6 +21,7 @@
     "chromatic": "chromatic --project-token=${CHROMATIC_PROJECT_TOKEN}"
   },
   "dependencies": {
+    "@ethersproject/transactions": "^5.7.0",
     "@floating-ui/react": "^0.23.0",
     "@floating-ui/react-dom": "^1.3.0",
     "@keplr-wallet/analytics": "0.12.5",

--- a/packages/extension/src/index.tsx
+++ b/packages/extension/src/index.tsx
@@ -71,6 +71,7 @@ import { IBCTransferPage } from "./pages/ibc-transfer";
 import { SignCosmosICNSPage } from "./pages/sign/cosmos/icns";
 import { ErrorBoundary } from "./error-boundary";
 import { useMatchPopupSize } from "./popup-size";
+import { SignEthereumTxPage } from "./pages/sign/ethereum";
 
 configure({
   enforceActions: "always", // Make mobx to strict mode.
@@ -330,6 +331,7 @@ const RoutesAfterReady: FunctionComponent = observer(() => {
                 path="/sign-cosmos-icns"
                 element={<SignCosmosICNSPage />}
               />
+              <Route path="/sign-ethereum" element={<SignEthereumTxPage />} />
               <Route path="/wallet/select" element={<WalletSelectPage />} />
               <Route path="/wallet/delete" element={<WalletDeletePage />} />
               <Route

--- a/packages/extension/src/pages/sign/components/ledger-guide-box.tsx
+++ b/packages/extension/src/pages/sign/components/ledger-guide-box.tsx
@@ -7,17 +7,20 @@ import {
   ErrCodeDeviceLocked,
   ErrFailedGetPublicKey,
   ErrFailedInit,
-  ErrModule,
+  ErrModuleLedgerSign,
   ErrPublicKeyUnmatched,
   ErrSignRejected,
-} from "../utils/cosmos-ledger-sign";
-import { SignInteractionStore } from "@keplr-wallet/stores";
+} from "../utils/ledger-types";
+import { PlainObject } from "@keplr-wallet/background";
 
 export const LedgerGuideBox: FunctionComponent<{
-  interactionData: NonNullable<SignInteractionStore["waitingData"]>;
+  data: {
+    keyInsensitive: PlainObject;
+    isEthereum: boolean;
+  };
   isLedgerInteracting: boolean;
   ledgerInteractingError: Error | undefined;
-}> = ({ isLedgerInteracting, ledgerInteractingError, interactionData }) => {
+}> = ({ isLedgerInteracting, ledgerInteractingError, data }) => {
   return (
     <VerticalCollapseTransition
       collapsed={!isLedgerInteracting && ledgerInteractingError == null}
@@ -28,7 +31,7 @@ export const LedgerGuideBox: FunctionComponent<{
         if (ledgerInteractingError) {
           if (
             ledgerInteractingError instanceof KeplrError &&
-            ledgerInteractingError.module === ErrModule
+            ledgerInteractingError.module === ErrModuleLedgerSign
           ) {
             switch (ledgerInteractingError.code) {
               case ErrFailedInit:
@@ -50,7 +53,7 @@ export const LedgerGuideBox: FunctionComponent<{
               case ErrFailedGetPublicKey: {
                 let app = "Cosmos";
 
-                const appData = interactionData.data.keyInsensitive;
+                const appData = data.keyInsensitive;
                 if (!appData) {
                   throw new Error("Invalid ledger app data");
                 }
@@ -61,10 +64,7 @@ export const LedgerGuideBox: FunctionComponent<{
                   app = "Terra";
                 }
 
-                if (
-                  "eip712" in interactionData.data &&
-                  interactionData.data.eip712
-                ) {
+                if (data.isEthereum) {
                   if (appData["Ethereum"]) {
                     app = "Ethereum";
                   } else {

--- a/packages/extension/src/pages/sign/cosmos/adr36.tsx
+++ b/packages/extension/src/pages/sign/cosmos/adr36.tsx
@@ -13,7 +13,7 @@ import { ColorPalette } from "../../../styles";
 import { ViewDataButton } from "../components/view-data-button";
 import { handleCosmosPreSign } from "../utils/handle-cosmos-sign";
 import { KeplrError } from "@keplr-wallet/router";
-import { ErrModule } from "../utils/cosmos-ledger-sign";
+import { ErrModuleLedgerSign } from "../utils/ledger-types";
 import { LedgerGuideBox } from "../components/ledger-guide-box";
 import { GuideBox } from "../../../components/guide-box";
 
@@ -150,7 +150,7 @@ export const SignCosmosADR36Page: FunctionComponent = observer(() => {
               console.log(e);
 
               if (e instanceof KeplrError) {
-                if (e.module === ErrModule) {
+                if (e.module === ErrModuleLedgerSign) {
                   setLedgerInteractingError(e);
                 } else {
                   setLedgerInteractingError(undefined);
@@ -271,7 +271,13 @@ export const SignCosmosADR36Page: FunctionComponent = observer(() => {
 
         {signInteractionStore.waitingData ? (
           <LedgerGuideBox
-            interactionData={signInteractionStore.waitingData}
+            data={{
+              keyInsensitive:
+                signInteractionStore.waitingData.data.keyInsensitive,
+              isEthereum:
+                "eip712" in signInteractionStore.waitingData.data &&
+                signInteractionStore.waitingData.data.eip712 != null,
+            }}
             isLedgerInteracting={isLedgerInteracting}
             ledgerInteractingError={ledgerInteractingError}
           />

--- a/packages/extension/src/pages/sign/cosmos/tx/view.tsx
+++ b/packages/extension/src/pages/sign/cosmos/tx/view.tsx
@@ -30,7 +30,7 @@ import { defaultRegistry } from "../../components/messages/registry";
 import { useUnmount } from "../../../../hooks/use-unmount";
 import { handleCosmosPreSign } from "../../utils/handle-cosmos-sign";
 import { KeplrError } from "@keplr-wallet/router";
-import { ErrModule } from "../../utils/cosmos-ledger-sign";
+import { ErrModuleLedgerSign } from "../../utils/ledger-types";
 import { LedgerGuideBox } from "../../components/ledger-guide-box";
 import { Gutter } from "../../../../components/gutter";
 import { GuideBox } from "../../../../components/guide-box";
@@ -244,7 +244,7 @@ export const CosmosTxView: FunctionComponent<{
         console.log(e);
 
         if (e instanceof KeplrError) {
-          if (e.module === ErrModule) {
+          if (e.module === ErrModuleLedgerSign) {
             setLedgerInteractingError(e);
           } else {
             setLedgerInteractingError(undefined);
@@ -404,7 +404,12 @@ export const CosmosTxView: FunctionComponent<{
         ) : null}
 
         <LedgerGuideBox
-          interactionData={interactionData}
+          data={{
+            keyInsensitive: interactionData.data.keyInsensitive,
+            isEthereum:
+              "eip712" in interactionData.data &&
+              interactionData.data.eip712 != null,
+          }}
           isLedgerInteracting={isLedgerInteracting}
           ledgerInteractingError={ledgerInteractingError}
         />

--- a/packages/extension/src/pages/sign/ethereum/index.tsx
+++ b/packages/extension/src/pages/sign/ethereum/index.tsx
@@ -1,0 +1,1 @@
+export * from "./wrapper";

--- a/packages/extension/src/pages/sign/ethereum/view.tsx
+++ b/packages/extension/src/pages/sign/ethereum/view.tsx
@@ -1,0 +1,149 @@
+import React, { FunctionComponent, useState } from "react";
+import { SignEthereumInteractionStore } from "@keplr-wallet/stores";
+import { Box } from "../../../components/box";
+import { XAxis } from "../../../components/axis";
+import { Body2, Subtitle3 } from "../../../components/typography";
+import { ColorPalette } from "../../../styles";
+import { observer } from "mobx-react-lite";
+import { useStore } from "../../../stores";
+import { BackButton } from "../../../layouts/header/components";
+import { HeaderLayout } from "../../../layouts/header";
+import { useInteractionInfo } from "../../../hooks";
+import { KeplrError } from "@keplr-wallet/router";
+import { ErrModule } from "../utils/cosmos-ledger-sign";
+import { Buffer } from "buffer/";
+
+/**
+ * CosmosTxView의 주석을 꼭 참고하셈
+ * 이 View는 아직 실험적이고 임시로 구현한거임
+ * evmos에서 ADR-036 view랑 똑같이 구현해놔서 그게 마음에 안들어서 2.0에서 잠시 뺐다가
+ * 쓰는 사람들이 약간 있길래 최소한의 UI로 먼저 구현함
+ */
+export const EthereumSigningView: FunctionComponent<{
+  interactionData: NonNullable<SignEthereumInteractionStore["waitingData"]>;
+}> = observer(({ interactionData }) => {
+  const { chainStore, signEthereumInteractionStore } = useStore();
+
+  const interactionInfo = useInteractionInfo();
+
+  const [isLedgerInteracting, setIsLedgerInteracting] = useState(false);
+  const [ledgerInteractingError, setLedgerInteractingError] = useState<
+    Error | undefined
+  >(undefined);
+
+  return (
+    <HeaderLayout
+      title="Sign Ethereum"
+      fixedHeight={true}
+      left={
+        <BackButton
+          hidden={
+            interactionInfo.interaction && !interactionInfo.interactionInternal
+          }
+        />
+      }
+      bottomButton={{
+        text: "Approve",
+        color: "primary",
+        size: "large",
+        isLoading:
+          signEthereumInteractionStore.isObsoleteInteraction(
+            interactionData.id
+          ) || isLedgerInteracting,
+        onClick: async () => {
+          if (interactionData.data.keyType === "ledger") {
+            setIsLedgerInteracting(true);
+            setLedgerInteractingError(undefined);
+          }
+
+          try {
+            // const signature = await handleCosmosPreSign(
+            //   signInteractionStore.waitingData,
+            //   signDocWrapper
+            // );
+
+            await signEthereumInteractionStore.approveWithProceedNext(
+              interactionData.id,
+              undefined,
+              (proceedNext) => {
+                if (!proceedNext) {
+                  if (
+                    interactionInfo.interaction &&
+                    !interactionInfo.interactionInternal
+                  ) {
+                    window.close();
+                  }
+                }
+              }
+            );
+          } catch (e) {
+            console.log(e);
+
+            if (e instanceof KeplrError) {
+              if (e.module === ErrModule) {
+                setLedgerInteractingError(e);
+              } else {
+                setLedgerInteractingError(undefined);
+              }
+            } else {
+              setLedgerInteractingError(undefined);
+            }
+          } finally {
+            setIsLedgerInteracting(false);
+          }
+        },
+      }}
+    >
+      <Box
+        height="100%"
+        padding="0.75rem"
+        paddingTop="0.5rem"
+        paddingBottom="0"
+        style={{
+          overflow: "auto",
+        }}
+      >
+        <Box
+          height="13rem"
+          padding="1rem"
+          backgroundColor={ColorPalette["gray-600"]}
+          borderRadius="0.375rem"
+          style={{
+            overflow: "auto",
+          }}
+        >
+          <pre
+            style={{
+              color: ColorPalette["gray-10"],
+              // Remove normalized style of pre tag
+              margin: 0,
+            }}
+          >
+            {Buffer.from(interactionData.data.message).toString("hex")}
+          </pre>
+        </Box>
+
+        <div style={{ flex: 1 }} />
+        <Box
+          padding="1rem"
+          backgroundColor={ColorPalette["gray-600"]}
+          borderRadius="0.375rem"
+        >
+          <XAxis alignY="center">
+            <Body2 color={ColorPalette["gray-200"]}>Requested Network</Body2>
+            <div style={{ flex: 1 }} />
+            <Subtitle3 color={ColorPalette["gray-50"]}>
+              {chainStore.getChain(interactionData.data.chainId).chainName}
+            </Subtitle3>
+          </XAxis>
+        </Box>
+
+        {/*<LedgerGuideBox*/}
+        {/*  interactionData={signInteractionStore.waitingData}*/}
+        {/*  isLedgerInteracting={isLedgerInteracting}*/}
+        {/*  ledgerInteractingError={ledgerInteractingError}*/}
+        {/*/>*/}
+      </Box>
+    </HeaderLayout>
+  );
+});

--- a/packages/extension/src/pages/sign/ethereum/wrapper.tsx
+++ b/packages/extension/src/pages/sign/ethereum/wrapper.tsx
@@ -1,0 +1,27 @@
+import React, { FunctionComponent } from "react";
+import { observer } from "mobx-react-lite";
+import { useStore } from "../../../stores";
+import { useInteractionInfo } from "../../../hooks";
+import { EthereumSigningView } from "./view";
+import { Splash } from "../../../components/splash";
+
+export const SignEthereumTxPage: FunctionComponent = observer(() => {
+  const { signEthereumInteractionStore } = useStore();
+
+  useInteractionInfo(() => {
+    signEthereumInteractionStore.rejectAll();
+  });
+
+  return (
+    <React.Fragment>
+      {signEthereumInteractionStore.waitingData ? (
+        <EthereumSigningView
+          key={signEthereumInteractionStore.waitingData.id}
+          interactionData={signEthereumInteractionStore.waitingData}
+        />
+      ) : (
+        <Splash />
+      )}
+    </React.Fragment>
+  );
+});

--- a/packages/extension/src/pages/sign/utils/cosmos-ledger-sign.ts
+++ b/packages/extension/src/pages/sign/utils/cosmos-ledger-sign.ts
@@ -11,15 +11,16 @@ import { LedgerUtils } from "../../../utils";
 import Eth from "@ledgerhq/hw-app-eth";
 import { EIP712MessageValidator } from "@keplr-wallet/background";
 import { domainHash, messageHash } from "@keplr-wallet/background";
-
-export const ErrModule = "ledger-sign";
-export const ErrFailedInit = 1;
-export const ErrCodeUnsupportedApp = 2;
-export const ErrCodeDeviceLocked = 3;
-export const ErrFailedGetPublicKey = 4;
-export const ErrPublicKeyUnmatched = 5;
-export const ErrFailedSign = 6;
-export const ErrSignRejected = 7;
+import {
+  ErrModuleLedgerSign,
+  ErrFailedInit,
+  ErrCodeUnsupportedApp,
+  ErrCodeDeviceLocked,
+  ErrFailedGetPublicKey,
+  ErrPublicKeyUnmatched,
+  ErrFailedSign,
+  ErrSignRejected,
+} from "./ledger-types";
 
 export const connectAndSignEIP712WithLedger = async (
   expectedPubKey: Uint8Array,
@@ -39,7 +40,11 @@ export const connectAndSignEIP712WithLedger = async (
   try {
     transport = await TransportWebUSB.create();
   } catch (e) {
-    throw new KeplrError(ErrModule, ErrFailedInit, "Failed to init transport");
+    throw new KeplrError(
+      ErrModuleLedgerSign,
+      ErrFailedInit,
+      "Failed to init transport"
+    );
   }
 
   let ethApp = new Eth(transport);
@@ -52,7 +57,11 @@ export const connectAndSignEIP712WithLedger = async (
   } catch (e) {
     // Device is locked
     if (e?.message.includes("(0x6b0c)")) {
-      throw new KeplrError(ErrModule, ErrCodeDeviceLocked, "Device is locked");
+      throw new KeplrError(
+        ErrModuleLedgerSign,
+        ErrCodeDeviceLocked,
+        "Device is locked"
+      );
     } else if (
       // User is in home sceen or other app.
       e?.message.includes("(0x6511)") ||
@@ -79,7 +88,7 @@ export const connectAndSignEIP712WithLedger = async (
       pubKey = new PubKeySecp256k1(Buffer.from(res.publicKey, "hex"));
     } catch (e) {
       throw new KeplrError(
-        ErrModule,
+        ErrModuleLedgerSign,
         ErrFailedGetPublicKey,
         e.message || e.toString()
       );
@@ -91,7 +100,7 @@ export const connectAndSignEIP712WithLedger = async (
       ) !== Buffer.from(pubKey.toBytes()).toString("hex")
     ) {
       throw new KeplrError(
-        ErrModule,
+        ErrModuleLedgerSign,
         ErrPublicKeyUnmatched,
         "Public key unmatched"
       );
@@ -115,7 +124,11 @@ export const connectAndSignEIP712WithLedger = async (
     } catch (e) {
       console.log(e);
 
-      throw new KeplrError(ErrModule, ErrFailedSign, e.message || e.toString());
+      throw new KeplrError(
+        ErrModuleLedgerSign,
+        ErrFailedSign,
+        e.message || e.toString()
+      );
     }
 
     try {
@@ -130,13 +143,17 @@ export const connectAndSignEIP712WithLedger = async (
     } catch (e) {
       if (e?.message.includes("(0x6985)")) {
         throw new KeplrError(
-          ErrModule,
+          ErrModuleLedgerSign,
           ErrSignRejected,
           "User rejected signing"
         );
       }
 
-      throw new KeplrError(ErrModule, ErrFailedSign, e.message || e.toString());
+      throw new KeplrError(
+        ErrModuleLedgerSign,
+        ErrFailedSign,
+        e.message || e.toString()
+      );
     }
   } finally {
     await transport.close();
@@ -155,7 +172,7 @@ export const connectAndSignWithLedger = async (
 ): Promise<Uint8Array> => {
   if (propApp !== "Cosmos" && propApp !== "Terra") {
     throw new KeplrError(
-      ErrModule,
+      ErrModuleLedgerSign,
       ErrCodeUnsupportedApp,
       `Unsupported app: ${propApp}`
     );
@@ -165,14 +182,22 @@ export const connectAndSignWithLedger = async (
   try {
     transport = await TransportWebUSB.create();
   } catch (e) {
-    throw new KeplrError(ErrModule, ErrFailedInit, "Failed to init transport");
+    throw new KeplrError(
+      ErrModuleLedgerSign,
+      ErrFailedInit,
+      "Failed to init transport"
+    );
   }
   let app = new CosmosApp(propApp, transport);
 
   try {
     const version = await app.getVersion();
     if (version.device_locked) {
-      throw new KeplrError(ErrModule, ErrCodeDeviceLocked, "Device is locked");
+      throw new KeplrError(
+        ErrModuleLedgerSign,
+        ErrCodeDeviceLocked,
+        "Device is locked"
+      );
     }
   } catch (e) {
     await transport.close();
@@ -197,7 +222,7 @@ export const connectAndSignWithLedger = async (
         Buffer.from(expected.toBytes()).toString()
       ) {
         throw new KeplrError(
-          ErrModule,
+          ErrModuleLedgerSign,
           ErrPublicKeyUnmatched,
           "Public key unmatched"
         );
@@ -214,20 +239,24 @@ export const connectAndSignWithLedger = async (
       } else {
         if (signResponse.error_message === "Transaction rejected") {
           throw new KeplrError(
-            ErrModule,
+            ErrModuleLedgerSign,
             ErrSignRejected,
             signResponse.error_message
           );
         }
 
         throw new KeplrError(
-          ErrModule,
+          ErrModuleLedgerSign,
           ErrFailedSign,
           signResponse.error_message
         );
       }
     } else {
-      throw new KeplrError(ErrModule, ErrFailedGetPublicKey, res.error_message);
+      throw new KeplrError(
+        ErrModuleLedgerSign,
+        ErrFailedGetPublicKey,
+        res.error_message
+      );
     }
   } finally {
     await transport.close();

--- a/packages/extension/src/pages/sign/utils/handle-eth-sign.ts
+++ b/packages/extension/src/pages/sign/utils/handle-eth-sign.ts
@@ -1,0 +1,235 @@
+import { Buffer } from "buffer/";
+import { SignEthereumInteractionStore } from "@keplr-wallet/stores";
+import { EthSignType } from "@keplr-wallet/types";
+import Transport from "@ledgerhq/hw-transport";
+import TransportWebUSB from "@ledgerhq/hw-transport-webusb";
+import { KeplrError } from "@keplr-wallet/router";
+import {
+  ErrCodeDeviceLocked,
+  ErrFailedGetPublicKey,
+  ErrFailedInit,
+  ErrFailedSign,
+  ErrModuleLedgerSign,
+  ErrPublicKeyUnmatched,
+  ErrSignRejected,
+} from "./ledger-types";
+import Eth from "@ledgerhq/hw-app-eth";
+import { LedgerUtils } from "../../../utils";
+import { PubKeySecp256k1 } from "@keplr-wallet/crypto";
+import {
+  domainHash,
+  EIP712MessageValidator,
+  messageHash,
+} from "@keplr-wallet/background";
+import { serialize } from "@ethersproject/transactions";
+
+export const handleEthereumPreSign = async (
+  interactionData: NonNullable<SignEthereumInteractionStore["waitingData"]>
+): Promise<Uint8Array | undefined> => {
+  switch (interactionData.data.keyType) {
+    case "ledger": {
+      const appData = interactionData.data.keyInsensitive;
+      if (!appData) {
+        throw new Error("Invalid ledger app data");
+      }
+      if (typeof appData !== "object") {
+        throw new Error("Invalid ledger app data");
+      }
+      if (!appData["bip44Path"] || typeof appData["bip44Path"] !== "object") {
+        throw new Error("Invalid ledger app data");
+      }
+
+      const bip44Path = appData["bip44Path"] as {
+        account: number;
+        change: number;
+        addressIndex: number;
+      };
+
+      const publicKey = Buffer.from(
+        (appData["Ethereum"] as any)["pubKey"],
+        "hex"
+      );
+      if (publicKey.length === 0) {
+        throw new Error("Invalid ledger app data");
+      }
+
+      return connectAndSignEthWithLedger(
+        publicKey,
+        bip44Path,
+        interactionData.data.message,
+        interactionData.data.signType
+      );
+    }
+    default:
+      return;
+  }
+};
+
+export const connectAndSignEthWithLedger = async (
+  expectedPubKey: Uint8Array,
+  bip44Path: {
+    account: number;
+    change: number;
+    addressIndex: number;
+  },
+  message: Uint8Array,
+  signType: EthSignType
+): Promise<Uint8Array> => {
+  let transport: Transport;
+  try {
+    transport = await TransportWebUSB.create();
+  } catch (e) {
+    throw new KeplrError(
+      ErrModuleLedgerSign,
+      ErrFailedInit,
+      "Failed to init transport"
+    );
+  }
+
+  let ethApp = new Eth(transport);
+
+  // Ensure that the keplr can connect to ethereum app on ledger.
+  // getAppConfiguration() works even if the ledger is on screen saver mode.
+  // To detect the screen saver mode, we should request the address before using.
+  try {
+    await ethApp.getAddress(`m/44'/60'/'0/0/0`);
+  } catch (e) {
+    // Device is locked
+    if (e?.message.includes("(0x6b0c)")) {
+      throw new KeplrError(
+        ErrModuleLedgerSign,
+        ErrCodeDeviceLocked,
+        "Device is locked"
+      );
+    } else if (
+      // User is in home sceen or other app.
+      e?.message.includes("(0x6511)") ||
+      e?.message.includes("(0x6e00)")
+    ) {
+      // Do nothing
+    } else {
+      await transport.close();
+
+      throw e;
+    }
+  }
+
+  transport = await LedgerUtils.tryAppOpen(transport, "Ethereum");
+  ethApp = new Eth(transport);
+
+  try {
+    let pubKey: PubKeySecp256k1;
+    try {
+      const res = await ethApp.getAddress(
+        `m/44'/60'/${bip44Path.account}'/${bip44Path.change}/${bip44Path.addressIndex}`
+      );
+
+      pubKey = new PubKeySecp256k1(Buffer.from(res.publicKey, "hex"));
+    } catch (e) {
+      throw new KeplrError(
+        ErrModuleLedgerSign,
+        ErrFailedGetPublicKey,
+        e.message || e.toString()
+      );
+    }
+
+    if (
+      Buffer.from(new PubKeySecp256k1(expectedPubKey).toBytes()).toString(
+        "hex"
+      ) !== Buffer.from(pubKey.toBytes()).toString("hex")
+    ) {
+      throw new KeplrError(
+        ErrModuleLedgerSign,
+        ErrPublicKeyUnmatched,
+        "Public key unmatched"
+      );
+    }
+
+    if (signType === EthSignType.EIP712) {
+      // Pre validate the eip712 message to separate the error case.
+      await EIP712MessageValidator.validateAsync(
+        JSON.parse(Buffer.from(message).toString())
+      );
+    }
+
+    try {
+      switch (signType) {
+        case EthSignType.MESSAGE: {
+          return ethSignatureToBytes(
+            await ethApp.signPersonalMessage(
+              `m/44'/60'/${bip44Path.account}'/${bip44Path.change}/${bip44Path.addressIndex}`,
+              Buffer.from(message).toString("hex")
+            )
+          );
+        }
+        case EthSignType.TRANSACTION: {
+          const tx = JSON.parse(Buffer.from(message).toString());
+          const rlpArray = serialize(tx).replace("0x", "");
+          return ethSignatureToBytes(
+            await ethApp.signTransaction(
+              `m/44'/60'/${bip44Path.account}'/${bip44Path.change}/${bip44Path.addressIndex}`,
+              rlpArray
+            )
+          );
+        }
+        case EthSignType.EIP712: {
+          const data = await EIP712MessageValidator.validateAsync(
+            JSON.parse(Buffer.from(message).toString())
+          );
+
+          // Unfortunately, signEIP712Message not works on ledger yet.
+          return ethSignatureToBytes(
+            await ethApp.signEIP712HashedMessage(
+              `m/44'/60'/${bip44Path.account}'/${bip44Path.change}/${bip44Path.addressIndex}`,
+              domainHash(data),
+              messageHash(data)
+            )
+          );
+        }
+        default:
+          throw new Error("Invalid sign type");
+      }
+    } catch (e) {
+      if (e?.message.includes("(0x6985)")) {
+        throw new KeplrError(
+          ErrModuleLedgerSign,
+          ErrSignRejected,
+          "User rejected signing"
+        );
+      }
+
+      throw new KeplrError(
+        ErrModuleLedgerSign,
+        ErrFailedSign,
+        e.message || e.toString()
+      );
+    }
+  } finally {
+    await transport.close();
+  }
+};
+
+function ethSignatureToBytes(signature: {
+  v: number | string;
+  r: string;
+  s: string;
+}): Uint8Array {
+  // Validate signature.r is hex encoded
+  const r = Buffer.from(signature.r, "hex");
+  // Validate signature.s is hex encoded
+  const s = Buffer.from(signature.s, "hex");
+
+  // Must be 32 bytes
+  if (r.length !== 32 || s.length !== 32) {
+    throw new Error("Unable to process signature: malformed fields");
+  }
+
+  const v =
+    typeof signature.v === "string" ? parseInt(signature.v, 16) : signature.v;
+
+  if (!Number.isInteger(v)) {
+    throw new Error("Unable to process signature: malformed fields");
+  }
+
+  return Buffer.concat([r, s, Buffer.from([v])]);
+}

--- a/packages/extension/src/pages/sign/utils/ledger-types.ts
+++ b/packages/extension/src/pages/sign/utils/ledger-types.ts
@@ -1,0 +1,8 @@
+export const ErrModuleLedgerSign = "ledger-sign";
+export const ErrFailedInit = 1;
+export const ErrCodeUnsupportedApp = 2;
+export const ErrCodeDeviceLocked = 3;
+export const ErrFailedGetPublicKey = 4;
+export const ErrPublicKeyUnmatched = 5;
+export const ErrFailedSign = 6;
+export const ErrSignRejected = 7;

--- a/packages/extension/src/stores/root.tsx
+++ b/packages/extension/src/stores/root.tsx
@@ -31,6 +31,7 @@ import {
   ICNSInteractionStore,
   ICNSQueries,
   PermissionManagerStore,
+  SignEthereumInteractionStore,
 } from "@keplr-wallet/stores";
 import {
   KeplrETCQueries,
@@ -66,6 +67,7 @@ export class RootStore {
   public readonly interactionStore: InteractionStore;
   public readonly permissionStore: PermissionStore;
   public readonly signInteractionStore: SignInteractionStore;
+  public readonly signEthereumInteractionStore: SignEthereumInteractionStore;
   public readonly chainSuggestStore: ChainSuggestStore;
   public readonly icnsInteractionStore: ICNSInteractionStore;
 
@@ -154,6 +156,9 @@ export class RootStore {
       new InExtensionMessageRequester()
     );
     this.signInteractionStore = new SignInteractionStore(this.interactionStore);
+    this.signEthereumInteractionStore = new SignEthereumInteractionStore(
+      this.interactionStore
+    );
     this.chainSuggestStore = new ChainSuggestStore(
       this.interactionStore,
       CommunityChainInfoRepo

--- a/packages/provider/src/core.ts
+++ b/packages/provider/src/core.ts
@@ -290,12 +290,23 @@ export class Keplr implements IKeplr, KeplrCoreTypes {
   }
 
   async signEthereum(
-    _chainId: string,
-    _signer: string,
-    _data: string | Uint8Array,
-    _type: EthSignType
+    chainId: string,
+    signer: string,
+    message: Uint8Array,
+    signType: EthSignType
   ): Promise<Uint8Array> {
-    throw new Error("TODO");
+    return await sendSimpleMessage(
+      this.requester,
+      BACKGROUND_PORT,
+      "keyring-ethereum",
+      "request-sign-ethereum",
+      {
+        chainId,
+        signer,
+        message,
+        signType,
+      }
+    );
   }
 
   async signICNSAdr36(

--- a/packages/stores/src/core/interaction/eth-sign.ts
+++ b/packages/stores/src/core/interaction/eth-sign.ts
@@ -1,0 +1,70 @@
+import { InteractionStore } from "./interaction";
+import { computed, makeObservable } from "mobx";
+import { EthSignType } from "@keplr-wallet/types";
+import { PlainObject } from "@keplr-wallet/background";
+
+export type SignEthereumInteractionData = {
+  origin: string;
+  chainId: string;
+  signer: string;
+  message: Uint8Array;
+  signType: EthSignType;
+  keyType: string;
+  keyInsensitive: PlainObject;
+};
+
+export class SignEthereumInteractionStore {
+  constructor(protected readonly interactionStore: InteractionStore) {
+    makeObservable(this);
+  }
+
+  get waitingDatas() {
+    return this.interactionStore.getAllData<SignEthereumInteractionData>(
+      "request-sign-ethereum"
+    );
+  }
+
+  @computed
+  get waitingData() {
+    const datas = this.waitingDatas;
+
+    if (datas.length === 0) {
+      return undefined;
+    }
+
+    return datas[0];
+  }
+
+  async approveWithProceedNext(
+    id: string,
+    signature: Uint8Array | undefined,
+    afterFn: (proceedNext: boolean) => void | Promise<void>,
+    options: {
+      preDelay?: number;
+    } = {}
+  ) {
+    await this.interactionStore.approveWithProceedNextV2(
+      id,
+      {
+        signature,
+      },
+      afterFn,
+      options
+    );
+  }
+
+  async rejectWithProceedNext(
+    id: string,
+    afterFn: (proceedNext: boolean) => void | Promise<void>
+  ) {
+    await this.interactionStore.rejectWithProceedNext(id, afterFn);
+  }
+
+  async rejectAll() {
+    await this.interactionStore.rejectAll("request-sign-cosmos");
+  }
+
+  isObsoleteInteraction(id: string | undefined): boolean {
+    return this.interactionStore.isObsoleteInteraction(id);
+  }
+}

--- a/packages/stores/src/core/interaction/index.ts
+++ b/packages/stores/src/core/interaction/index.ts
@@ -3,3 +3,4 @@ export * from "./permission";
 export * from "./sign";
 export * from "./chain-suggest";
 export * from "./icns";
+export * from "./eth-sign";

--- a/yarn.lock
+++ b/yarn.lock
@@ -5152,6 +5152,7 @@ __metadata:
   resolution: "@keplr-wallet/extension@workspace:packages/extension"
   dependencies:
     "@babel/core": ^7.19.3
+    "@ethersproject/transactions": ^5.7.0
     "@floating-ui/react": ^0.23.0
     "@floating-ui/react-dom": ^1.3.0
     "@keplr-wallet/analytics": 0.12.5

--- a/yarn.lock
+++ b/yarn.lock
@@ -4044,16 +4044,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/basex@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/basex@npm:5.7.0"
-  dependencies:
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-  checksum: 326087b7e1f3787b5fe6cd1cf2b4b5abfafbc355a45e88e22e5e9d6c845b613ffc5301d629b28d5c4d5e2bfe9ec424e6782c804956dff79be05f0098cb5817de
-  languageName: node
-  linkType: hard
-
 "@ethersproject/bignumber@npm:^5.6.0":
   version: 5.6.0
   resolution: "@ethersproject/bignumber@npm:5.6.0"
@@ -4154,47 +4144,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/hdnode@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/hdnode@npm:5.7.0"
-  dependencies:
-    "@ethersproject/abstract-signer": ^5.7.0
-    "@ethersproject/basex": ^5.7.0
-    "@ethersproject/bignumber": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/pbkdf2": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-    "@ethersproject/sha2": ^5.7.0
-    "@ethersproject/signing-key": ^5.7.0
-    "@ethersproject/strings": ^5.7.0
-    "@ethersproject/transactions": ^5.7.0
-    "@ethersproject/wordlists": ^5.7.0
-  checksum: bfe5ca2d89a42de73655f853170ef4766b933c5f481cddad709b3aca18823275b096e572f92d1602a052f80b426edde44ad6b9d028799775a7dad4a5bbed2133
-  languageName: node
-  linkType: hard
-
-"@ethersproject/json-wallets@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/json-wallets@npm:5.7.0"
-  dependencies:
-    "@ethersproject/abstract-signer": ^5.7.0
-    "@ethersproject/address": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/hdnode": ^5.7.0
-    "@ethersproject/keccak256": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/pbkdf2": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-    "@ethersproject/random": ^5.7.0
-    "@ethersproject/strings": ^5.7.0
-    "@ethersproject/transactions": ^5.7.0
-    aes-js: 3.0.0
-    scrypt-js: 3.0.1
-  checksum: f583458d22db62efaaf94d38dd243482776a45bf90f9f3882fbad5aa0b8fd288b41eb7c1ff8ec0b99c9b751088e43d6173530db64dd33c59f9d8daa8d7ad5aa2
-  languageName: node
-  linkType: hard
-
 "@ethersproject/keccak256@npm:^5.5.0":
   version: 5.5.0
   resolution: "@ethersproject/keccak256@npm:5.5.0"
@@ -4264,16 +4213,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/pbkdf2@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/pbkdf2@npm:5.7.0"
-  dependencies:
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/sha2": ^5.7.0
-  checksum: b895adb9e35a8a127e794f7aadc31a2424ef355a70e51cde10d457e3e888bb8102373199a540cf61f2d6b9a32e47358f9c65b47d559f42bf8e596b5fd67901e9
-  languageName: node
-  linkType: hard
-
 "@ethersproject/properties@npm:^5.6.0":
   version: 5.6.0
   resolution: "@ethersproject/properties@npm:5.6.0"
@@ -4289,16 +4228,6 @@ __metadata:
   dependencies:
     "@ethersproject/logger": ^5.7.0
   checksum: 6ab0ccf0c3aadc9221e0cdc5306ce6cd0df7f89f77d77bccdd1277182c9ead0202cd7521329ba3acde130820bf8af299e17cf567d0d497c736ee918207bbf59f
-  languageName: node
-  linkType: hard
-
-"@ethersproject/random@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/random@npm:5.7.0"
-  dependencies:
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-  checksum: 017829c91cff6c76470852855108115b0b52c611b6be817ed1948d56ba42d6677803ec2012aa5ae298a7660024156a64c11fcf544e235e239ab3f89f0fff7345
   languageName: node
   linkType: hard
 
@@ -4329,17 +4258,6 @@ __metadata:
     "@ethersproject/bytes": ^5.7.0
     "@ethersproject/logger": ^5.7.0
   checksum: bce165b0f7e68e4d091c9d3cf47b247cac33252df77a095ca4281d32d5eeaaa3695d9bc06b2b057c5015353a68df89f13a4a54a72e888e4beeabbe56b15dda6e
-  languageName: node
-  linkType: hard
-
-"@ethersproject/sha2@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/sha2@npm:5.7.0"
-  dependencies:
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    hash.js: 1.1.7
-  checksum: 09321057c022effbff4cc2d9b9558228690b5dd916329d75c4b1ffe32ba3d24b480a367a7cc92d0f0c0b1c896814d03351ae4630e2f1f7160be2bcfbde435dbc
   languageName: node
   linkType: hard
 
@@ -4427,29 +4345,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/wallet@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/wallet@npm:5.7.0"
-  dependencies:
-    "@ethersproject/abstract-provider": ^5.7.0
-    "@ethersproject/abstract-signer": ^5.7.0
-    "@ethersproject/address": ^5.7.0
-    "@ethersproject/bignumber": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/hash": ^5.7.0
-    "@ethersproject/hdnode": ^5.7.0
-    "@ethersproject/json-wallets": ^5.7.0
-    "@ethersproject/keccak256": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-    "@ethersproject/random": ^5.7.0
-    "@ethersproject/signing-key": ^5.7.0
-    "@ethersproject/transactions": ^5.7.0
-    "@ethersproject/wordlists": ^5.7.0
-  checksum: a4009bf7331eddab38e3015b5e9101ef92de7f705b00a6196b997db0e5635b6d83561674d46c90c6f77b87c0500fe4a6b0183ba13749efc22db59c99deb82fbd
-  languageName: node
-  linkType: hard
-
 "@ethersproject/web@npm:^5.6.0":
   version: 5.6.0
   resolution: "@ethersproject/web@npm:5.6.0"
@@ -4473,19 +4368,6 @@ __metadata:
     "@ethersproject/properties": ^5.7.0
     "@ethersproject/strings": ^5.7.0
   checksum: 9d4ca82f8b1295bbc1c59d58cb351641802d2f70f4b7d523fc726f51b0615296da6d6585dee5749b4d5e4a6a9af6d6650d46fe562d5b04f43a0af5c7f7f4a77e
-  languageName: node
-  linkType: hard
-
-"@ethersproject/wordlists@npm:^5.7.0":
-  version: 5.7.0
-  resolution: "@ethersproject/wordlists@npm:5.7.0"
-  dependencies:
-    "@ethersproject/bytes": ^5.7.0
-    "@ethersproject/hash": ^5.7.0
-    "@ethersproject/logger": ^5.7.0
-    "@ethersproject/properties": ^5.7.0
-    "@ethersproject/strings": ^5.7.0
-  checksum: 30eb6eb0731f9ef5faa44bf9c0c6e950bcaaef61e4d2d9ce0ae6d341f4e2d6d1f4ab4f8880bfce03b7aac4b862fb740e1421170cfbf8e2aafc359277d49e6e97
   languageName: node
   linkType: hard
 
@@ -5161,11 +5043,8 @@ __metadata:
   dependencies:
     "@ethereumjs/common": ^2.6.5
     "@ethereumjs/tx": ^3.5.2
-    "@ethersproject/bignumber": ^5.7.0
-    "@ethersproject/bytes": ^5.7.0
     "@ethersproject/hash": ^5.7.0
     "@ethersproject/transactions": ^5.7.0
-    "@ethersproject/wallet": ^5.7.0
     "@keplr-wallet/chain-validator": 0.12.5
     "@keplr-wallet/common": 0.12.5
     "@keplr-wallet/cosmos": 0.12.5
@@ -10619,13 +10498,6 @@ __metadata:
   version: 1.2.1
   resolution: "address@npm:1.2.1"
   checksum: e4c0f961464ccad09c3f7ed3a8d12f609354a87dd1ad379e43661e9684446fbf158be3edeef85e1590dfc6c88c0897c5908bc18f232eb86e43993a2ada5820fa
-  languageName: node
-  linkType: hard
-
-"aes-js@npm:3.0.0":
-  version: 3.0.0
-  resolution: "aes-js@npm:3.0.0"
-  checksum: 251e26d533cd1a915b44896b17d5ed68c24a02484cfdd2e74ec700a309267db96651ea4eb657bf20aac32a3baa61f6e34edf8e2fec2de440a655da9942d334b8
   languageName: node
   linkType: hard
 
@@ -28198,7 +28070,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scrypt-js@npm:3.0.1, scrypt-js@npm:^3.0.0, scrypt-js@npm:^3.0.1":
+"scrypt-js@npm:^3.0.0, scrypt-js@npm:^3.0.1":
   version: 3.0.1
   resolution: "scrypt-js@npm:3.0.1"
   checksum: b7c7d1a68d6ca946f2fbb0778e0c4ec63c65501b54023b2af7d7e9f48fdb6c6580d6f7675cd53bda5944c5ebc057560d5a6365079752546865defb3b79dea454


### PR DESCRIPTION
#736

BREAKING CHANGE: When EthSignType.TRANSACTION, it returned signed tx. However, since all other sign types return signature, it has been changed to return signature rather than signed tx to ensure the same usability as other sign types.