### PR TITLE
support bitbadges for ethermint ledger

### DIFF
--- a/packages/background/src/keyring-cosmos/service.ts
+++ b/packages/background/src/keyring-cosmos/service.ts
@@ -1226,7 +1226,7 @@ Salt: ${salt}`;
   public static throwErrorIfEthermintWithLedgerButNotSupported(
     chainId: string
   ) {
-    if (!chainId.startsWith("evmos_") && !chainId.startsWith("injective")) {
+    if (!chainId.startsWith("evmos_") && !chainId.startsWith("injective") && !chainId.startsWith("bitbadges")) {
       throw new KeplrError(
         "keyring",
         152,


### PR DESCRIPTION
I am currently creating a Cosmos chain with the ethermint spec and would like to support Keplr ledger. However, I am currently blacklisted for my Chain IDs unless they start with "evmos" or "injective". 

I created an issue awhile ago via [https://github.com/chainapsis/keplr-wallet/issues/720](https://github.com/chainapsis/keplr-wallet/issues/720). It was suggested that I could simply start my chain ID with evmos; however, I do not think that is good practice.

I am proposing a simple change to add "bitbadges" to the allowlist. 