### PR TITLE
Add signOptions parameter to `getOfflineSigner`

### DIFF
--- a/packages/provider-mock/src/mock.ts
+++ b/packages/provider-mock/src/mock.ts
@@ -178,7 +178,10 @@ export class MockKeplr implements Keplr {
     throw new Error("Not implemented");
   }
 
-  getOfflineSigner(chainId: string): OfflineAminoSigner & OfflineDirectSigner {
+  getOfflineSigner(
+    chainId: string,
+    _?: KeplrSignOptions
+  ): OfflineAminoSigner & OfflineDirectSigner {
     return new CosmJSOfflineSigner(chainId, this);
   }
 
@@ -287,12 +290,16 @@ export class MockKeplr implements Keplr {
   }
 
   getOfflineSignerAuto(
-    _chainId: string
+    _chainId: string,
+    _?: KeplrSignOptions
   ): Promise<OfflineAminoSigner | OfflineDirectSigner> {
     throw new Error("Not implemented");
   }
 
-  getOfflineSignerOnlyAmino(chainId: string): OfflineAminoSigner {
+  getOfflineSignerOnlyAmino(
+    chainId: string,
+    _?: KeplrSignOptions
+  ): OfflineAminoSigner {
     return new CosmJSOfflineSignerOnlyAmino(chainId, this);
   }
 

--- a/packages/provider/src/core.ts
+++ b/packages/provider/src/core.ts
@@ -331,22 +331,29 @@ export class Keplr implements IKeplr, KeplrCoreTypes {
     );
   }
 
-  getOfflineSigner(chainId: string): OfflineAminoSigner & OfflineDirectSigner {
-    return new CosmJSOfflineSigner(chainId, this);
+  getOfflineSigner(
+    chainId: string,
+    signOptions?: KeplrSignOptions
+  ): OfflineAminoSigner & OfflineDirectSigner {
+    return new CosmJSOfflineSigner(chainId, this, signOptions);
   }
 
-  getOfflineSignerOnlyAmino(chainId: string): OfflineAminoSigner {
-    return new CosmJSOfflineSignerOnlyAmino(chainId, this);
+  getOfflineSignerOnlyAmino(
+    chainId: string,
+    signOptions?: KeplrSignOptions
+  ): OfflineAminoSigner {
+    return new CosmJSOfflineSignerOnlyAmino(chainId, this, signOptions);
   }
 
   async getOfflineSignerAuto(
-    chainId: string
+    chainId: string,
+    signOptions?: KeplrSignOptions
   ): Promise<OfflineAminoSigner | OfflineDirectSigner> {
     const key = await this.getKey(chainId);
     if (key.isNanoLedger) {
-      return new CosmJSOfflineSignerOnlyAmino(chainId, this);
+      return new CosmJSOfflineSignerOnlyAmino(chainId, this, signOptions);
     }
-    return new CosmJSOfflineSigner(chainId, this);
+    return new CosmJSOfflineSigner(chainId, this, signOptions);
   }
 
   async suggestToken(

--- a/packages/provider/src/cosmjs.ts
+++ b/packages/provider/src/cosmjs.ts
@@ -7,12 +7,14 @@ import {
   StdSignDoc,
   DirectSignResponse,
   SignDoc,
+  KeplrSignOptions,
 } from "@keplr-wallet/types";
 
 export class CosmJSOfflineSignerOnlyAmino implements OfflineAminoSigner {
   constructor(
     protected readonly chainId: string,
-    protected readonly keplr: Keplr
+    protected readonly keplr: Keplr,
+    protected readonly signOptions?: KeplrSignOptions
   ) {}
 
   async getAccounts(): Promise<AccountData[]> {
@@ -42,10 +44,15 @@ export class CosmJSOfflineSignerOnlyAmino implements OfflineAminoSigner {
       throw new Error("Unknown signer address");
     }
 
-    return await this.keplr.signAmino(this.chainId, signerAddress, signDoc);
+    return await this.keplr.signAmino(
+      this.chainId,
+      signerAddress,
+      signDoc,
+      this.signOptions
+    );
   }
 
-  // Fallback function for the legacy cosmjs implementation before the staragte.
+  // Fallback function for the legacy cosmjs implementation before the stargate.
   async sign(
     signerAddress: string,
     signDoc: StdSignDoc
@@ -58,8 +65,8 @@ export class CosmJSOfflineSigner
   extends CosmJSOfflineSignerOnlyAmino
   implements OfflineAminoSigner, OfflineDirectSigner
 {
-  constructor(chainId: string, keplr: Keplr) {
-    super(chainId, keplr);
+  constructor(chainId: string, keplr: Keplr, signOptions?: KeplrSignOptions) {
+    super(chainId, keplr, signOptions);
   }
 
   async signDirect(
@@ -76,6 +83,11 @@ export class CosmJSOfflineSigner
       throw new Error("Unknown signer address");
     }
 
-    return await this.keplr.signDirect(this.chainId, signerAddress, signDoc);
+    return await this.keplr.signDirect(
+      this.chainId,
+      signerAddress,
+      signDoc,
+      this.signOptions
+    );
   }
 }

--- a/packages/provider/src/inject.ts
+++ b/packages/provider/src/inject.ts
@@ -485,22 +485,29 @@ export class InjectedKeplr implements IKeplr, KeplrCoreTypes {
     ]);
   }
 
-  getOfflineSigner(chainId: string): OfflineAminoSigner & OfflineDirectSigner {
-    return new CosmJSOfflineSigner(chainId, this);
+  getOfflineSigner(
+    chainId: string,
+    signOptions?: KeplrSignOptions
+  ): OfflineAminoSigner & OfflineDirectSigner {
+    return new CosmJSOfflineSigner(chainId, this, signOptions);
   }
 
-  getOfflineSignerOnlyAmino(chainId: string): OfflineAminoSigner {
-    return new CosmJSOfflineSignerOnlyAmino(chainId, this);
+  getOfflineSignerOnlyAmino(
+    chainId: string,
+    signOptions?: KeplrSignOptions
+  ): OfflineAminoSigner {
+    return new CosmJSOfflineSignerOnlyAmino(chainId, this, signOptions);
   }
 
   async getOfflineSignerAuto(
-    chainId: string
+    chainId: string,
+    signOptions?: KeplrSignOptions
   ): Promise<OfflineAminoSigner | OfflineDirectSigner> {
     const key = await this.getKey(chainId);
     if (key.isNanoLedger) {
-      return new CosmJSOfflineSignerOnlyAmino(chainId, this);
+      return new CosmJSOfflineSignerOnlyAmino(chainId, this, signOptions);
     }
-    return new CosmJSOfflineSigner(chainId, this);
+    return new CosmJSOfflineSigner(chainId, this, signOptions);
   }
 
   async suggestToken(

--- a/packages/types/src/wallet/keplr.ts
+++ b/packages/types/src/wallet/keplr.ts
@@ -130,10 +130,17 @@ export interface Keplr {
     type: EthSignType
   ): Promise<Uint8Array>;
 
-  getOfflineSigner(chainId: string): OfflineAminoSigner & OfflineDirectSigner;
-  getOfflineSignerOnlyAmino(chainId: string): OfflineAminoSigner;
+  getOfflineSigner(
+    chainId: string,
+    signOptions?: KeplrSignOptions
+  ): OfflineAminoSigner & OfflineDirectSigner;
+  getOfflineSignerOnlyAmino(
+    chainId: string,
+    signOptions?: KeplrSignOptions
+  ): OfflineAminoSigner;
   getOfflineSignerAuto(
-    chainId: string
+    chainId: string,
+    signOptions?: KeplrSignOptions
   ): Promise<OfflineAminoSigner | OfflineDirectSigner>;
 
   suggestToken(

--- a/packages/types/src/window.ts
+++ b/packages/types/src/window.ts
@@ -1,15 +1,20 @@
-import { Keplr } from "./wallet";
+import { Keplr, KeplrSignOptions } from "./wallet";
 import { OfflineAminoSigner, OfflineDirectSigner } from "./cosmjs";
 import { SecretUtils } from "./secretjs";
 
 export interface Window {
   keplr?: Keplr;
   getOfflineSigner?: (
-    chainId: string
+    chainId: string,
+    signOptions?: KeplrSignOptions
   ) => OfflineAminoSigner & OfflineDirectSigner;
-  getOfflineSignerOnlyAmino?: (chainId: string) => OfflineAminoSigner;
+  getOfflineSignerOnlyAmino?: (
+    chainId: string,
+    signOptions?: KeplrSignOptions
+  ) => OfflineAminoSigner;
   getOfflineSignerAuto?: (
-    chainId: string
+    chainId: string,
+    signOptions?: KeplrSignOptions
   ) => Promise<OfflineAminoSigner | OfflineDirectSigner>;
   getEnigmaUtils?: (chainId: string) => SecretUtils;
 }

--- a/packages/wc-client/src/index.ts
+++ b/packages/wc-client/src/index.ts
@@ -424,22 +424,29 @@ export class KeplrWalletConnectV2 implements Keplr {
     return await Promise.allSettled(paramArray);
   }
 
-  getOfflineSigner(chainId: string): OfflineAminoSigner & OfflineDirectSigner {
-    return new CosmJSOfflineSigner(chainId, this);
+  getOfflineSigner(
+    chainId: string,
+    signOptions?: KeplrSignOptions
+  ): OfflineAminoSigner & OfflineDirectSigner {
+    return new CosmJSOfflineSigner(chainId, this, signOptions);
   }
 
   async getOfflineSignerAuto(
-    chainId: string
+    chainId: string,
+    signOptions?: KeplrSignOptions
   ): Promise<OfflineAminoSigner | OfflineDirectSigner> {
     const key = await this.getKey(chainId);
     if (key.isNanoLedger) {
-      return new CosmJSOfflineSignerOnlyAmino(chainId, this);
+      return new CosmJSOfflineSignerOnlyAmino(chainId, this, signOptions);
     }
-    return new CosmJSOfflineSigner(chainId, this);
+    return new CosmJSOfflineSigner(chainId, this, signOptions);
   }
 
-  getOfflineSignerOnlyAmino(chainId: string): OfflineAminoSigner {
-    return new CosmJSOfflineSignerOnlyAmino(chainId, this);
+  getOfflineSignerOnlyAmino(
+    chainId: string,
+    signOptions?: KeplrSignOptions
+  ): OfflineAminoSigner {
+    return new CosmJSOfflineSignerOnlyAmino(chainId, this, signOptions);
   }
 
   getSecret20ViewingKey(


### PR DESCRIPTION
멀티시그에서 `getOfflineSigner` 로 서명할 때`preferNoSetMemo`, `disableBalanceCheck` 기능을 사용하기 위해
`getOfflineSigner` 메소드들에 signOptions 매개변수를 추가합니다.

멀티시그에서는 서명할 때 fee를 내지 않기 때문에 balance를 체크할 필요가 없습니다

