### PR TITLE
[QA] main 디자인 qa을 반영 했습니다

### DIFF
--- a/packages/mobile/src/components/icon-button/icon-button.tsx
+++ b/packages/mobile/src/components/icon-button/icon-button.tsx
@@ -11,7 +11,6 @@ export const IconButton: FunctionComponent<{
   disabled?: boolean;
   onPress?: () => void;
   hasBackgroundColor?: boolean;
-  hasRipple?: boolean;
 
   containerStyle?: ViewStyle;
   textStyle?: TextStyle;
@@ -19,6 +18,7 @@ export const IconButton: FunctionComponent<{
 
   rippleColor?: string;
   underlayColor?: string;
+  activeOpacity?: number;
 }> = ({
   text,
   icon,
@@ -29,30 +29,24 @@ export const IconButton: FunctionComponent<{
   style: buttonStyle,
   containerStyle,
   hasBackgroundColor,
-  hasRipple,
   rippleColor: propRippleColor,
   underlayColor: propUnderlayColor,
+  activeOpacity = 0.3,
 }) => {
   const style = useStyle();
 
   const rippleColor = (() => {
-    if (!hasRipple) {
-      return undefined;
-    }
     if (propRippleColor) {
       return propRippleColor;
     }
-    return style.get('color-gray-500').color;
+    return style.get('color-gray-550').color;
   })();
 
   const underlayColor = (() => {
-    if (!hasRipple) {
-      return undefined;
-    }
     if (propUnderlayColor) {
       return propUnderlayColor;
     }
-    return style.get('color-gray-500').color;
+    return style.get('color-gray-550').color;
   })();
 
   const backgroundColor = 'background-color-gray-600';
@@ -75,6 +69,8 @@ export const IconButton: FunctionComponent<{
             'justify-center',
             'items-center',
             'height-full',
+            'border-radius-32',
+            'padding-6',
           ]),
           buttonStyle,
         ])}
@@ -82,8 +78,7 @@ export const IconButton: FunctionComponent<{
         enabled={!disabled}
         rippleColor={rippleColor}
         underlayColor={underlayColor}
-        activeOpacity={0.3}
-        disableRippleAndUnderlay={!hasRipple}>
+        activeOpacity={activeOpacity}>
         {path === 'left' ? (
           <Box marginRight={4} alignY="center">
             <Box>

--- a/packages/mobile/src/components/input/fee-control/index.tsx
+++ b/packages/mobile/src/components/input/fee-control/index.tsx
@@ -221,7 +221,6 @@ export const FeeControl: FunctionComponent<{
                 color={style.get('color-white').color}
               />
             }
-            hasRipple={true}
             style={style.flatten(['border-radius-64'])}
             containerStyle={style.flatten(['width-32', 'height-32'])}
             onPress={() => {

--- a/packages/mobile/src/components/input/reciepient-input/index.tsx
+++ b/packages/mobile/src/components/input/reciepient-input/index.tsx
@@ -97,7 +97,6 @@ export const RecipientInput = observer(
                     color={style.get('color-gray-10').color}
                   />
                 }
-                hasRipple={true}
                 rippleColor={style.get('color-gray-500').color}
                 underlayColor={style.get('color-gray-500').color}
                 containerStyle={style.flatten(['width-24', 'height-24'])}

--- a/packages/mobile/src/components/page/scroll-view.tsx
+++ b/packages/mobile/src/components/page/scroll-view.tsx
@@ -51,7 +51,7 @@ export const PageWithScrollView = forwardRef<
       <ContainerElement
         style={StyleSheet.flatten([
           style.flatten(
-            ['flex-1', 'border-width-top-1', 'border-color-gray-600'],
+            ['flex-1'],
             /*
              In android, overflow of container view is hidden by default.
              That's why even if you make overflow visible to the scroll view's style, it will behave like hidden unless you change the overflow property of this container view.

--- a/packages/mobile/src/components/pageHeader/header.tsx
+++ b/packages/mobile/src/components/pageHeader/header.tsx
@@ -96,7 +96,7 @@ export const HomeScreenHeader = observer(() => {
               </Text>
               <ArrowDownFillIcon
                 size={20}
-                color={style.get('color-gray-200').color}
+                color={style.get('color-gray-400').color}
               />
             </Columns>
           </Pressable>

--- a/packages/mobile/src/components/radio-group/layered/layered.tsx
+++ b/packages/mobile/src/components/radio-group/layered/layered.tsx
@@ -145,7 +145,7 @@ const getRadioItemStyle = ({
     case 'large': {
       style = {
         ...style,
-        height: 33,
+        height: 32,
         borderRadius: 16.5,
         paddingHorizontal: 10,
       };

--- a/packages/mobile/src/components/rect-button/index.tsx
+++ b/packages/mobile/src/components/rect-button/index.tsx
@@ -18,7 +18,6 @@ import {useStyle} from '../../styles';
 export const RectButton: FunctionComponent<
   RectButtonProps & {
     style?: ViewStyle;
-    disableRippleAndUnderlay?: boolean;
   }
 > = props => {
   const style = useStyle();
@@ -29,7 +28,6 @@ export const RectButton: FunctionComponent<
     rippleColor,
     underlayColor,
     activeOpacity,
-    disableRippleAndUnderlay,
     ...rest
   } = props;
 
@@ -99,15 +97,10 @@ export const RectButton: FunctionComponent<
       <NativeRectButton
         style={restStyle}
         rippleColor={
-          disableRippleAndUnderlay
-            ? undefined
-            : rippleColor || style.get('color-rect-button-default-ripple').color
+          rippleColor || style.get('color-rect-button-default-ripple').color
         }
         underlayColor={
-          disableRippleAndUnderlay
-            ? undefined
-            : underlayColor ||
-              style.get('color-rect-button-default-underlay').color
+          underlayColor || style.get('color-rect-button-default-underlay').color
         }
         activeOpacity={activeOpacity ?? 0.2}
         {...rest}>

--- a/packages/mobile/src/components/special-button/types.ts
+++ b/packages/mobile/src/components/special-button/types.ts
@@ -3,7 +3,6 @@ import React from 'react';
 export interface SpecialButtonProps {
   size?: 'extra-small' | 'small' | 'medium' | 'large';
   left?: React.ReactNode;
-  width: number;
   text?: string;
   right?: React.ReactNode;
   disabled?: boolean;

--- a/packages/mobile/src/components/toggle/index.tsx
+++ b/packages/mobile/src/components/toggle/index.tsx
@@ -3,6 +3,7 @@ import {Box} from '../box';
 import {useStyle} from '../../styles';
 import {Path, Svg} from 'react-native-svg';
 import {IconProps} from '../icon/types';
+import {ViewStyle} from 'react-native';
 
 type ToggleSize = 'small' | 'medium';
 
@@ -11,6 +12,7 @@ interface ToggleProps {
   setIsOpen?: (isOpen: boolean) => void;
   disabled?: boolean;
   size?: ToggleSize;
+  containerStyle?: ViewStyle;
 }
 
 export const Toggle: FunctionComponent<ToggleProps> = ({
@@ -18,6 +20,7 @@ export const Toggle: FunctionComponent<ToggleProps> = ({
   setIsOpen,
   disabled,
   size,
+  containerStyle,
 }) => {
   const style = useStyle();
 
@@ -36,7 +39,8 @@ export const Toggle: FunctionComponent<ToggleProps> = ({
           ? style.get('color-blue-400').color
           : style.get('color-gray-400').color
       }
-      onClick={() => (setIsOpen && !disabled ? setIsOpen(!isOpen) : null)}>
+      onClick={() => (setIsOpen && !disabled ? setIsOpen(!isOpen) : null)}
+      style={containerStyle}>
       <Box
         alignX="center"
         alignY="center"

--- a/packages/mobile/src/screen/home/available.tsx
+++ b/packages/mobile/src/screen/home/available.tsx
@@ -174,13 +174,20 @@ export const AvailableTabView: FunctionComponent<{
                       right={
                         hasLowBalanceTokens ? (
                           <React.Fragment>
-                            <Text
-                              style={style.flatten([
-                                'body2',
-                                'color-gray-300',
-                              ])}>
-                              <FormattedMessage id="page.main.available.hide-low-balance" />
-                            </Text>
+                            <Pressable
+                              onPress={() => {
+                                uiConfigStore.setHideLowBalance(
+                                  !uiConfigStore.isHideLowBalance,
+                                );
+                              }}>
+                              <Text
+                                style={style.flatten([
+                                  'body2',
+                                  'color-gray-300',
+                                ])}>
+                                <FormattedMessage id="page.main.available.hide-low-balance" />
+                              </Text>
+                            </Pressable>
                             <Gutter size={4} />
                             <Toggle
                               size="small"
@@ -190,6 +197,16 @@ export const AvailableTabView: FunctionComponent<{
                                   !uiConfigStore.isHideLowBalance,
                                 );
                               }}
+                              containerStyle={style.flatten(
+                                !uiConfigStore.isHideLowBalance
+                                  ? [
+                                      'background-color-transparent',
+                                      'border-width-2',
+                                      'border-color-gray-500',
+                                      'padding-4',
+                                    ]
+                                  : [],
+                              )}
                             />
                           </React.Fragment>
                         ) : undefined

--- a/packages/mobile/src/screen/home/components/claim-all/index.tsx
+++ b/packages/mobile/src/screen/home/components/claim-all/index.tsx
@@ -433,15 +433,14 @@ export const ClaimAll: FunctionComponent<{isNotReady?: boolean}> = observer(
               {isLedger || isKeystone ? (
                 <Button
                   text={'Claim All'}
-                  size="small"
+                  size="medium"
                   loading={claimAllIsLoading}
                   disabled={claimAllDisabled}
                   onPress={claimAll}
                 />
               ) : (
                 <SpecialButton
-                  width={91}
-                  size="small"
+                  size="medium"
                   text="Claim All"
                   disabled={claimAllDisabled}
                   isLoading={claimAllIsLoading}

--- a/packages/mobile/src/screen/home/components/claim-all/index.tsx
+++ b/packages/mobile/src/screen/home/components/claim-all/index.tsx
@@ -464,7 +464,7 @@ export const ClaimAll: FunctionComponent<{isNotReady?: boolean}> = observer(
           <Box
             alignX="center"
             style={style.flatten(
-              [],
+              ['padding-10'],
               [isPressingExpandButton && 'background-color-gray-500@50%'],
             )}>
             <Box

--- a/packages/mobile/src/screen/home/components/deposit-modal/copy-address-scene.tsx
+++ b/packages/mobile/src/screen/home/components/deposit-modal/copy-address-scene.tsx
@@ -455,6 +455,8 @@ const CopyAddressItem: FunctionComponent<{
                   chainName: address.chainInfo.chainName,
                 });
               }}
+              containerStyle={style.flatten(['width-36', 'height-36'])}
+              activeOpacity={1}
               icon={
                 <QRCodeIcon
                   size={20}

--- a/packages/mobile/src/screen/home/components/deposit-modal/qr-scene.tsx
+++ b/packages/mobile/src/screen/home/components/deposit-modal/qr-scene.tsx
@@ -35,6 +35,7 @@ export const QRScene = observer(() => {
             nav.goBack();
           }}
           icon={color => <ArrowLeftIcon color={color} size={24} />}
+          containerStyle={style.flatten(['width-32', 'height-32'])}
         />
         <Column weight={1} />
         <ChainImageFallback

--- a/packages/mobile/src/screen/home/index.tsx
+++ b/packages/mobile/src/screen/home/index.tsx
@@ -98,7 +98,7 @@ export const HomeScreen: FunctionComponent = observer(() => {
     <React.Fragment>
       <PageWithScrollView
         backgroundMode={'default'}
-        style={style.flatten(['padding-x-12'])}>
+        style={style.flatten(['padding-x-12', 'padding-top-8'])}>
         <Stack gutter={10}>
           <YAxis alignX="center">
             <LayeredHorizontalRadioGroup
@@ -195,21 +195,20 @@ export const HomeScreen: FunctionComponent = observer(() => {
 
           <Gutter size={12} />
           <ClaimAll isNotReady={isNotReady} />
+          <Gutter size={12} />
 
           {!isNotReady ? (
-            <Stack gutter={12}>
-              {tabStatus === 'available' ? (
-                <SearchTextInput
-                  ref={searchRef}
-                  value={search}
-                  onChange={e => {
-                    e.preventDefault();
-                    setSearch(e.nativeEvent.text);
-                  }}
-                  placeholder="Search for asset or chain (i.e. ATOM, Cosmos)"
-                />
-              ) : null}
-            </Stack>
+            tabStatus === 'available' ? (
+              <SearchTextInput
+                ref={searchRef}
+                value={search}
+                onChange={e => {
+                  e.preventDefault();
+                  setSearch(e.nativeEvent.text);
+                }}
+                placeholder="Search for asset or chain (i.e. ATOM, Cosmos)"
+              />
+            ) : null
           ) : null}
 
           {tabStatus === 'available' ? (

--- a/packages/mobile/src/screen/home/index.tsx
+++ b/packages/mobile/src/screen/home/index.tsx
@@ -117,6 +117,7 @@ export const HomeScreen: FunctionComponent = observer(() => {
                 setTabStatus(key as TabStatus);
               }}
               itemMinWidth={92}
+              size="large"
             />
           </YAxis>
           <Box height={168} alignX="center" alignY="center">

--- a/packages/mobile/src/screen/setting/screens/token/add/index.tsx
+++ b/packages/mobile/src/screen/setting/screens/token/add/index.tsx
@@ -311,7 +311,6 @@ export const SettingTokenAddScreen: FunctionComponent = observer(() => {
                 // readOnly={interactionInfo.interaction}
                 right={
                   <IconButton
-                    hasRipple={true}
                     rippleColor={style.get('color-gray-500').color}
                     underlayColor={style.get('color-gray-500').color}
                     icon={


### PR DESCRIPTION
0d58f81e869c11c5023119ed0dfc37a1bc9c76c4 
<img width="481" alt="Screenshot 2023-12-01 at 6 30 36 PM" src="https://github.com/chainapsis/keplr-wallet/assets/10705018/29e0dbe1-eb8d-4b0c-a78f-e4b11605e7b6">

-> https://www.notion.so/chainapsis/Mobile-2-0-Design-QA-4d17f1de86764d999f98e6c1bed7ee7f?p=ebe34fafb1924f63ab00303aed61e46c&pm=s 해당 qa 적용

79ecff477ae025b9b8112d61c90c015a6d98131a
->https://www.notion.so/chainapsis/Mobile-2-0-Design-QA-4d17f1de86764d999f98e6c1bed7ee7f?p=7c4985324d9c41e494ce6c4e6caab762&pm=s
해당 qa적용, 모든 icon button은 rippled이 적용되다 보니 hasRipple prop을 제거 했습니다.

11af71925acb0d39317d9a2cb57c865c49255c41

![Kapture 2023-12-01 at 18 32 07](https://github.com/chainapsis/keplr-wallet/assets/10705018/a863bbff-09f5-4b2b-a49c-f66a9c742a2b)
->https://www.notion.so/chainapsis/Mobile-2-0-Design-QA-4d17f1de86764d999f98e6c1bed7ee7f?p=756788c295d44626a23b98bba57aef1f&pm=s  사이즈 및 스페셜 버튼 개선 작업을 했습니다.

606ff7479d98d53a8647d8bf639c3a61661b366d
<img width="347" alt="Screenshot 2023-12-01 at 6 32 48 PM" src="https://github.com/chainapsis/keplr-wallet/assets/10705018/ee6311a8-a46b-4fd0-ab0c-84606c13ec77">
->https://www.notion.so/chainapsis/Mobile-2-0-Design-QA-4d17f1de86764d999f98e6c1bed7ee7f?p=ac773614a2dd4cc49afbfe77c5ef74b5&pm=s

ebd44ade3f6f406c4d2074e6ee3c0b1599dcdc23
<img width="314" alt="Screenshot 2023-12-01 at 6 33 26 PM" src="https://github.com/chainapsis/keplr-wallet/assets/10705018/dbc2985d-5bff-497f-8750-9dbdcfbac43d">
->https://www.notion.so/chainapsis/Mobile-2-0-Design-QA-4d17f1de86764d999f98e6c1bed7ee7f?p=3263cd4b05c94218adc7c6ef731a23d9&pm=s

eec84afced1e74233178e6948c724f04d59c8b4b
<img width="325" alt="Screenshot 2023-12-01 at 6 33 54 PM" src="https://github.com/chainapsis/keplr-wallet/assets/10705018/67ec9ef8-5f6a-447c-bba5-f4d64d4b256d">
->https://www.notion.so/chainapsis/Mobile-2-0-Design-QA-4d17f1de86764d999f98e6c1bed7ee7f?p=cb66519bb23946b28f1009b7dccb6afe&pm=s

4eb06da820229b729deba9ec260007745443b7a4
<img width="398" alt="Screenshot 2023-12-01 at 6 34 22 PM" src="https://github.com/chainapsis/keplr-wallet/assets/10705018/c2eb513f-e5da-4878-b58e-11948e67cd30">
-> https://www.notion.so/chainapsis/Mobile-2-0-Design-QA-4d17f1de86764d999f98e6c1bed7ee7f?p=1967cbe91c9d4772bad998684974406f&pm=s



02b011d6c7b6b8210facee902a1921f596d2d5f8
-> 타이틀의 border을 지웠습니다. 
일부 페이지에서는 코드상으로는 scrollVIew에서의 상단 top 보더 입니다