### PR TITLE
Remove hardcoded cointype ID in isEthermintLike function

### DIFF
--- a/packages/background/src/keyring/service.ts
+++ b/packages/background/src/keyring/service.ts
@@ -1265,7 +1265,6 @@ export class KeyRingService {
 
   static isEthermintLike(chainInfo: ChainInfo): boolean {
     return (
-      chainInfo.bip44.coinType === 60 ||
       !!chainInfo.features?.includes("eth-address-gen") ||
       !!chainInfo.features?.includes("eth-key-sign")
     );


### PR DESCRIPTION
### Title:
Remove hardcoded cointype ID in `isEthermintLike` function

### Description:

#### Problem Statement:
The hardcoded cointype ID of `60` in the `isEthermintLike` function limits its flexibility and causes issues for networks that do not use this cointype, such as the Kava testnet.

#### Proposed Changes:

- Removed the hardcoded condition `chainInfo.bip44.coinType === 60 ||` from the `isEthermintLike` function.

#### Background:
As per Kava Labs' new update, Kava Mainnet adopted a new cointype ID, moving away from the standard cointype of `60`. This change makes it necessary to remove the hardcoded value to make Keplr Wallet compatible with other networks, including Kava testnet.

[Background information](https://medium.com/stakin/kava-labs-quick-guide-overview-4c9d2f07b12)
[Resolves #800 Github Issue](https://github.com/chainapsis/keplr-wallet/issues/800)

#### Files Changed:
- `packages/background/src/keyring/service.ts`

```diff
@@ -1265,7 +1265,6 @@ export class KeyRingService {
  static isEthermintLike(chainInfo: ChainInfo): boolean {
    return (
-     chainInfo.bip44.coinType === 60 ||  
      !!chainInfo.features?.includes("eth-address-gen") ||
      !!chainInfo.features?.includes("eth-key-sign")
    );
  }
```

#### Impact:
This change will make Keplr Wallet more flexible and allow compatibility with networks that do not use the hardcoded cointype ID.