### PR TITLE
ibc go v7 hot fix

### DIFF
--- a/packages/chain-validator/src/feature.ts
+++ b/packages/chain-validator/src/feature.ts
@@ -18,6 +18,7 @@ export const SupportedChainFeatures = [
   "axelar-evm-bridge",
   "osmosis-txfees",
   "terra-classic-fee",
+  "ibc-go-v7-hot-fix",
 ];
 
 /**

--- a/packages/stores/package.json
+++ b/packages/stores/package.json
@@ -31,6 +31,7 @@
     "buffer": "^6.0.3",
     "deepmerge": "^4.2.2",
     "eventemitter3": "^4.0.7",
+    "long": "^4.0.0",
     "mobx": "^6.1.7",
     "mobx-utils": "^6.0.3",
     "p-queue": "^6.6.2",

--- a/packages/stores/src/account/cosmos.ts
+++ b/packages/stores/src/account/cosmos.ts
@@ -1038,8 +1038,20 @@ export class CosmosAccountImpl {
           delete msg.value.timeout_timestamp;
         }
 
+        const forceDirectSign = (() => {
+          if (!this.base.isNanoLedger) {
+            if (
+              this.chainId.startsWith("injective") ||
+              this.chainId.startsWith("stride")
+            ) {
+              return true;
+            }
+          }
+          return false;
+        })();
+
         return {
-          aminoMsgs: [msg],
+          aminoMsgs: forceDirectSign ? undefined : [msg],
           protoMsgs: [
             {
               typeUrl: "/ibc.applications.transfer.v1.MsgTransfer",

--- a/packages/stores/src/account/cosmos.ts
+++ b/packages/stores/src/account/cosmos.ts
@@ -1042,7 +1042,10 @@ export class CosmosAccountImpl {
           if (!this.base.isNanoLedger) {
             if (
               this.chainId.startsWith("injective") ||
-              this.chainId.startsWith("stride")
+              this.chainId.startsWith("stride") ||
+              this.chainGetter
+                .getChain(this.chainId)
+                .hasFeature("ibc-go-v7-hot-fix")
             ) {
               return true;
             }

--- a/packages/stores/src/account/cosmos.ts
+++ b/packages/stores/src/account/cosmos.ts
@@ -4,8 +4,10 @@ import {
   AppCurrency,
   BroadcastMode,
   Coin,
+  Keplr,
   KeplrSignOptions,
   Msg,
+  SignDoc,
   StdFee,
   StdSignDoc,
 } from "@keplr-wallet/types";
@@ -56,6 +58,7 @@ import {
 import { ExtensionOptionsWeb3Tx } from "@keplr-wallet/proto-types/ethermint/types/v1/web3";
 import { MsgRevoke } from "@keplr-wallet/proto-types/cosmos/authz/v1beta1/tx";
 import { simpleFetch } from "@keplr-wallet/simple-fetch";
+import Long from "long";
 
 export interface CosmosAccount {
   cosmos: CosmosAccountImpl;
@@ -277,7 +280,7 @@ export class CosmosAccountImpl {
     this.base.setTxTypeInProgress(type);
 
     let txHash: Uint8Array;
-    let signDoc: StdSignDoc;
+    let signDoc: StdSignDoc | SignDoc;
     try {
       if (typeof msgs === "function") {
         msgs = await msgs();
@@ -336,12 +339,20 @@ export class CosmosAccountImpl {
       this.base.setTxTypeInProgress("");
 
       // After sending tx, the balances is probably changed due to the fee.
-      for (const feeAmount of signDoc.fee.amount) {
+      const feeDenoms: string[] = (() => {
+        if ("fee" in signDoc) {
+          return signDoc.fee.amount.map((amount) => amount.denom);
+        } else if ("authInfoBytes" in signDoc) {
+          const authInfo = AuthInfo.decode(signDoc.authInfoBytes);
+          return authInfo.fee?.amount.map((amount) => amount.denom) ?? [];
+        } else {
+          return [];
+        }
+      })();
+      for (const feeDenom of feeDenoms) {
         const bal = this.queries.queryBalances
           .getQueryBech32Address(this.base.bech32Address)
-          .balances.find(
-            (bal) => bal.currency.coinMinimalDenom === feeAmount.denom
-          );
+          .balances.find((bal) => bal.currency.coinMinimalDenom === feeDenom);
 
         if (bal) {
           bal.fetch();
@@ -371,22 +382,25 @@ export class CosmosAccountImpl {
     signOptions?: KeplrSignOptionsWithAltSignMethods
   ): Promise<{
     txHash: Uint8Array;
-    signDoc: StdSignDoc;
+    signDoc: StdSignDoc | SignDoc;
   }> {
     if (this.base.walletStatus !== WalletStatus.Loaded) {
       throw new Error(`Wallet is not loaded: ${this.base.walletStatus}`);
     }
 
-    const aminoMsgs: Msg[] = msgs.aminoMsgs;
+    const isDirectSign = !msgs.aminoMsgs || msgs.aminoMsgs.length === 0;
+
+    const aminoMsgs: Msg[] = msgs.aminoMsgs || [];
     const protoMsgs: Any[] = msgs.protoMsgs;
 
-    // TODO: Make proto sign doc if `aminoMsgs` is empty or null
-    if (aminoMsgs.length === 0 || protoMsgs.length === 0) {
+    if (protoMsgs.length === 0) {
       throw new Error("There is no msg to send");
     }
 
-    if (aminoMsgs.length !== protoMsgs.length) {
-      throw new Error("The length of aminoMsgs and protoMsgs are different");
+    if (!isDirectSign) {
+      if (aminoMsgs.length !== protoMsgs.length) {
+        throw new Error("The length of aminoMsgs and protoMsgs are different");
+      }
     }
 
     const account = await BaseAccount.fetchFromRest(
@@ -409,156 +423,176 @@ export class CosmosAccountImpl {
       );
     }
 
+    if (eip712Signing && isDirectSign) {
+      throw new Error("EIP712 signing is not supported for proto signing");
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const keplr = (await this.base.getKeplr())!;
 
-    const signDocRaw: StdSignDoc = {
-      chain_id: this.chainId,
-      account_number: account.getAccountNumber().toString(),
-      sequence: account.getSequence().toString(),
-      fee: fee,
-      msgs: aminoMsgs,
-      memo: escapeHTML(memo),
-    };
-
-    const chainIsInjective = this.chainId.startsWith("injective");
-
-    if (eip712Signing) {
-      if (chainIsInjective) {
-        // Due to injective's problem, it should exist if injective with ledger.
-        // There is currently no effective way to handle this in keplr. Just set a very large number.
-        (signDocRaw as Mutable<StdSignDoc>).timeout_height =
-          Number.MAX_SAFE_INTEGER.toString();
-      } else {
-        // If not injective (evmos), they require fee payer.
-        // XXX: "feePayer" should be "payer". But, it maybe from ethermint team's mistake.
-        //      That means this part is not standard.
-        (signDocRaw as Mutable<StdSignDoc>).fee = {
-          ...signDocRaw.fee,
-          feePayer: this.base.bech32Address,
-        };
-      }
-    }
-
-    const signDoc = sortObjectByKey(signDocRaw);
-
-    // Should use bind to avoid "this" problem
-    let signAmino = keplr.signAmino.bind(keplr);
-    if (signOptions?.signAmino) {
-      signAmino = signOptions.signAmino;
-    }
-
-    // Should use bind to avoid "this" problem
-    let experimentalSignEIP712CosmosTx_v0 =
-      keplr.experimentalSignEIP712CosmosTx_v0.bind(keplr);
-    if (signOptions?.experimentalSignEIP712CosmosTx_v0) {
-      experimentalSignEIP712CosmosTx_v0 =
-        signOptions.experimentalSignEIP712CosmosTx_v0;
-    }
-
-    const signResponse: AminoSignResponse = await (async () => {
-      if (!eip712Signing) {
-        return await signAmino(
-          this.chainId,
-          this.base.bech32Address,
-          signDoc,
+    const signedTx = await (async () => {
+      if (isDirectSign) {
+        return await this.createSignedTxWithDirectSign(
+          keplr,
+          account,
+          msgs.protoMsgs,
+          fee,
+          memo,
           signOptions
         );
-      }
+      } else {
+        const signDocRaw: StdSignDoc = {
+          chain_id: this.chainId,
+          account_number: account.getAccountNumber().toString(),
+          sequence: account.getSequence().toString(),
+          fee: fee,
+          msgs: aminoMsgs,
+          memo: escapeHTML(memo),
+        };
 
-      return await experimentalSignEIP712CosmosTx_v0(
-        this.chainId,
-        this.base.bech32Address,
-        getEip712TypedDataBasedOnChainId(this.chainId, msgs),
-        signDoc,
-        signOptions
-      );
-    })();
+        const chainIsInjective = this.chainId.startsWith("injective");
 
-    const signedTx = TxRaw.encode({
-      bodyBytes: TxBody.encode(
-        TxBody.fromPartial({
-          messages: protoMsgs,
-          timeoutHeight: signResponse.signed.timeout_height,
-          memo: signResponse.signed.memo,
-          extensionOptions: eip712Signing
-            ? [
+        if (eip712Signing) {
+          if (chainIsInjective) {
+            // Due to injective's problem, it should exist if injective with ledger.
+            // There is currently no effective way to handle this in keplr. Just set a very large number.
+            (signDocRaw as Mutable<StdSignDoc>).timeout_height =
+              Number.MAX_SAFE_INTEGER.toString();
+          } else {
+            // If not injective (evmos), they require fee payer.
+            // XXX: "feePayer" should be "payer". But, it maybe from ethermint team's mistake.
+            //      That means this part is not standard.
+            (signDocRaw as Mutable<StdSignDoc>).fee = {
+              ...signDocRaw.fee,
+              feePayer: this.base.bech32Address,
+            };
+          }
+        }
+
+        const signDoc = sortObjectByKey(signDocRaw);
+
+        // Should use bind to avoid "this" problem
+        let signAmino = keplr.signAmino.bind(keplr);
+        if (signOptions?.signAmino) {
+          signAmino = signOptions.signAmino;
+        }
+
+        // Should use bind to avoid "this" problem
+        let experimentalSignEIP712CosmosTx_v0 =
+          keplr.experimentalSignEIP712CosmosTx_v0.bind(keplr);
+        if (signOptions?.experimentalSignEIP712CosmosTx_v0) {
+          experimentalSignEIP712CosmosTx_v0 =
+            signOptions.experimentalSignEIP712CosmosTx_v0;
+        }
+
+        const signResponse: AminoSignResponse = await (async () => {
+          if (!eip712Signing) {
+            return await signAmino(
+              this.chainId,
+              this.base.bech32Address,
+              signDoc,
+              signOptions
+            );
+          }
+
+          return await experimentalSignEIP712CosmosTx_v0(
+            this.chainId,
+            this.base.bech32Address,
+            getEip712TypedDataBasedOnChainId(this.chainId, msgs),
+            signDoc,
+            signOptions
+          );
+        })();
+
+        return {
+          tx: TxRaw.encode({
+            bodyBytes: TxBody.encode(
+              TxBody.fromPartial({
+                messages: protoMsgs,
+                timeoutHeight: signResponse.signed.timeout_height,
+                memo: signResponse.signed.memo,
+                extensionOptions: eip712Signing
+                  ? [
+                      {
+                        typeUrl: (() => {
+                          if (chainIsInjective) {
+                            return "/injective.types.v1beta1.ExtensionOptionsWeb3Tx";
+                          }
+
+                          return "/ethermint.types.v1.ExtensionOptionsWeb3Tx";
+                        })(),
+                        value: ExtensionOptionsWeb3Tx.encode(
+                          ExtensionOptionsWeb3Tx.fromPartial({
+                            typedDataChainId: EthermintChainIdHelper.parse(
+                              this.chainId
+                            ).ethChainId.toString(),
+                            feePayer: !chainIsInjective
+                              ? signResponse.signed.fee.feePayer
+                              : undefined,
+                            feePayerSig: !chainIsInjective
+                              ? Buffer.from(
+                                  signResponse.signature.signature,
+                                  "base64"
+                                )
+                              : undefined,
+                          })
+                        ).finish(),
+                      },
+                    ]
+                  : undefined,
+              })
+            ).finish(),
+            authInfoBytes: AuthInfo.encode({
+              signerInfos: [
                 {
-                  typeUrl: (() => {
-                    if (chainIsInjective) {
-                      return "/injective.types.v1beta1.ExtensionOptionsWeb3Tx";
-                    }
+                  publicKey: {
+                    typeUrl: (() => {
+                      if (!useEthereumSign) {
+                        return "/cosmos.crypto.secp256k1.PubKey";
+                      }
 
-                    return "/ethermint.types.v1.ExtensionOptionsWeb3Tx";
-                  })(),
-                  value: ExtensionOptionsWeb3Tx.encode(
-                    ExtensionOptionsWeb3Tx.fromPartial({
-                      typedDataChainId: EthermintChainIdHelper.parse(
-                        this.chainId
-                      ).ethChainId.toString(),
-                      feePayer: !chainIsInjective
-                        ? signResponse.signed.fee.feePayer
-                        : undefined,
-                      feePayerSig: !chainIsInjective
-                        ? Buffer.from(
-                            signResponse.signature.signature,
-                            "base64"
-                          )
-                        : undefined,
-                    })
-                  ).finish(),
+                      if (chainIsInjective) {
+                        return "/injective.crypto.v1beta1.ethsecp256k1.PubKey";
+                      }
+
+                      return "/ethermint.crypto.v1.ethsecp256k1.PubKey";
+                    })(),
+                    value: PubKey.encode({
+                      key: Buffer.from(
+                        signResponse.signature.pub_key.value,
+                        "base64"
+                      ),
+                    }).finish(),
+                  },
+                  modeInfo: {
+                    single: {
+                      mode: SignMode.SIGN_MODE_LEGACY_AMINO_JSON,
+                    },
+                    multi: undefined,
+                  },
+                  sequence: signResponse.signed.sequence,
                 },
-              ]
-            : undefined,
-        })
-      ).finish(),
-      authInfoBytes: AuthInfo.encode({
-        signerInfos: [
-          {
-            publicKey: {
-              typeUrl: (() => {
-                if (!useEthereumSign) {
-                  return "/cosmos.crypto.secp256k1.PubKey";
-                }
-
-                if (chainIsInjective) {
-                  return "/injective.crypto.v1beta1.ethsecp256k1.PubKey";
-                }
-
-                return "/ethermint.crypto.v1.ethsecp256k1.PubKey";
-              })(),
-              value: PubKey.encode({
-                key: Buffer.from(
-                  signResponse.signature.pub_key.value,
-                  "base64"
-                ),
-              }).finish(),
-            },
-            modeInfo: {
-              single: {
-                mode: SignMode.SIGN_MODE_LEGACY_AMINO_JSON,
-              },
-              multi: undefined,
-            },
-            sequence: signResponse.signed.sequence,
-          },
-        ],
-        fee: Fee.fromPartial({
-          amount: signResponse.signed.fee.amount as Coin[],
-          gasLimit: signResponse.signed.fee.gas,
-          payer:
-            eip712Signing && !chainIsInjective
-              ? // Fee delegation feature not yet supported. But, for eip712 ethermint signing, we must set fee payer.
-                signResponse.signed.fee.feePayer
-              : undefined,
-        }),
-      }).finish(),
-      signatures:
-        // Injective needs the signature in the signatures list even if eip712
-        !eip712Signing || chainIsInjective
-          ? [Buffer.from(signResponse.signature.signature, "base64")]
-          : [new Uint8Array(0)],
-    }).finish();
+              ],
+              fee: Fee.fromPartial({
+                amount: signResponse.signed.fee.amount as Coin[],
+                gasLimit: signResponse.signed.fee.gas,
+                payer:
+                  eip712Signing && !chainIsInjective
+                    ? // Fee delegation feature not yet supported. But, for eip712 ethermint signing, we must set fee payer.
+                      signResponse.signed.fee.feePayer
+                    : undefined,
+              }),
+            }).finish(),
+            signatures:
+              // Injective needs the signature in the signatures list even if eip712
+              !eip712Signing || chainIsInjective
+                ? [Buffer.from(signResponse.signature.signature, "base64")]
+                : [new Uint8Array(0)],
+          }).finish(),
+          signDoc: signResponse.signed,
+        };
+      }
+    })();
 
     // Should use bind to avoid "this" problem
     let sendTx = keplr.sendTx.bind(keplr);
@@ -567,8 +601,96 @@ export class CosmosAccountImpl {
     }
 
     return {
-      txHash: await sendTx(this.chainId, signedTx, "sync" as BroadcastMode),
-      signDoc: signResponse.signed,
+      txHash: await sendTx(this.chainId, signedTx.tx, "sync" as BroadcastMode),
+      signDoc: signedTx.signDoc,
+    };
+  }
+
+  protected async createSignedTxWithDirectSign(
+    keplr: Keplr,
+    account: BaseAccount,
+    protoMsgs: Any[],
+    fee: StdFee,
+    memo: string,
+    signOptions: KeplrSignOptionsWithAltSignMethods | undefined
+  ): Promise<{
+    tx: Uint8Array;
+    signDoc: SignDoc;
+  }> {
+    const useEthereumSign =
+      this.chainGetter
+        .getChain(this.chainId)
+        .features?.includes("eth-key-sign") === true;
+
+    const chainIsInjective = this.chainId.startsWith("injective");
+
+    // Should use bind to avoid "this" problem
+    let signDirect = keplr.signDirect.bind(keplr);
+    if (signOptions?.signDirect) {
+      signDirect = signOptions.signDirect;
+    }
+
+    const signed = await signDirect(
+      this.chainId,
+      this.base.bech32Address,
+      {
+        bodyBytes: TxBody.encode(
+          TxBody.fromPartial({
+            messages: protoMsgs,
+            memo,
+          })
+        ).finish(),
+        authInfoBytes: AuthInfo.encode({
+          signerInfos: [
+            {
+              publicKey: {
+                typeUrl: (() => {
+                  if (!useEthereumSign) {
+                    return "/cosmos.crypto.secp256k1.PubKey";
+                  }
+
+                  if (chainIsInjective) {
+                    return "/injective.crypto.v1beta1.ethsecp256k1.PubKey";
+                  }
+
+                  return "/ethermint.crypto.v1.ethsecp256k1.PubKey";
+                })(),
+                value: PubKey.encode({
+                  key: this.base.pubKey,
+                }).finish(),
+              },
+              modeInfo: {
+                single: {
+                  mode: SignMode.SIGN_MODE_DIRECT,
+                },
+                multi: undefined,
+              },
+              sequence: account.getSequence().toString(),
+            },
+          ],
+          fee: Fee.fromPartial({
+            amount: fee.amount.map((coin) => {
+              return {
+                denom: coin.denom,
+                amount: coin.amount.toString(),
+              };
+            }),
+            gasLimit: fee.gas,
+          }),
+        }).finish(),
+        chainId: this.chainId,
+        accountNumber: Long.fromString(account.getAccountNumber().toString()),
+      },
+      signOptions
+    );
+
+    return {
+      tx: TxRaw.encode({
+        bodyBytes: signed.signed.bodyBytes,
+        authInfoBytes: signed.signed.authInfoBytes,
+        signatures: [Buffer.from(signed.signature.signature, "base64")],
+      }).finish(),
+      signDoc: signed.signed,
     };
   }
 

--- a/packages/stores/src/account/types.ts
+++ b/packages/stores/src/account/types.ts
@@ -9,9 +9,7 @@ import {
 } from "@keplr-wallet/types";
 
 export type ProtoMsgsOrWithAminoMsgs = {
-  // TODO: Make `aminoMsgs` nullable
-  //       And, make proto sign doc if `aminoMsgs` is null
-  aminoMsgs: Msg[];
+  aminoMsgs?: Msg[];
   protoMsgs: Any[];
 
   // Add rlp types data if you need to support ethermint with ledger.
@@ -27,6 +25,7 @@ export type ProtoMsgsOrWithAminoMsgs = {
 
 export interface KeplrSignOptionsWithAltSignMethods extends KeplrSignOptions {
   readonly signAmino?: Keplr["signAmino"];
+  readonly signDirect?: Keplr["signDirect"];
   readonly experimentalSignEIP712CosmosTx_v0?: Keplr["experimentalSignEIP712CosmosTx_v0"];
   readonly sendTx?: (
     chainId: string,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5576,6 +5576,7 @@ __metadata:
     buffer: ^6.0.3
     deepmerge: ^4.2.2
     eventemitter3: ^4.0.7
+    long: ^4.0.0
     mobx: ^6.1.7
     mobx-utils: ^6.0.3
     p-queue: ^6.6.2


### PR DESCRIPTION
In ibc-go v7, there is a bug which MsgTransfer not implement `LegacyMsg`.
And, it makes error like below
```
recovered: expected *legacytx.LegacyMsg when using amino JSON stack: goroutine 8036803 [running]: runtime/debug.Stack() runtime/debug/stack.go:24 +0x65 github.com/cosmos/cosmos-sdk/baseapp.newDefaultRecoveryMiddleware.func1({0x23894a0, 0xc0e4f9dff0}) github.com/cosmos/cosmos-sdk@v0.47.3/baseapp/recovery.go:71 +0x27 github.com/cosmos/cosmos-sdk/baseapp.newRecoveryMiddleware.func1({0x23894a0?, 0xc0e4f9dff0?}) github.com/cosmos/cosmos-sdk@v0.47.3/baseapp/recovery.go:39 +0x30 github.com/cosmos/cosmos-sdk/baseapp.processRecovery({0x23894a0, 0xc0e4f9dff0}, 0xc0984e42c0?) github.com/cosmos/cosmos-sdk@v0.47.3/baseapp/recovery.go:28 +0x37 github.com/cosmos/cosmos-sdk/baseapp.processRecovery({0x23894a0, 0xc0e4f9dff0}, 0x46b5e60?) github.com/cosmos/cosmos-sdk@v0.47.3/baseapp/recovery.go:33 +0x5e github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).runTx.func1() github.com/cosmos/cosmos-sdk@v0.47.3/baseapp/baseapp.go:641 +0xf0 panic({0x23894a0, 0xc0e4f9dff0}) runtime/panic.go:890 +0x262 github.com/cosmos/cosmos-sdk/x/auth/ante.SetUpContextDecorator.AnteHandle.func1() github.com/cosmos/cosmos-sdk@v0.47.3/x/aut
```
There is no way to solve this problem because it is bug on chain itself.
Temporarily, force injective/stride to use the direct signing for ibc transfer.
However, it is still impossible to use ledger for ibc transfer because ledger only supports amino signing.