### PR TITLE
디자인 QA 글로벌 적용

### DIFF
--- a/packages/mobile/src/components/input/fee-control/transaction-fee-modal.tsx
+++ b/packages/mobile/src/components/input/fee-control/transaction-fee-modal.tsx
@@ -54,7 +54,7 @@ export const TransactionFeeModal: FunctionComponent<{
   })();
 
   return (
-    <Box padding={12}>
+    <Box paddingX={12} paddingBottom={12}>
       <BaseModalHeader
         title={intl.formatMessage({
           id: 'components.input.fee-control.modal.title',
@@ -62,6 +62,7 @@ export const TransactionFeeModal: FunctionComponent<{
         titleStyle={style.flatten(['h4', 'text-left'])}
       />
 
+      <Gutter size={12} />
       <Label
         content={intl.formatMessage({
           id: 'components.input.fee-control.modal.fee-title',

--- a/packages/mobile/src/components/input/reciepient-input/address-book-modal.tsx
+++ b/packages/mobile/src/components/input/reciepient-input/address-book-modal.tsx
@@ -126,6 +126,7 @@ export const AddressBookModal: FunctionComponent<{
           title={intl.formatMessage({
             id: 'components.address-book-modal.title',
           })}
+          titleStyle={{paddingBottom: 6}}
         />
 
         <YAxis alignX="left">

--- a/packages/mobile/src/components/modal/infoModal.tsx
+++ b/packages/mobile/src/components/modal/infoModal.tsx
@@ -23,14 +23,14 @@ export const InformationModal: FunctionComponent<InformationModalProps> = ({
         {paddingBottom: 60 + insects.bottom},
       ])}>
       <Box>
-        <Box paddingBottom={20} paddingTop={12} paddingX={8}>
+        <Box paddingBottom={12} paddingX={8}>
           <Columns sum={1} gutter={10} alignY="center">
             <InformationOutlinedIcon
               size={20}
               color={style.get('color-text-low').color}
             />
 
-            <Text style={style.flatten(['h4', 'color-text-high'])}>
+            <Text style={style.flatten(['h4', 'color-text-high', 'padding-8'])}>
               {title}
             </Text>
           </Columns>

--- a/packages/mobile/src/components/modal/infoModal.tsx
+++ b/packages/mobile/src/components/modal/infoModal.tsx
@@ -5,6 +5,7 @@ import {Box} from '../../components/box';
 import {useStyle} from '../../styles';
 import {Columns} from '../../components/column';
 import {InformationOutlinedIcon} from '../../components/icon/information-outlined';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
 export interface InformationModalProps {
   title: string;
   paragraph: string;
@@ -14,11 +15,12 @@ export const InformationModal: FunctionComponent<InformationModalProps> = ({
   paragraph,
 }) => {
   const style = useStyle();
+  const insects = useSafeAreaInsets();
   return (
     <BottomSheetView
       style={StyleSheet.flatten([
         style.flatten(['padding-x-12']),
-        {paddingBottom: 60},
+        {paddingBottom: 60 + insects.bottom},
       ])}>
       <Box>
         <Box paddingBottom={20} paddingTop={12} paddingX={8}>

--- a/packages/mobile/src/components/modal/modal.tsx
+++ b/packages/mobile/src/components/modal/modal.tsx
@@ -153,10 +153,10 @@ export const BaseModalHeader = ({
   const style = useStyle();
 
   return (
-    <Box paddingBottom={12} style={StyleSheet.flatten([headerStyle])}>
+    <Box padding={8} style={StyleSheet.flatten([headerStyle])}>
       <Text
         style={StyleSheet.flatten([
-          style.flatten(['color-white', 'text-center', 'subtitle1']),
+          style.flatten(['color-white', 'text-center', 'h4']),
           titleStyle,
         ])}>
         {title}

--- a/packages/mobile/src/components/modal/modal.tsx
+++ b/packages/mobile/src/components/modal/modal.tsx
@@ -153,7 +153,10 @@ export const BaseModalHeader = ({
   const style = useStyle();
 
   return (
-    <Box padding={8} style={StyleSheet.flatten([headerStyle])}>
+    <Box
+      paddingTop={10}
+      paddingBottom={8}
+      style={StyleSheet.flatten([headerStyle])}>
       <Text
         style={StyleSheet.flatten([
           style.flatten(['color-white', 'text-center', 'h4']),

--- a/packages/mobile/src/screen/home/components/token-found-modal/index.tsx
+++ b/packages/mobile/src/screen/home/components/token-found-modal/index.tsx
@@ -133,6 +133,7 @@ const TokenFoundScene = observer(() => {
   return (
     <Box padding={12} paddingTop={1} height={'100%'}>
       <BaseModalHeader title={`${numFoundToken} New Token(s) Found`} />
+      <Gutter size={12} />
       <BottomSheetScrollView>
         <Stack gutter={12}>
           {chainStore.tokenScans.map(tokenScan => {

--- a/packages/mobile/src/screen/home/components/token/index.tsx
+++ b/packages/mobile/src/screen/home/components/token/index.tsx
@@ -55,7 +55,7 @@ export const TokenTitleView: FunctionComponent<{
             {onOpenModal ? (
               <InformationOutlinedIcon
                 size={20}
-                color={style.get('color-text-low').color}
+                color={style.get('color-gray-400').color}
               />
             ) : null}
           </Columns>

--- a/packages/mobile/src/screen/sign/sign-modal.tsx
+++ b/packages/mobile/src/screen/sign/sign-modal.tsx
@@ -326,10 +326,12 @@ export const SignModal: FunctionComponent<{
           () => {},
         );
       }}>
-      <BottomSheetView style={style.flatten(['padding-12'])}>
+      <BottomSheetView style={style.flatten(['padding-12', 'padding-top-0'])}>
         <BaseModalHeader
           title={intl.formatMessage({id: 'page.sign.cosmos.tx.title'})}
+          titleStyle={style.flatten(['h3'])}
         />
+        <Gutter size={24} />
 
         <Columns sum={1} alignY="center">
           <Text style={style.flatten(['h5', 'color-blue-400'])}>


### PR DESCRIPTION
# 구현사항

ce4dfbf21f16c1d3092b4a73041f1a1be5e5e6f8 : https://www.notion.so/chainapsis/Mobile-2-0-Design-QA-4d17f1de86764d999f98e6c1bed7ee7f?p=c28207c17f89445e84a2b0b288fd80d3&pm=s 툴팁 아이콘 색상 변경

76b4a35f94aafcdb6116cef18bc8ef617661a5b2 : https://www.notion.so/chainapsis/Mobile-2-0-Design-QA-4d17f1de86764d999f98e6c1bed7ee7f?p=f20c1724ae6a4da0902311cbfd4b1acf&pm=s info modal 패딩값 변경

e49692dde1b1f61da8127adede17d77d06ab3bdf : https://www.notion.so/chainapsis/Mobile-2-0-Design-QA-4d17f1de86764d999f98e6c1bed7ee7f?p=a269454d973f407eb3d9ed8d7f7f79b2&pm=s 모달의 전반적인 타이틀과 text사이의 간격 조정함 
- 전반적인 간격을 조절 하기 위해서 baseModalTitle에 padding을 8을 준다음 그외의 모달 마다 다른 간격은 각 모달에서 조정 하도록 했습니다
paddingTop에는 10 바텀에는  8를 준 이유는 모달의 인디케이터 페딩이 10이고 디자인상 인디케이터 아래 패딩은 12여서 
해당 값을 조절 하기 위해서 paddingTop이 10입니다