### PR TITLE
Secret Network Permits Support

### DIFF
--- a/packages/background/src/secret-wasm/query-authorization.ts
+++ b/packages/background/src/secret-wasm/query-authorization.ts
@@ -1,6 +1,9 @@
 import { Permit } from "@keplr-wallet/types";
 
+export type QueryAuthorizationType = "permit" | "viewing_key";
+
 export abstract class QueryAuthorization {
+  abstract type: QueryAuthorizationType;
   abstract getId(): string;
   abstract toString(): string;
 
@@ -19,6 +22,8 @@ export abstract class QueryAuthorization {
 }
 
 export class PermitQueryAuthorization extends QueryAuthorization {
+  type: QueryAuthorizationType = "permit";
+
   constructor(public permit: Permit) {
     super();
   }
@@ -33,6 +38,7 @@ export class PermitQueryAuthorization extends QueryAuthorization {
 }
 
 export class ViewingKeyAuthorization extends QueryAuthorization {
+  type: QueryAuthorizationType = "viewing_key";
   constructor(public viewingKey: string) {
     super();
   }

--- a/packages/background/src/secret-wasm/query-authorization.ts
+++ b/packages/background/src/secret-wasm/query-authorization.ts
@@ -33,15 +33,15 @@ export class PermitQueryAuthorization extends QueryAuthorization {
 }
 
 export class ViewingKeyAuthorization extends QueryAuthorization {
-  constructor(public value: string) {
+  constructor(public viewingKey: string) {
     super();
   }
 
   getId(): string {
-    return this.value;
+    return this.viewingKey;
   }
 
   toString(): string {
-    return this.value;
+    return this.viewingKey;
   }
 }

--- a/packages/background/src/secret-wasm/query-authorization.ts
+++ b/packages/background/src/secret-wasm/query-authorization.ts
@@ -1,0 +1,47 @@
+import { Permit } from "@keplr-wallet/types";
+
+export abstract class QueryAuthorization {
+  abstract getId(): string;
+  abstract toString(): string;
+
+  static fromInput(input: string | Permit): QueryAuthorization {
+    if (typeof input === "string") {
+      try {
+        const permit: Permit = JSON.parse(input);
+        return new PermitQueryAuthorization(permit);
+      } catch (error) {
+        return new ViewingKeyAuthorization(input);
+      }
+    } else {
+      return new PermitQueryAuthorization(input);
+    }
+  }
+}
+
+export class PermitQueryAuthorization extends QueryAuthorization {
+  constructor(public permit: Permit) {
+    super();
+  }
+
+  getId(): string {
+    return this.permit.signature.signature;
+  }
+
+  toString(): string {
+    return JSON.stringify(this.permit);
+  }
+}
+
+export class ViewingKeyAuthorization extends QueryAuthorization {
+  constructor(public value: string) {
+    super();
+  }
+
+  getId(): string {
+    return this.value;
+  }
+
+  toString(): string {
+    return this.value;
+  }
+}

--- a/packages/background/src/token-cw20/handler.ts
+++ b/packages/background/src/token-cw20/handler.ts
@@ -16,6 +16,7 @@ import {
 import { KeyRingCosmosService } from "../keyring-cosmos";
 import { PermissionInteractiveService } from "../permission-interactive";
 import { Buffer } from "buffer/";
+import { QueryAuthorization } from "../secret-wasm/query-authorization";
 
 export const getHandler: (
   service: TokenCW20Service,
@@ -81,13 +82,17 @@ const handleSuggestTokenMsg: (
 
     const key = await keyRingCosmosService.getKeySelected(msg.chainId);
     const associatedAccountAddress = Buffer.from(key.address).toString("hex");
+    let authorization: QueryAuthorization | undefined = undefined;
+    if (msg.authorizationStr) {
+      authorization = QueryAuthorization.fromInput(msg.authorizationStr);
+    }
 
     await service.suggestToken(
       env,
       msg.chainId,
       msg.contractAddress,
       associatedAccountAddress,
-      msg.viewingKey
+      authorization
     );
   };
 };

--- a/packages/background/src/token-cw20/handler.ts
+++ b/packages/background/src/token-cw20/handler.ts
@@ -82,17 +82,17 @@ const handleSuggestTokenMsg: (
 
     const key = await keyRingCosmosService.getKeySelected(msg.chainId);
     const associatedAccountAddress = Buffer.from(key.address).toString("hex");
-    let authorization: QueryAuthorization | undefined = undefined;
+    let queryAuthorization: QueryAuthorization | undefined = undefined;
     if (msg.authorizationStr) {
-      authorization = QueryAuthorization.fromInput(msg.authorizationStr);
+      queryAuthorization = QueryAuthorization.fromInput(msg.authorizationStr);
     }
-
     await service.suggestToken(
       env,
       msg.chainId,
       msg.contractAddress,
       associatedAccountAddress,
-      authorization
+      msg.suggestViewingKey ? "viewing_key" : "permit",
+      queryAuthorization
     );
   };
 };

--- a/packages/background/src/token-cw20/handler.ts
+++ b/packages/background/src/token-cw20/handler.ts
@@ -9,7 +9,7 @@ import { TokenCW20Service } from "./service";
 import {
   GetAllTokenInfosMsg,
   AddTokenMsg,
-  GetSecret20ViewingKey,
+  GetSecret20QueryAuthorization,
   RemoveTokenMsg,
   SuggestTokenMsg,
 } from "./messages";
@@ -44,12 +44,12 @@ export const getHandler: (
         return handleAddTokenMsg(service)(env, msg as AddTokenMsg);
       case RemoveTokenMsg:
         return handleRemoveTokenMsg(service)(env, msg as RemoveTokenMsg);
-      case GetSecret20ViewingKey:
-        return handleGetSecret20ViewingKey(
+      case GetSecret20QueryAuthorization:
+        return handleGetSecret20QueryAuthorization(
           service,
           permissionInteractionService,
           keyRingCosmosService
-        )(env, msg as GetSecret20ViewingKey);
+        )(env, msg as GetSecret20QueryAuthorization);
       default:
         throw new KeplrError("tokens", 120, "Unknown msg type");
     }
@@ -123,11 +123,11 @@ const handleRemoveTokenMsg: (
   };
 };
 
-const handleGetSecret20ViewingKey: (
+const handleGetSecret20QueryAuthorization: (
   service: TokenCW20Service,
   permissionInteractionService: PermissionInteractiveService,
   keyRingCosmosService: KeyRingCosmosService
-) => InternalHandler<GetSecret20ViewingKey> = (
+) => InternalHandler<GetSecret20QueryAuthorization> = (
   service,
   permissionInteractionService,
   keyRingCosmosService
@@ -142,10 +142,11 @@ const handleGetSecret20ViewingKey: (
     const key = await keyRingCosmosService.getKeySelected(msg.chainId);
     const associatedAccountAddress = Buffer.from(key.address).toString("hex");
 
-    return service.getSecret20ViewingKey(
+    return service.getSecret20QueryAuthorization(
       msg.chainId,
       msg.contractAddress,
-      associatedAccountAddress
+      associatedAccountAddress,
+      msg.queryAuthorizationType
     );
   };
 };

--- a/packages/background/src/token-cw20/handler.ts
+++ b/packages/background/src/token-cw20/handler.ts
@@ -83,8 +83,10 @@ const handleSuggestTokenMsg: (
     const key = await keyRingCosmosService.getKeySelected(msg.chainId);
     const associatedAccountAddress = Buffer.from(key.address).toString("hex");
     let queryAuthorization: QueryAuthorization | undefined = undefined;
-    if (msg.authorizationStr) {
-      queryAuthorization = QueryAuthorization.fromInput(msg.authorizationStr);
+    if (msg.queryAuthorizationStr) {
+      queryAuthorization = QueryAuthorization.fromInput(
+        msg.queryAuthorizationStr
+      );
     }
     await service.suggestToken(
       env,

--- a/packages/background/src/token-cw20/init.ts
+++ b/packages/background/src/token-cw20/init.ts
@@ -3,7 +3,7 @@ import {
   GetAllTokenInfosMsg,
   AddTokenMsg,
   RemoveTokenMsg,
-  GetSecret20ViewingKey,
+  GetSecret20QueryAuthorization,
   SuggestTokenMsg,
 } from "./messages";
 import { ROUTE } from "./constants";
@@ -22,7 +22,7 @@ export function init(
   router.registerMessage(SuggestTokenMsg);
   router.registerMessage(AddTokenMsg);
   router.registerMessage(RemoveTokenMsg);
-  router.registerMessage(GetSecret20ViewingKey);
+  router.registerMessage(GetSecret20QueryAuthorization);
 
   router.addHandler(
     ROUTE,

--- a/packages/background/src/token-cw20/messages.ts
+++ b/packages/background/src/token-cw20/messages.ts
@@ -35,7 +35,7 @@ export class SuggestTokenMsg extends Message<void> {
   constructor(
     public readonly chainId: string,
     public readonly contractAddress: string,
-    public readonly viewingKey?: string
+    public readonly authorizationStr?: string
   ) {
     super();
   }

--- a/packages/background/src/token-cw20/messages.ts
+++ b/packages/background/src/token-cw20/messages.ts
@@ -36,6 +36,7 @@ export class SuggestTokenMsg extends Message<void> {
   constructor(
     public readonly chainId: string,
     public readonly contractAddress: string,
+    public readonly suggestViewingKey: boolean,
     public readonly authorizationStr?: string
   ) {
     super();

--- a/packages/background/src/token-cw20/messages.ts
+++ b/packages/background/src/token-cw20/messages.ts
@@ -2,6 +2,7 @@ import { KeplrError, Message } from "@keplr-wallet/router";
 import { ROUTE } from "./constants";
 import { TokenInfo } from "./types";
 import { AppCurrency } from "@keplr-wallet/types";
+import { QueryAuthorizationType } from "../secret-wasm/query-authorization";
 
 export class GetAllTokenInfosMsg extends Message<
   Record<string, TokenInfo[] | undefined>
@@ -125,14 +126,15 @@ export class RemoveTokenMsg extends Message<
   }
 }
 
-export class GetSecret20ViewingKey extends Message<string> {
+export class GetSecret20QueryAuthorization extends Message<string> {
   public static type() {
-    return "get-secret20-viewing-key";
+    return "get-secret20-query-authorization";
   }
 
   constructor(
     public readonly chainId: string,
-    public readonly contractAddress: string
+    public readonly contractAddress: string,
+    public readonly queryAuthorizationType: QueryAuthorizationType | undefined
   ) {
     super();
   }
@@ -156,6 +158,6 @@ export class GetSecret20ViewingKey extends Message<string> {
   }
 
   type(): string {
-    return GetSecret20ViewingKey.type();
+    return GetSecret20QueryAuthorization.type();
   }
 }

--- a/packages/background/src/token-cw20/messages.ts
+++ b/packages/background/src/token-cw20/messages.ts
@@ -37,7 +37,7 @@ export class SuggestTokenMsg extends Message<void> {
     public readonly chainId: string,
     public readonly contractAddress: string,
     public readonly suggestViewingKey: boolean,
-    public readonly authorizationStr?: string
+    public readonly queryAuthorizationStr?: string
   ) {
     super();
   }

--- a/packages/background/src/token-cw20/service.ts
+++ b/packages/background/src/token-cw20/service.ts
@@ -172,13 +172,13 @@ export class TokenCW20Service {
       // If is an existing secret20 token, and query authorization is provided,
       // just try to change the viewing key or permit.
       if (queryAuthorization) {
-        const authorizationStr = queryAuthorization.toString();
-        if (existing.currency.authorizationStr !== authorizationStr) {
+        const queryAuthorizationStr = queryAuthorization.toString();
+        if (existing.currency.queryAuthorizationStr !== queryAuthorizationStr) {
           await this.setToken(
             chainId,
             {
               ...existing.currency,
-              authorizationStr,
+              queryAuthorizationStr,
             },
             associatedAccountAddress
           );
@@ -189,7 +189,7 @@ export class TokenCW20Service {
         // provided and the query authorization types do not differ, do nothing.
         // Otherwise, continue to the add token screen.
         const existingQueryAuthorization = QueryAuthorization.fromInput(
-          existing.currency.authorizationStr
+          existing.currency.queryAuthorizationStr
         );
         console.log(
           "existingQueryAuthorization vs suggestedQueryAuthorizationType",
@@ -286,7 +286,7 @@ export class TokenCW20Service {
       throw new Error("Unknown type of currency");
     }
 
-    if (currency.type === "secret20" && !currency.authorizationStr) {
+    if (currency.type === "secret20" && !currency.queryAuthorizationStr) {
       throw new Error("Viewing key or Permit must be set");
     }
 
@@ -373,13 +373,13 @@ export class TokenCW20Service {
     if (token) {
       if ("type" in token.currency && token.currency.type === "secret20") {
         if (!queryAuthorizationTypeFilter) {
-          return token.currency.authorizationStr;
+          return token.currency.queryAuthorizationStr;
         }
         const queryAuthorization = QueryAuthorization.fromInput(
-          token.currency.authorizationStr
+          token.currency.queryAuthorizationStr
         );
         if (queryAuthorization.type === queryAuthorizationTypeFilter) {
-          return token.currency.authorizationStr;
+          return token.currency.queryAuthorizationStr;
         }
       }
     }

--- a/packages/chain-validator/src/schema.spec.ts
+++ b/packages/chain-validator/src/schema.spec.ts
@@ -273,7 +273,7 @@ describe("Test chain info schema", () => {
       let currency: Secret20Currency = {
         type: "secret20",
         contractAddress: "this should be validated in the keeper",
-        authorizationStr: "Test viewingKey",
+        queryAuthorizationStr: "Test viewingKey",
         coinDenom: "TEST",
         coinMinimalDenom: "utest",
         coinDecimals: 0,
@@ -294,7 +294,7 @@ describe("Test chain info schema", () => {
       let currency: Secret20Currency = {
         type: "secret20",
         contractAddress: "this should be validated in the keeper",
-        authorizationStr: "Test viewingKey",
+        queryAuthorizationStr: "Test viewingKey",
         coinDenom: "TEST",
         coinMinimalDenom:
           "secret20:this should be validated in the keeper:utest",

--- a/packages/chain-validator/src/schema.spec.ts
+++ b/packages/chain-validator/src/schema.spec.ts
@@ -273,7 +273,7 @@ describe("Test chain info schema", () => {
       let currency: Secret20Currency = {
         type: "secret20",
         contractAddress: "this should be validated in the keeper",
-        viewingKey: "Test viewingKey",
+        authorizationStr: "Test viewingKey",
         coinDenom: "TEST",
         coinMinimalDenom: "utest",
         coinDecimals: 0,
@@ -294,7 +294,7 @@ describe("Test chain info schema", () => {
       let currency: Secret20Currency = {
         type: "secret20",
         contractAddress: "this should be validated in the keeper",
-        viewingKey: "Test viewingKey",
+        authorizationStr: "Test viewingKey",
         coinDenom: "TEST",
         coinMinimalDenom:
           "secret20:this should be validated in the keeper:utest",

--- a/packages/chain-validator/src/schema.ts
+++ b/packages/chain-validator/src/schema.ts
@@ -54,7 +54,7 @@ export const Secret20CurrencySchema = (
   .keys({
     type: Joi.string().equal("secret20").required(),
     contractAddress: Joi.string().required(),
-    authorizationStr: Joi.string().required(),
+    queryAuthorizationStr: Joi.string().required(),
   })
   .custom((value: Secret20Currency) => {
     if (

--- a/packages/chain-validator/src/schema.ts
+++ b/packages/chain-validator/src/schema.ts
@@ -54,7 +54,7 @@ export const Secret20CurrencySchema = (
   .keys({
     type: Joi.string().equal("secret20").required(),
     contractAddress: Joi.string().required(),
-    viewingKey: Joi.string().required(),
+    authorizationStr: Joi.string().required(),
   })
   .custom((value: Secret20Currency) => {
     if (

--- a/packages/extension/src/pages/main/components/token/index.tsx
+++ b/packages/extension/src/pages/main/components/token/index.tsx
@@ -180,7 +180,7 @@ export const TokenItem: FunctionComponent<TokenItemProps> = observer(
                 viewToken.chainInfo.chainId
               }&contractAddress=${
                 (viewToken.token.currency as Secret20Currency).contractAddress
-              }`
+              }&suggestedQueryAuthorizationType=viewing_key`
             );
 
             return;

--- a/packages/extension/src/pages/setting/token/add/index.tsx
+++ b/packages/extension/src/pages/setting/token/add/index.tsx
@@ -106,6 +106,10 @@ export const SettingTokenAddPage: FunctionComponent = observer(() => {
           "viewingKey",
           tokensStore.waitingSuggestedToken.data.authorization?.toString() ?? ""
         );
+        setIsUseSecret20Permit(
+          tokensStore.waitingSuggestedToken.data
+            .suggestedQueryAuthorizationType === "permit"
+        );
       }
     }
   }, [interactionInfo, setValue, tokensStore.waitingSuggestedToken]);
@@ -128,7 +132,7 @@ export const SettingTokenAddPage: FunctionComponent = observer(() => {
   }, [accountStore, chainId]);
 
   const isSecretWasm = chainStore.getChain(chainId).hasFeature("secretwasm");
-  const [isUseSecret20Permit, setIsUseSecret20Permit] = useState(false);
+  const [isUseSecret20Permit, setIsUseSecret20Permit] = useState(true);
   const [secret20PermitPermissions, onChangeSecret20PermitPermissions] =
     useState("allowance, balance, history");
   const [isOpenSecret20ViewingKey, setIsOpenSecret20ViewingKey] =

--- a/packages/extension/src/pages/setting/token/add/index.tsx
+++ b/packages/extension/src/pages/setting/token/add/index.tsx
@@ -155,48 +155,43 @@ export const SettingTokenAddPage: FunctionComponent = observer(() => {
 
   useEffect(() => {
     if (isSecretWasm && queryContract.tokenInfo) {
-      const random = new Uint8Array(32);
-      crypto.getRandomValues(random);
-      const randomSignature = Buffer.from(random).toString("hex");
-      const currency = {
-        coinMinimalDenom: `secret20:${contractAddress}:${queryContract.tokenInfo.name}`,
-        coinDenom: queryContract.tokenInfo.symbol,
-        coinDecimals: queryContract.tokenInfo.decimals,
-      };
-      tokensStore
-        .addToken(chainId, {
-          type: "secret20",
-          contractAddress,
-          authorizationStr: new PermitQueryAuthorization({
-            params: {
-              permit_name: "fake",
-              allowed_tokens: ["fake"],
-              chain_id: "fake",
-              permissions: [],
-            },
-            signature: {
-              pub_key: {
-                type: "fake",
-                value: "fake",
+      const getBalance = queriesStore
+        .get(chainId)
+        .secret.querySecret20ContractBalance(
+          accountStore.getAccount(chainId).bech32Address,
+          {
+            type: "secret20",
+            contractAddress,
+            authorizationStr: new PermitQueryAuthorization({
+              params: {
+                permit_name: "fake",
+                allowed_tokens: ["fake"],
+                chain_id: "fake",
+                permissions: [],
               },
-              signature: randomSignature,
-            },
-          }).toString(),
-          coinMinimalDenom: queryContract.tokenInfo.name,
-          coinDenom: queryContract.tokenInfo.symbol,
-          coinDecimals: queryContract.tokenInfo.decimals,
-        })
-        .then(() => {
-          const getBalance = queriesStore
-            .get(chainId)
-            .queryBalances.getQueryBech32Address(
-              accountStore.getAccount(chainId).bech32Address
-            )
-            .getBalance(currency);
-          setSecret20TestPermitQuery(getBalance);
-        });
+              signature: {
+                pub_key: {
+                  type: "fake",
+                  value: "fake",
+                },
+                signature: "fake",
+              },
+            }).toString(),
+            coinMinimalDenom: `secret20:${contractAddress}:${queryContract.tokenInfo.name}`,
+            coinDenom: queryContract.tokenInfo.symbol,
+            coinDecimals: queryContract.tokenInfo.decimals,
+          }
+        );
+      setSecret20TestPermitQuery(getBalance);
     }
-  }, [queryContract.tokenInfo]);
+  }, [
+    accountStore,
+    chainId,
+    contractAddress,
+    isSecretWasm,
+    queriesStore,
+    queryContract.tokenInfo,
+  ]);
 
   const isSecret20PermitSupported = useMemo(() => {
     return !(

--- a/packages/extension/src/pages/setting/token/add/index.tsx
+++ b/packages/extension/src/pages/setting/token/add/index.tsx
@@ -32,6 +32,7 @@ import {
   QueryAuthorization,
   ViewingKeyAuthorization,
 } from "@keplr-wallet/background/build/secret-wasm/query-authorization";
+import { Buffer } from "buffer";
 
 const Styles = {
   Container: styled(Stack)`
@@ -144,13 +145,16 @@ export const SettingTokenAddPage: FunctionComponent = observer(() => {
   })();
 
   const createPermit = async (): Promise<Permit> => {
+    const random = new Uint8Array(32);
+    crypto.getRandomValues(random);
+    const permitName = Buffer.from(random).toString("hex");
     return new Promise((resolve, reject) => {
       const account = accountStore.getAccount(chainId);
       account.secret
         .createSecret20Permit(
           account.bech32Address,
           chainId,
-          "permit-name",
+          permitName,
           [contractAddress],
           ["history", "balance", "allowance"],
           (permit) => {

--- a/packages/extension/src/pages/setting/token/add/index.tsx
+++ b/packages/extension/src/pages/setting/token/add/index.tsx
@@ -104,7 +104,8 @@ export const SettingTokenAddPage: FunctionComponent = observer(() => {
         );
         setValue(
           "viewingKey",
-          tokensStore.waitingSuggestedToken.data.authorization?.toString() ?? ""
+          tokensStore.waitingSuggestedToken.data.queryAuthorization?.toString() ??
+            ""
         );
         setUseSecret20Permit(
           tokensStore.waitingSuggestedToken.data
@@ -170,7 +171,7 @@ export const SettingTokenAddPage: FunctionComponent = observer(() => {
           {
             type: "secret20",
             contractAddress,
-            authorizationStr: new PermitQueryAuthorization({
+            queryAuthorizationStr: new PermitQueryAuthorization({
               params: {
                 permit_name: "fake",
                 allowed_tokens: ["fake"],
@@ -346,7 +347,7 @@ export const SettingTokenAddPage: FunctionComponent = observer(() => {
             currency = {
               type: "secret20",
               contractAddress,
-              authorizationStr: queryAuthorization.toString(),
+              queryAuthorizationStr: queryAuthorization.toString(),
               coinMinimalDenom: queryContract.tokenInfo.name,
               coinDenom: queryContract.tokenInfo.symbol,
               coinDecimals: queryContract.tokenInfo.decimals,

--- a/packages/extension/src/pages/setting/token/add/index.tsx
+++ b/packages/extension/src/pages/setting/token/add/index.tsx
@@ -133,7 +133,9 @@ export const SettingTokenAddPage: FunctionComponent = observer(() => {
   }, [accountStore, chainId]);
 
   const isSecretWasm = chainStore.getChain(chainId).hasFeature("secretwasm");
-  const [useSecret20Permit, setUseSecret20Permit] = useState(true);
+  const [useSecret20Permit, setUseSecret20Permit] = useState(
+    !(searchParams.get("suggestedQueryAuthorizationType") === "viewing_key")
+  );
   const [secret20PermitPermissions, onChangeSecret20PermitPermissions] =
     useState("allowance, balance, history");
   const [isOpenSecret20ViewingKey, setIsOpenSecret20ViewingKey] =
@@ -391,6 +393,7 @@ export const SettingTokenAddPage: FunctionComponent = observer(() => {
               }
             );
           } else {
+            console.log("add token", currency);
             await tokensStore.addToken(chainId, currency);
 
             navigate("/");

--- a/packages/extension/src/pages/setting/token/add/index.tsx
+++ b/packages/extension/src/pages/setting/token/add/index.tsx
@@ -106,7 +106,7 @@ export const SettingTokenAddPage: FunctionComponent = observer(() => {
           "viewingKey",
           tokensStore.waitingSuggestedToken.data.authorization?.toString() ?? ""
         );
-        setIsUseSecret20Permit(
+        setUseSecret20Permit(
           tokensStore.waitingSuggestedToken.data
             .suggestedQueryAuthorizationType === "permit"
         );
@@ -132,7 +132,7 @@ export const SettingTokenAddPage: FunctionComponent = observer(() => {
   }, [accountStore, chainId]);
 
   const isSecretWasm = chainStore.getChain(chainId).hasFeature("secretwasm");
-  const [isUseSecret20Permit, setIsUseSecret20Permit] = useState(true);
+  const [useSecret20Permit, setUseSecret20Permit] = useState(true);
   const [secret20PermitPermissions, onChangeSecret20PermitPermissions] =
     useState("allowance, balance, history");
   const [isOpenSecret20ViewingKey, setIsOpenSecret20ViewingKey] =
@@ -202,9 +202,13 @@ export const SettingTokenAddPage: FunctionComponent = observer(() => {
   ]);
 
   const isSecret20PermitSupported = useMemo(() => {
-    return !(
+    const supported = !(
       secret20TestPermitQuery?.error?.message?.includes("parse_err") === true
     );
+    if (!supported) {
+      setUseSecret20Permit(false);
+    }
+    return supported;
   }, [secret20TestPermitQuery?.error]);
 
   const permitButtonLabel = useMemo(() => {
@@ -294,7 +298,7 @@ export const SettingTokenAddPage: FunctionComponent = observer(() => {
 
             if (!isOpenSecret20ViewingKey) {
               blockRejectAll.current = true;
-              if (isUseSecret20Permit) {
+              if (useSecret20Permit) {
                 try {
                   queryAuthorization = new PermitQueryAuthorization(
                     await createPermit(
@@ -454,10 +458,10 @@ export const SettingTokenAddPage: FunctionComponent = observer(() => {
                   <Skeleton type="button">
                     <Button
                       text={permitButtonLabel}
-                      color={isUseSecret20Permit ? "primary" : "secondary"}
+                      color={useSecret20Permit ? "primary" : "secondary"}
                       disabled={!isSecret20PermitSupported}
                       onClick={() => {
-                        setIsUseSecret20Permit(true);
+                        setUseSecret20Permit(true);
                         setIsOpenSecret20ViewingKey(false);
                       }}
                     />
@@ -468,14 +472,14 @@ export const SettingTokenAddPage: FunctionComponent = observer(() => {
                   <Skeleton type="button">
                     <Button
                       text="Viewing Key"
-                      color={!isUseSecret20Permit ? "primary" : "secondary"}
-                      onClick={() => setIsUseSecret20Permit(false)}
+                      color={!useSecret20Permit ? "primary" : "secondary"}
+                      onClick={() => setUseSecret20Permit(false)}
                     />
                   </Skeleton>
                 </Column>
               </Columns>
             </Box>
-            {isUseSecret20Permit ? (
+            {useSecret20Permit ? (
               <TextInput
                 label="Permit Permissions"
                 placeholder="e.g. allowance, balance, history"

--- a/packages/extension/src/pages/setting/token/manage/index.tsx
+++ b/packages/extension/src/pages/setting/token/manage/index.tsx
@@ -169,7 +169,7 @@ const TokenItem: FunctionComponent<{
       tokenInfo.currency.type === "secret20"
     ) {
       const queryAuthorization = QueryAuthorization.fromInput(
-        tokenInfo.currency.authorizationStr
+        tokenInfo.currency.queryAuthorizationStr
       );
       if (queryAuthorization instanceof PermitQueryAuthorization) {
         return "Permit";
@@ -214,7 +214,7 @@ const TokenItem: FunctionComponent<{
                     tokenInfo.currency.type === "secret20"
                   ) {
                     await navigator.clipboard.writeText(
-                      tokenInfo.currency.authorizationStr
+                      tokenInfo.currency.queryAuthorizationStr
                     );
 
                     notification.show("success", "Viewing key copied", "");

--- a/packages/extension/src/pages/setting/token/manage/index.tsx
+++ b/packages/extension/src/pages/setting/token/manage/index.tsx
@@ -217,7 +217,11 @@ const TokenItem: FunctionComponent<{
                       tokenInfo.currency.queryAuthorizationStr
                     );
 
-                    notification.show("success", "Viewing key copied", "");
+                    notification.show(
+                      "success",
+                      `${secret20AuthorizationType} copied`,
+                      ""
+                    );
                   }
                 }}
               >

--- a/packages/extension/src/pages/setting/token/manage/index.tsx
+++ b/packages/extension/src/pages/setting/token/manage/index.tsx
@@ -21,6 +21,10 @@ import { useConfirm } from "../../../../hooks/confirm";
 import { useNotification } from "../../../../hooks/notification";
 import { Gutter } from "../../../../components/gutter";
 import { Tooltip } from "../../../../components/tooltip";
+import {
+  PermitQueryAuthorization,
+  QueryAuthorization,
+} from "@keplr-wallet/background/build/secret-wasm/query-authorization";
 
 const Styles = {
   Container: styled(Stack)`
@@ -159,6 +163,23 @@ const TokenItem: FunctionComponent<{
     return false;
   })();
 
+  const secret20AuthorizationType = (() => {
+    if (
+      "type" in tokenInfo.currency &&
+      tokenInfo.currency.type === "secret20"
+    ) {
+      const queryAuthorization = QueryAuthorization.fromInput(
+        tokenInfo.currency.authorizationStr
+      );
+      if (queryAuthorization instanceof PermitQueryAuthorization) {
+        return "Permit";
+      } else {
+        return "Viewing Key";
+      }
+    }
+    return "";
+  })();
+
   const confirm = useConfirm();
 
   return (
@@ -183,7 +204,7 @@ const TokenItem: FunctionComponent<{
 
         <Columns sum={1} gutter="0.5rem" alignY="center">
           {isSecret20 ? (
-            <Tooltip content="Copy Viewing Key">
+            <Tooltip content={`Copy ${secret20AuthorizationType}`}>
               <ItemStyles.Icon
                 onClick={async (e) => {
                   e.preventDefault();
@@ -193,7 +214,7 @@ const TokenItem: FunctionComponent<{
                     tokenInfo.currency.type === "secret20"
                   ) {
                     await navigator.clipboard.writeText(
-                      tokenInfo.currency.viewingKey
+                      tokenInfo.currency.authorizationStr
                     );
 
                     notification.show("success", "Viewing key copied", "");

--- a/packages/provider-mock/src/mock.ts
+++ b/packages/provider-mock/src/mock.ts
@@ -16,6 +16,7 @@ import {
   ChainInfoWithoutEndpoints,
   SecretUtils,
   SettledResponses,
+  Permit,
 } from "@keplr-wallet/types";
 import {
   Bech32Address,
@@ -183,6 +184,16 @@ export class MockKeplr implements Keplr {
   }
 
   getSecret20ViewingKey(): Promise<string> {
+    throw new Error("Not implemented");
+  }
+
+  getSecret20QueryAuthorization(
+    _chainId: string,
+    _contractAddress: string
+  ): Promise<{
+    permit: Permit | undefined;
+    viewing_key: string | undefined;
+  }> {
     throw new Error("Not implemented");
   }
 

--- a/packages/provider/src/core.ts
+++ b/packages/provider/src/core.ts
@@ -1,23 +1,24 @@
 import {
+  AminoSignResponse,
+  BroadcastMode,
   ChainInfo,
+  ChainInfoWithoutEndpoints,
+  DirectSignResponse,
   EthSignType,
+  ICNSAdr36Signatures,
   Keplr as IKeplr,
   KeplrIntereactionOptions,
   KeplrMode,
   KeplrSignOptions,
   Key,
-  BroadcastMode,
-  AminoSignResponse,
-  StdSignDoc,
-  StdTx,
   OfflineAminoSigner,
-  StdSignature,
-  DirectSignResponse,
   OfflineDirectSigner,
-  ICNSAdr36Signatures,
-  ChainInfoWithoutEndpoints,
+  Permit,
   SecretUtils,
   SettledResponses,
+  StdSignature,
+  StdSignDoc,
+  StdTx,
 } from "@keplr-wallet/types";
 import {
   BACKGROUND_PORT,
@@ -384,6 +385,35 @@ export class Keplr implements IKeplr, KeplrCoreTypes {
         queryAuthorizationType: "viewing_key",
       }
     );
+  }
+
+  async getSecret20QueryAuthorization(
+    chainId: string,
+    contractAddress: string
+  ): Promise<{ permit: Permit | undefined; viewing_key: string | undefined }> {
+    const queryAuthorizationStr = await sendSimpleMessage(
+      this.requester,
+      BACKGROUND_PORT,
+      "token-cw20",
+      "get-secret20-query-authorization",
+      {
+        chainId,
+        contractAddress,
+        queryAuthorizationType: "viewing_key",
+      }
+    );
+    try {
+      const permit: Permit = JSON.parse(queryAuthorizationStr);
+      return {
+        permit,
+        viewing_key: undefined,
+      };
+    } catch (error) {
+      return {
+        permit: undefined,
+        viewing_key: queryAuthorizationStr,
+      };
+    }
   }
 
   async getEnigmaPubKey(chainId: string): Promise<Uint8Array> {

--- a/packages/provider/src/core.ts
+++ b/packages/provider/src/core.ts
@@ -352,7 +352,8 @@ export class Keplr implements IKeplr, KeplrCoreTypes {
   async suggestToken(
     chainId: string,
     contractAddress: string,
-    viewingKey?: string
+    viewingKey?: string,
+    suggestViewingKey: boolean = true
   ): Promise<void> {
     return await sendSimpleMessage(
       this.requester,
@@ -362,6 +363,7 @@ export class Keplr implements IKeplr, KeplrCoreTypes {
       {
         chainId,
         contractAddress,
+        suggestViewingKey,
         viewingKey,
       }
     );

--- a/packages/provider/src/core.ts
+++ b/packages/provider/src/core.ts
@@ -375,10 +375,11 @@ export class Keplr implements IKeplr, KeplrCoreTypes {
       this.requester,
       BACKGROUND_PORT,
       "token-cw20",
-      "get-secret20-viewing-key",
+      "get-secret20-query-authorization",
       {
         chainId,
         contractAddress,
+        queryAuthorizationType: "viewing_key",
       }
     );
   }

--- a/packages/provider/src/inject.ts
+++ b/packages/provider/src/inject.ts
@@ -19,6 +19,7 @@ import {
   ChainInfoWithoutEndpoints,
   SecretUtils,
   SettledResponses,
+  Permit,
 } from "@keplr-wallet/types";
 import { Result, JSONUint8Array } from "@keplr-wallet/router";
 import { KeplrEnigmaUtils } from "./enigma";
@@ -520,6 +521,19 @@ export class InjectedKeplr implements IKeplr, KeplrCoreTypes {
     contractAddress: string
   ): Promise<string> {
     return await this.requestMethod("getSecret20ViewingKey", [
+      chainId,
+      contractAddress,
+    ]);
+  }
+
+  async getSecret20QueryAuthorization(
+    chainId: string,
+    contractAddress: string
+  ): Promise<{
+    permit: Permit | undefined;
+    viewing_key: string | undefined;
+  }> {
+    return await this.requestMethod("getSecret20QueryAuthorization", [
       chainId,
       contractAddress,
     ]);

--- a/packages/stores/src/core/tokens.ts
+++ b/packages/stores/src/core/tokens.ts
@@ -13,7 +13,10 @@ import { Bech32Address, ChainIdHelper } from "@keplr-wallet/cosmos";
 import { Buffer } from "buffer/";
 import { IAccountStore } from "../account";
 import { KeyRingStore } from "./keyring";
-import { QueryAuthorization } from "@keplr-wallet/background/build/secret-wasm/query-authorization";
+import {
+  QueryAuthorization,
+  QueryAuthorizationType,
+} from "@keplr-wallet/background/build/secret-wasm/query-authorization";
 
 export class TokensStore {
   @observable
@@ -234,6 +237,7 @@ export class TokensStore {
     const datas = this.interactionStore.getAllData<{
       chainId: string;
       contractAddress: string;
+      suggestedQueryAuthorizationType: QueryAuthorizationType;
       authorization?: QueryAuthorization;
     }>("suggest-token-cw20");
 

--- a/packages/stores/src/core/tokens.ts
+++ b/packages/stores/src/core/tokens.ts
@@ -13,6 +13,7 @@ import { Bech32Address, ChainIdHelper } from "@keplr-wallet/cosmos";
 import { Buffer } from "buffer/";
 import { IAccountStore } from "../account";
 import { KeyRingStore } from "./keyring";
+import { QueryAuthorization } from "@keplr-wallet/background/build/secret-wasm/query-authorization";
 
 export class TokensStore {
   @observable
@@ -233,7 +234,7 @@ export class TokensStore {
     const datas = this.interactionStore.getAllData<{
       chainId: string;
       contractAddress: string;
-      viewingKey?: string;
+      authorization?: QueryAuthorization;
     }>("suggest-token-cw20");
 
     if (datas.length > 0) {
@@ -249,7 +250,7 @@ export class TokensStore {
     const d = this.interactionStore.getData<{
       chainId: string;
       contractAddress: string;
-      viewingKey?: string;
+      authorization?: QueryAuthorization;
     }>(id);
     if (!d) {
       return;

--- a/packages/stores/src/core/tokens.ts
+++ b/packages/stores/src/core/tokens.ts
@@ -238,7 +238,7 @@ export class TokensStore {
       chainId: string;
       contractAddress: string;
       suggestedQueryAuthorizationType: QueryAuthorizationType;
-      authorization?: QueryAuthorization;
+      queryAuthorization?: QueryAuthorization;
     }>("suggest-token-cw20");
 
     if (datas.length > 0) {
@@ -254,7 +254,7 @@ export class TokensStore {
     const d = this.interactionStore.getData<{
       chainId: string;
       contractAddress: string;
-      authorization?: QueryAuthorization;
+      queryAuthorization?: QueryAuthorization;
     }>(id);
     if (!d) {
       return;

--- a/packages/stores/src/query/balances.ts
+++ b/packages/stores/src/query/balances.ts
@@ -50,10 +50,10 @@ export class ObservableQueryBalancesImplMap {
     let key = currency.coinMinimalDenom;
     // If the currency is secret20, it will be different according to not only the minimal denom but also the viewing key of the currency.
     if ("type" in currency && currency.type === "secret20") {
-      const authorization = QueryAuthorization.fromInput(
+      const queryAuthorization = QueryAuthorization.fromInput(
         currency.queryAuthorizationStr
       );
-      key = currency.coinMinimalDenom + "/" + authorization.getId();
+      key = currency.coinMinimalDenom + "/" + queryAuthorization.getId();
     }
 
     if (!this.balanceImplMap.has(key)) {

--- a/packages/stores/src/query/balances.ts
+++ b/packages/stores/src/query/balances.ts
@@ -51,7 +51,7 @@ export class ObservableQueryBalancesImplMap {
     // If the currency is secret20, it will be different according to not only the minimal denom but also the viewing key of the currency.
     if ("type" in currency && currency.type === "secret20") {
       const authorization = QueryAuthorization.fromInput(
-        currency.authorizationStr
+        currency.queryAuthorizationStr
       );
       key = currency.coinMinimalDenom + "/" + authorization.getId();
     }

--- a/packages/stores/src/query/balances.ts
+++ b/packages/stores/src/query/balances.ts
@@ -5,6 +5,7 @@ import { CoinPretty, Dec, Int } from "@keplr-wallet/unit";
 import { AppCurrency } from "@keplr-wallet/types";
 import { HasMapStore, IObservableQuery, QuerySharedContext } from "../common";
 import { computedFn } from "mobx-utils";
+import { QueryAuthorization } from "@keplr-wallet/background/build/secret-wasm/query-authorization";
 
 export interface IObservableQueryBalanceImpl extends IObservableQuery {
   balance: CoinPretty;
@@ -49,7 +50,10 @@ export class ObservableQueryBalancesImplMap {
     let key = currency.coinMinimalDenom;
     // If the currency is secret20, it will be different according to not only the minimal denom but also the viewing key of the currency.
     if ("type" in currency && currency.type === "secret20") {
-      key = currency.coinMinimalDenom + "/" + currency.viewingKey;
+      const authorization = QueryAuthorization.fromInput(
+        currency.authorizationStr
+      );
+      key = currency.coinMinimalDenom + "/" + authorization.getId();
     }
 
     if (!this.balanceImplMap.has(key)) {

--- a/packages/stores/src/query/secret-wasm/contract-query.ts
+++ b/packages/stores/src/query/secret-wasm/contract-query.ts
@@ -107,15 +107,15 @@ export class ObservableSecretContractChainQuery<
       data = fetched.data;
       headers = fetched.headers;
     } catch (e) {
-      if (e.response?.data?.error) {
-        const encryptedError = e.response.data.error;
+      if (e.response?.data?.message) {
+        const encryptedError = e.response.data.message;
 
         const errorMessageRgx =
-          /rpc error: code = (.+) = encrypted: (.+): (.+)/g;
+          /encrypted: (.+?): (?:instantiate|execute|query|reply to) contract failed/g;
 
         const rgxMatches = errorMessageRgx.exec(encryptedError);
-        if (rgxMatches != null && rgxMatches.length === 4) {
-          const errorCipherB64 = rgxMatches[2];
+        if (rgxMatches != null && rgxMatches.length === 2) {
+          const errorCipherB64 = rgxMatches[1];
           const errorCipherBz = Buffer.from(errorCipherB64, "base64");
 
           if (this.keplr && this.nonce) {

--- a/packages/stores/src/query/secret-wasm/queries.ts
+++ b/packages/stores/src/query/secret-wasm/queries.ts
@@ -3,9 +3,13 @@ import { ChainGetter } from "../../chain";
 import { ObservableQuerySecretContractCodeHash } from "./contract-hash";
 import { ObservableQuerySecret20ContractInfo } from "./secret20-contract-info";
 import { DeepReadonly } from "utility-types";
-import { ObservableQuerySecret20BalanceRegistry } from "./secret20-balance";
-import { Keplr } from "@keplr-wallet/types";
+import {
+  ObservableQuerySecret20BalanceImpl,
+  ObservableQuerySecret20BalanceRegistry,
+} from "./secret20-balance";
+import { Keplr, Secret20Currency } from "@keplr-wallet/types";
 import { QuerySharedContext } from "../../common";
+import { DenomHelper } from "@keplr-wallet/common";
 
 export interface SecretQueries {
   secret: SecretQueriesImpl;
@@ -45,10 +49,10 @@ export class SecretQueriesImpl {
 
   constructor(
     base: QueriesSetBase,
-    sharedContext: QuerySharedContext,
-    chainId: string,
-    chainGetter: ChainGetter,
-    apiGetter: () => Promise<Keplr | undefined>
+    protected sharedContext: QuerySharedContext,
+    protected chainId: string,
+    protected chainGetter: ChainGetter,
+    protected apiGetter: () => Promise<Keplr | undefined>
   ) {
     this.querySecretContractCodeHash =
       new ObservableQuerySecretContractCodeHash(
@@ -71,6 +75,23 @@ export class SecretQueriesImpl {
       chainGetter,
       apiGetter,
       this.querySecretContractCodeHash
+    );
+  }
+
+  querySecret20ContractBalance(
+    bech32Address: string,
+    currency: Secret20Currency
+  ): ObservableQuerySecret20BalanceImpl {
+    const denomHelper = new DenomHelper(currency.coinMinimalDenom);
+    return new ObservableQuerySecret20BalanceImpl(
+      this.sharedContext,
+      this.chainId,
+      this.chainGetter,
+      this.apiGetter,
+      denomHelper,
+      bech32Address,
+      this.querySecretContractCodeHash,
+      currency
     );
   }
 }

--- a/packages/stores/src/query/secret-wasm/queries.ts
+++ b/packages/stores/src/query/secret-wasm/queries.ts
@@ -9,7 +9,6 @@ import {
 } from "./secret20-balance";
 import { Keplr, Secret20Currency } from "@keplr-wallet/types";
 import { QuerySharedContext } from "../../common";
-import { DenomHelper } from "@keplr-wallet/common";
 
 export interface SecretQueries {
   secret: SecretQueriesImpl;
@@ -82,15 +81,14 @@ export class SecretQueriesImpl {
     bech32Address: string,
     currency: Secret20Currency
   ): ObservableQuerySecret20BalanceImpl {
-    const denomHelper = new DenomHelper(currency.coinMinimalDenom);
     return new ObservableQuerySecret20BalanceImpl(
       this.sharedContext,
       this.chainId,
       this.chainGetter,
       this.apiGetter,
-      denomHelper,
       bech32Address,
       this.querySecretContractCodeHash,
+      undefined,
       currency
     );
   }

--- a/packages/stores/src/query/secret-wasm/secret20-balance.ts
+++ b/packages/stores/src/query/secret-wasm/secret20-balance.ts
@@ -57,7 +57,7 @@ export class ObservableQuerySecret20BalanceImpl
     let msg = {};
     let queryAuth: QueryAuthorization | undefined;
     if ("type" in currency && currency.type === "secret20") {
-      queryAuth = QueryAuthorization.fromInput(currency.authorizationStr);
+      queryAuth = QueryAuthorization.fromInput(currency.queryAuthorizationStr);
       if (queryAuth instanceof PermitQueryAuthorization) {
         msg = {
           with_permit: {

--- a/packages/stores/src/query/secret-wasm/secret20-balance.ts
+++ b/packages/stores/src/query/secret-wasm/secret20-balance.ts
@@ -7,7 +7,7 @@ import { CoinPretty, Int } from "@keplr-wallet/unit";
 import { BalanceRegistry, IObservableQueryBalanceImpl } from "../balances";
 import { ObservableSecretContractChainQuery } from "./contract-query";
 import { WrongViewingKeyError } from "./errors";
-import { AppCurrency, Keplr } from "@keplr-wallet/types";
+import { AppCurrency, Keplr, Secret20Currency } from "@keplr-wallet/types";
 import {
   PermitQueryAuthorization,
   QueryAuthorization,
@@ -32,14 +32,15 @@ export class ObservableQuerySecret20BalanceImpl
     apiGetter: () => Promise<Keplr | undefined>,
     protected readonly denomHelper: DenomHelper,
     protected readonly bech32Address: string,
-    querySecretContractCodeHash: ObservableQuerySecretContractCodeHash
+    querySecretContractCodeHash: ObservableQuerySecretContractCodeHash,
+    test_currency?: Secret20Currency
   ) {
     if (denomHelper.type !== "secret20") {
       throw new Error(`Denom helper must be secret20: ${denomHelper.denom}`);
     }
-    const currency = chainGetter
-      .getChain(chainId)
-      .forceFindCurrency(denomHelper.denom);
+    const currency =
+      test_currency ??
+      chainGetter.getChain(chainId).forceFindCurrency(denomHelper.denom);
     let msg = {};
     let queryAuth: QueryAuthorization | undefined;
     if ("type" in currency && currency.type === "secret20") {

--- a/packages/stores/src/query/secret-wasm/secret20-balance.ts
+++ b/packages/stores/src/query/secret-wasm/secret20-balance.ts
@@ -11,6 +11,7 @@ import { AppCurrency, Keplr } from "@keplr-wallet/types";
 import {
   PermitQueryAuthorization,
   QueryAuthorization,
+  ViewingKeyAuthorization,
 } from "@keplr-wallet/background/build/secret-wasm/query-authorization";
 
 export class ObservableQuerySecret20BalanceImpl
@@ -53,9 +54,9 @@ export class ObservableQuerySecret20BalanceImpl
             permit: queryAuth.permit,
           },
         };
-      } else {
+      } else if (queryAuth instanceof ViewingKeyAuthorization) {
         msg = {
-          balance: { address: bech32Address, key: queryAuth },
+          balance: { address: bech32Address, key: queryAuth.viewingKey },
         };
       }
     }

--- a/packages/stores/src/query/secret-wasm/secret20-balance.ts
+++ b/packages/stores/src/query/secret-wasm/secret20-balance.ts
@@ -17,7 +17,6 @@ import {
 export class ObservableQuerySecret20BalanceImpl
   extends ObservableSecretContractChainQuery<{
     balance: { amount: string };
-    // todo: handle permit errors
     ["viewing_key_error"]?: {
       msg: string;
     };
@@ -98,7 +97,6 @@ export class ObservableQuerySecret20BalanceImpl
     headers: any;
   }> {
     const { data, headers } = await super.fetchResponse(abortController);
-    // todo: handle permit errors
     if (data["viewing_key_error"]) {
       throw new WrongViewingKeyError(data["viewing_key_error"]?.msg);
     }

--- a/packages/types/src/currency.ts
+++ b/packages/types/src/currency.ts
@@ -26,7 +26,7 @@ export interface CW20Currency extends Currency {
 export interface Secret20Currency extends Currency {
   readonly type: "secret20";
   readonly contractAddress: string;
-  readonly viewingKey: string;
+  readonly authorizationStr: string;
 }
 
 /**

--- a/packages/types/src/currency.ts
+++ b/packages/types/src/currency.ts
@@ -26,7 +26,7 @@ export interface CW20Currency extends Currency {
 export interface Secret20Currency extends Currency {
   readonly type: "secret20";
   readonly contractAddress: string;
-  readonly authorizationStr: string;
+  readonly queryAuthorizationStr: string;
 }
 
 /**

--- a/packages/types/src/secretjs.ts
+++ b/packages/types/src/secretjs.ts
@@ -1,3 +1,5 @@
+import { StdSignature } from "./cosmjs";
+
 export interface SecretUtils {
   getPubkey: () => Promise<Uint8Array>;
   decrypt: (ciphertext: Uint8Array, nonce: Uint8Array) => Promise<Uint8Array>;
@@ -7,4 +9,16 @@ export interface SecretUtils {
     msg: object
   ) => Promise<Uint8Array>;
   getTxEncryptionKey: (nonce: Uint8Array) => Promise<Uint8Array>;
+}
+
+export type Permission = "owner" | "history" | "balance" | "allowance";
+
+export interface Permit {
+  params: {
+    permit_name: string;
+    allowed_tokens: string[];
+    chain_id: string;
+    permissions: Permission[];
+  };
+  signature: StdSignature;
 }

--- a/packages/types/src/wallet/keplr.ts
+++ b/packages/types/src/wallet/keplr.ts
@@ -139,7 +139,8 @@ export interface Keplr {
   suggestToken(
     chainId: string,
     contractAddress: string,
-    viewingKey?: string
+    viewingKey?: string,
+    suggestViewingKey?: boolean
   ): Promise<void>;
   getSecret20ViewingKey(
     chainId: string,

--- a/packages/types/src/wallet/keplr.ts
+++ b/packages/types/src/wallet/keplr.ts
@@ -9,7 +9,7 @@ import {
   DirectSignResponse,
   OfflineDirectSigner,
 } from "../cosmjs";
-import { SecretUtils } from "../secretjs";
+import { Permit, SecretUtils } from "../secretjs";
 import Long from "long";
 import { SettledResponses } from "../settled";
 
@@ -146,6 +146,10 @@ export interface Keplr {
     chainId: string,
     contractAddress: string
   ): Promise<string>;
+  getSecret20QueryAuthorization(
+    chainId: string,
+    contractAddress: string
+  ): Promise<{ permit: Permit | undefined; viewing_key: string | undefined }>;
   getEnigmaUtils(chainId: string): SecretUtils;
 
   // Related to Enigma.

--- a/packages/wc-client/src/index.ts
+++ b/packages/wc-client/src/index.ts
@@ -22,6 +22,7 @@ import {
   ChainInfoWithoutEndpoints,
   SecretUtils,
   SettledResponses,
+  Permit,
 } from "@keplr-wallet/types";
 import {
   CosmJSOfflineSigner,
@@ -437,6 +438,16 @@ export class KeplrWalletConnectV1 implements Keplr {
     _chainId: string,
     _contractAddress: string
   ): Promise<string> {
+    throw new Error("Not yet implemented");
+  }
+
+  getSecret20QueryAuthorization(
+    _chainId: string,
+    _contractAddress: string
+  ): Promise<{
+    permit: Permit | undefined;
+    viewing_key: string | undefined;
+  }> {
     throw new Error("Not yet implemented");
   }
 

--- a/packages/wc-client/src/index.ts
+++ b/packages/wc-client/src/index.ts
@@ -499,7 +499,8 @@ export class KeplrWalletConnectV1 implements Keplr {
   suggestToken(
     _chainId: string,
     _contractAddress: string,
-    _viewingKey?: string
+    _viewingKey?: string,
+    _suggestViewingKey: boolean = true
   ): Promise<void> {
     throw new Error("Not yet implemented");
   }


### PR DESCRIPTION
## Permits support
<img width="712" alt="Screenshot 2023-06-24 at 1 18 23 AM" src="https://github.com/chainapsis/keplr-wallet/assets/4157455/f4f49ed3-9fbe-4dfe-b9aa-648a76831c5a">

- [x] Determine if permits are supported after the user enters a certain contract address.
- [x] If it has permit support - create a permit instead of a VK.
- [ ] If it has permit support - under (Advanced), let the user switch back to VKs if they want.
- [ ] If it has permit support - under (Advanced), also keep the current option of importing an existing VK.
If not permit support - keep current behavior.

### Note:
* I did not hide away viewing keys as the spec asked. Instead I just displayed whether or not permits are supported and disabled the permit button accordingly. I just think it will cause confusion for users if viewing keys are hidden under advanced (at least in the transition period where apps will have to add support for loading permits from keplr)... Maybe in a month or two once apps support loading permits it would be more appropriate to hide it away imo. However, if you want exactly what the spec says I'll change it no problem.
* Users can specify the permit permissions by typing the permissions in a comma/space separated list

### Examples:
<img width="225" alt="Screenshot 2023-06-24 at 12 14 25 AM" src="https://github.com/chainapsis/keplr-wallet/assets/4157455/f24b068c-29be-465e-86fd-0120aac519f6"><img width="225" alt="Screenshot 2023-06-24 at 12 14 40 AM" src="https://github.com/chainapsis/keplr-wallet/assets/4157455/71373466-1e43-4ccf-b534-bfd28494cf71"><img width="225" alt="Screenshot 2023-06-24 at 12 15 43 AM" src="https://github.com/chainapsis/keplr-wallet/assets/4157455/75ae6c2f-25ce-4da4-b345-1510e5212b14">


## API suggestToken()
Add another option that is on by default for creating a permit instead of a VK:

#### Old:
```ts
suggestToken(chainId: string, contractAddress: string, viewingKey?: string): Promise<void>;
```

#### Spec New:
```ts
suggestToken(chainId: string, contractAddress: string, viewingKey?: string, createPermit: boolean = true): Promise<void>;

// if viewingKey is set, store it as a VK
// else if createPemit == true, create a permit and store it as a permit
// else if createPemit == false, open the AddToken screen
```

#### New actual implementation:
```ts
suggestToken(chainId: string, contractAddress: string, viewingKey?: string,  suggestViewingKey: boolean = true): Promise<void>;

// if suggestViewingKey is set, store it as a VK
// else if suggestViewingKey == false, open the AddToken screen with create a permit option selected.
// else if suggestViewingKey == true, open the AddToken screen with the viewing key option selected
```
### Note:
* I set `suggestViewingKey: boolean = true` by default because if it were `false` to instead suggest creating a permit it would basically be incompatible with all current apps. Since all current apps expect a viewing key to be made when `suggestToken` is called, not a permit.


## API getSecret20ViewingKeyOrPermit() (name TBD)

#### Spec:
```ts
// Deprecate this in the future (with proper notice):
getSecret20ViewingKey(chainId: string, contractAddress: string): Promise<string>;

// Add this API function:
getSecret20ViewingKeyOrPermit(
  chainId: string, 
  contractAddress: string
): Promise<{permit: object | undefined; viewing_key: string | undefined;}>;

// Return both permit & VK if any of them exist
```

#### Actual implementation:
* Instead of `getSecret20ViewingKeyOrPermit` I think `getSecret20QueryAuthorization` might be better. Because to me, using a viewing key or permit in a query is similar in concept to adding a authorization header to a rest call. That way instead of listing all the authorization types in the name it just broadly imply it can return any kind of authorization object. I am pretty sure `authorization` is the [correct terminology](https://auth0.com/docs/get-started/identity-fundamentals/authentication-and-authorization) of what a viewing key or a permit does.

```ts
getSecret20QueryAuthorization(
  chainId: string,
  contractAddress: string
): Promise<{ permit: Permit | undefined; viewing_key: string | undefined }>;

// Returns permit or VK if either exists. (only one or the other can be stored)
```

* Note: instead of returning `{ permit: Permit | undefined; viewing_key: string | undefined }` I could expose the internal `QueryAuthorization` class and return that, which would debatably be cleaner. But up to you guys, just something to think about.