### PR TITLE
Change Stargaze source

### DIFF
--- a/packages/mobile/src/screens/web/webpages/stargaze.tsx
+++ b/packages/mobile/src/screens/web/webpages/stargaze.tsx
@@ -5,7 +5,7 @@ export const StargazeWebpageScreen: FunctionComponent = () => {
   return (
     <WebpageScreen
       name="Stargaze"
-      source={{ uri: "https://www.stargaze.zone" }}
+      source={{ uri: "https://www.stargaze.zone/?wallet=keplr" }}
       originWhitelist={["https://www.stargaze.zone"]}
       allowsInlineMediaPlayback={true}
     />


### PR DESCRIPTION
To distinguish whether the user is employing a standard browser or a wallet app with custom URL input, or if they are using Keplr, I need a way to identify them. Therefore, I kindly ask for your approval on this PR.

Also, I would appreciate it if you could let me know when this change is deployed (in Android and iOS environments). How can I receive this information?