### PR TITLE
[KM-71] 상대시간명 통일 작업 

### DIFF
--- a/packages/mobile/src/screen/governance/components/card.tsx
+++ b/packages/mobile/src/screen/governance/components/card.tsx
@@ -1,4 +1,4 @@
-import React, {FunctionComponent, useState} from 'react';
+import React, {FunctionComponent} from 'react';
 import {observer} from 'mobx-react-lite';
 
 import {Text, View} from 'react-native';
@@ -18,6 +18,7 @@ import {Gutter} from '../../../components/gutter';
 import {useNavigation} from '@react-navigation/native';
 import {StackNavProp} from '../../../navigation';
 import {DASHBOARD_URL} from '../../../config';
+import {formatRelativeTimeString} from '../../../utils/format';
 
 export const GovernanceProposalStatusChip: FunctionComponent<{
   status: ProposalStatus;
@@ -82,8 +83,6 @@ export const GovernanceCardBody: FunctionComponent<{
     }
   };
 
-  const [current] = useState(() => new Date().getTime());
-
   // Relative time is not between the end time and actual current time.
   // Relative time is between the end time and "the time that the component is mounted."
   const proposalRelativeEndTimeString = (() => {
@@ -93,61 +92,14 @@ export const GovernanceCardBody: FunctionComponent<{
 
     switch (proposal.proposalStatus) {
       case ProposalStatus.DEPOSIT_PERIOD:
-        const relativeDepositEndTime =
-          (new Date(proposal.raw.deposit_end_time).getTime() - current) / 1000;
-        const relativeDepositEndTimeDays = Math.floor(
-          relativeDepositEndTime / (3600 * 24),
-        );
-        const relativeDepositEndTimeHours = Math.ceil(
-          relativeDepositEndTime / 3600,
-        );
+        return formatRelativeTimeString(intl, proposal.raw.deposit_end_time, {
+          numeric: 'always',
+        });
 
-        if (relativeDepositEndTimeDays) {
-          return (
-            intl
-              .formatRelativeTime(relativeDepositEndTimeDays, 'days', {
-                numeric: 'always',
-              })
-              .replace('in ', '') + ' left'
-          );
-        } else if (relativeDepositEndTimeHours) {
-          return (
-            intl
-              .formatRelativeTime(relativeDepositEndTimeHours, 'hours', {
-                numeric: 'always',
-              })
-              .replace('in ', '') + ' left'
-          );
-        }
-        return '';
       case ProposalStatus.VOTING_PERIOD:
-        const relativeVotingEndTime =
-          (new Date(proposal.raw.voting_end_time).getTime() - current) / 1000;
-        const relativeVotingEndTimeDays = Math.floor(
-          relativeVotingEndTime / (3600 * 24),
-        );
-        const relativeVotingEndTimeHours = Math.ceil(
-          relativeVotingEndTime / 3600,
-        );
-
-        if (relativeVotingEndTimeDays) {
-          return (
-            intl
-              .formatRelativeTime(relativeVotingEndTimeDays, 'days', {
-                numeric: 'always',
-              })
-              .replace('in ', '') + ' left'
-          );
-        } else if (relativeVotingEndTimeHours) {
-          return (
-            intl
-              .formatRelativeTime(relativeVotingEndTimeHours, 'hours', {
-                numeric: 'always',
-              })
-              .replace('in ', '') + ' left'
-          );
-        }
-        return '';
+        return formatRelativeTimeString(intl, proposal.raw.voting_end_time, {
+          numeric: 'always',
+        });
       case ProposalStatus.FAILED:
       case ProposalStatus.PASSED:
       case ProposalStatus.REJECTED:

--- a/packages/mobile/src/screen/governance/utils.ts
+++ b/packages/mobile/src/screen/governance/utils.ts
@@ -11,7 +11,12 @@ export const dateToLocalString = (intl: IntlShape, dateStr: string) => {
 
   return intl
     .formatDate(dateStr, {
-      // format: 'en',
+      day: 'numeric',
+      month: 'short',
+      hour: 'numeric',
+      minute: '2-digit',
+      hourCycle: 'h24',
+      timeZoneName: 'short',
       year: isYearDifferent ? 'numeric' : undefined,
     })
     .replace('GMT', 'UTC');

--- a/packages/mobile/src/screen/home/staked.tsx
+++ b/packages/mobile/src/screen/home/staked.tsx
@@ -19,7 +19,7 @@ import {useNavigation} from '@react-navigation/native';
 import {StackNavProp} from '../../navigation';
 import {SelectStakingChainModal} from './components/stakeing-chain-select-modal';
 import {BottomSheetModalMethods} from '@gorhom/bottom-sheet/lib/typescript/types';
-import {formatRelativeTime} from '../../utils/format';
+import {formatRelativeTimeString} from '../../utils/format';
 
 const zeroDec = new Dec(0);
 
@@ -65,14 +65,9 @@ export const StakedTabView: FunctionComponent<{
           return unbonding.viewToken.token.toDec().gt(new Dec(0));
         })
         .map(unbonding => {
-          const relativeTime = formatRelativeTime(unbonding.completeTime);
-
           return {
             viewToken: unbonding.viewToken,
-            altSentence: intl.formatRelativeTime(
-              relativeTime.value,
-              relativeTime.unit,
-            ),
+            altSentence: formatRelativeTimeString(intl, unbonding.completeTime),
           };
         }),
     [hugeQueriesStore.unbondings, intl],

--- a/packages/mobile/src/screen/staking/dashboard/dashboard.tsx
+++ b/packages/mobile/src/screen/staking/dashboard/dashboard.tsx
@@ -19,7 +19,7 @@ import {YAxis} from '../../../components/axis';
 import {Button} from '../../../components/button';
 import LinearGradient from 'react-native-linear-gradient';
 import {CoinPretty} from '@keplr-wallet/unit';
-import {formatRelativeTime} from '../../../utils/format';
+import {formatRelativeTimeString} from '../../../utils/format';
 import {useIntl} from 'react-intl';
 import {formatAprString} from '../../home/utils';
 import {InformationOutlinedIcon} from '../../../components/icon/information-outlined';
@@ -106,16 +106,12 @@ export const StakingDashboardScreen: FunctionComponent = observer(() => {
         }
 
         const balance = new CoinPretty(chainInfo.stakeCurrency, entry.balance);
-        const relativeTime = formatRelativeTime(entry.completion_time);
 
         res.push({
           coin: balance,
           name: validator.description.moniker,
           validatorAddress: validator.operator_address,
-          subString: intl.formatRelativeTime(
-            relativeTime.value,
-            relativeTime.unit,
-          ),
+          subString: formatRelativeTimeString(intl, entry.completion_time),
         });
       }
     }

--- a/packages/mobile/src/screen/staking/validator-detail/unbonding-card.tsx
+++ b/packages/mobile/src/screen/staking/validator-detail/unbonding-card.tsx
@@ -9,6 +9,7 @@ import {Box} from '../../../components/box';
 import {Gutter} from '../../../components/gutter';
 import {Stack} from '../../../components/stack';
 import {Column, Columns} from '../../../components/column';
+import {formatRelativeTimeString} from '../../../utils/format';
 
 export const UnbondingCard: FunctionComponent<{
   validatorAddress: string;
@@ -48,36 +49,10 @@ export const UnbondingCard: FunctionComponent<{
         backgroundColor={style.get('color-gray-600').color}>
         <Stack gutter={24}>
           {unbonding.entries.map((entry, i) => {
-            const remainingText = (() => {
-              const current = new Date().getTime();
-
-              const relativeEndTime =
-                (new Date(entry.completionTime).getTime() - current) / 1000;
-              const relativeEndTimeDays = Math.floor(
-                relativeEndTime / (3600 * 24),
-              );
-              const relativeEndTimeHours = Math.ceil(relativeEndTime / 3600);
-
-              if (relativeEndTimeDays) {
-                return (
-                  intl
-                    .formatRelativeTime(relativeEndTimeDays, 'days', {
-                      numeric: 'always',
-                    })
-                    .replace('in ', '') + ' left'
-                );
-              } else if (relativeEndTimeHours) {
-                return (
-                  intl
-                    .formatRelativeTime(relativeEndTimeHours, 'hours', {
-                      numeric: 'always',
-                    })
-                    .replace('in ', '') + ' left'
-                );
-              }
-
-              return '';
-            })();
+            const remainingText = formatRelativeTimeString(
+              intl,
+              entry.completionTime,
+            );
             const progress = (() => {
               const currentTime = new Date().getTime();
               const endTime = new Date(entry.completionTime).getTime();

--- a/packages/mobile/src/utils/format.ts
+++ b/packages/mobile/src/utils/format.ts
@@ -1,3 +1,5 @@
+import {FormatRelativeTimeOptions, IntlShape} from 'react-intl';
+
 export function formatRelativeTime(time: string): {
   unit: 'minute' | 'hour' | 'day';
   value: number;
@@ -40,4 +42,14 @@ export function formatRelativeTime(time: string): {
     unit: 'minute',
     value: Math.ceil(remainingMinutes),
   };
+}
+
+export function formatRelativeTimeString(
+  intl: IntlShape,
+  dateStr: string,
+  opts?: FormatRelativeTimeOptions,
+): string {
+  const {unit, value} = formatRelativeTime(dateStr);
+  const result = intl.formatRelativeTime(value, unit, opts);
+  return result.includes('in') ? result.replace('in ', '') + ' left' : result;
 }


### PR DESCRIPTION
# 구현사항
![Screenshot 2023-11-23 at 4 10 13 PM](https://github.com/chainapsis/keplr-wallet/assets/10705018/17ec2df5-027a-4658-8071-9ac74d30fc6b)

1. in days로 되어있는 텍스트를 -> days left로 변경
2. https://linear.app/chainapsis/issue/KM-71/intlformatdate-format=en-%EB%B2%84%EA%B7%B8-%EC%88%98%EC%A0%95%ED%95%98%EA%B8%B0 해당 이슈 수정
format : 'en'을 지우고 해당 테스트랑 같이 보여줄 수 있게 옵션 수정
