### PR TITLE
[QA] setting, 거번넌스, 사인 모달 메세지 qa 및 수정 작업

### DIFF
--- a/packages/mobile/App.tsx
+++ b/packages/mobile/App.tsx
@@ -39,7 +39,6 @@ const ThemeStatusBar: FunctionComponent = () => {
   const style = useStyle();
 
   style.setTheme('dark');
-
   return (
     <StatusBar
       translucent={true}

--- a/packages/mobile/src/components/chip/index.tsx
+++ b/packages/mobile/src/components/chip/index.tsx
@@ -1,12 +1,14 @@
 import React, {FunctionComponent} from 'react';
 import {useStyle} from '../../styles';
-import {Text, View} from 'react-native';
+import {StyleSheet, Text, TextStyle, View, ViewStyle} from 'react-native';
 
 export const Chip: FunctionComponent<{
   color?: 'success' | 'danger';
   mode?: 'fill' | 'light' | 'outline';
   text: string | React.ReactNode;
-}> = ({color, mode = 'fill', text}) => {
+  backgroundStyle?: ViewStyle;
+  textStyle?: TextStyle;
+}> = ({color, mode = 'fill', text, backgroundStyle, textStyle}) => {
   const style = useStyle();
 
   const baseColor = color === 'success' ? 'green' : 'red';
@@ -37,27 +39,33 @@ export const Chip: FunctionComponent<{
 
   return (
     <View
-      style={style.flatten(
-        [
-          ...(backgroundColorDefinition as any),
-          'padding-x-8',
-          'padding-y-2',
-          'border-radius-32',
-          'justify-center',
-          'items-center',
-        ],
-        [
-          mode === 'outline' && 'border-width-1',
-          mode === 'outline' && (`border-color-${baseColor}-400` as any),
-        ],
-      )}>
+      style={StyleSheet.flatten([
+        style.flatten(
+          [
+            ...(backgroundColorDefinition as any),
+            'padding-x-8',
+            'padding-y-2',
+            'border-radius-32',
+            'justify-center',
+            'items-center',
+          ],
+          [
+            mode === 'outline' && 'border-width-1',
+            mode === 'outline' && (`border-color-${baseColor}-400` as any),
+          ],
+        ),
+        backgroundStyle,
+      ])}>
       {typeof text === 'string' ? (
         <Text
-          style={style.flatten([
-            'text-overline',
-            'text-center',
-            'text-caption1',
-            ...(textColorDefinition as any),
+          style={StyleSheet.flatten([
+            style.flatten([
+              'text-overline',
+              'text-center',
+              'text-caption1',
+              ...(textColorDefinition as any),
+            ]),
+            textStyle,
           ])}>
           {text}
         </Text>

--- a/packages/mobile/src/screen/governance/components/card.tsx
+++ b/packages/mobile/src/screen/governance/components/card.tsx
@@ -23,11 +23,29 @@ import {formatRelativeTimeString} from '../../../utils/format';
 export const GovernanceProposalStatusChip: FunctionComponent<{
   status: ProposalStatus;
 }> = ({status}) => {
+  const style = useStyle();
   switch (status) {
-    case ProposalStatus.DEPOSIT_PERIOD:
-      return <Chip text="Deposit period" />;
     case ProposalStatus.VOTING_PERIOD:
-      return <Chip text="Voting period" mode="light" />;
+      return (
+        <Chip
+          text={
+            <Columns sum={1} gutter={4} alignY="center" columnAlign="center">
+              <Text style={style.flatten(['color-text-high', 'text-caption1'])}>
+                Voting period
+              </Text>
+              <Box
+                alignX="center"
+                alignY="center"
+                width={6}
+                height={6}
+                borderRadius={64}
+                backgroundColor={style.get('color-blue-300').color}
+              />
+            </Columns>
+          }
+        />
+      );
+
     case ProposalStatus.PASSED:
       return <Chip text="Passed" color="success" />;
     case ProposalStatus.REJECTED:
@@ -62,7 +80,7 @@ export const GovernanceCardBody: FunctionComponent<{
           accountStore.getAccount(chainId).bech32Address,
         ).vote;
   const navigation = useNavigation<StackNavProp>();
-  const voted = vote !== 'Unspecified';
+  const isVoted = vote !== 'Unspecified';
 
   const renderProposalDateString = (proposal: ViewProposal) => {
     switch (proposal.proposalStatus) {
@@ -137,9 +155,12 @@ export const GovernanceCardBody: FunctionComponent<{
                 {proposal.id}
               </Text>
               <Column weight={1} />
-              {voted ? (
+              {isVoted ? (
                 <React.Fragment>
                   <Chip
+                    backgroundStyle={style.flatten([
+                      'background-color-gray-400',
+                    ])}
                     text={
                       <Box alignX="center" alignY="center">
                         <Columns sum={1} gutter={2}>

--- a/packages/mobile/src/screen/governance/list/index.tsx
+++ b/packages/mobile/src/screen/governance/list/index.tsx
@@ -2,7 +2,7 @@ import React, {FunctionComponent, useMemo, useRef, useState} from 'react';
 import {observer} from 'mobx-react-lite';
 import {RouteProp, useRoute} from '@react-navigation/native';
 import {GovernanceNavigation} from '../../../navigation';
-import {FlatList, Text} from 'react-native';
+import {FlatList, StyleSheet, Text} from 'react-native';
 import {GovernanceCardBody} from '../components/card';
 import {useStore} from '../../../stores';
 import {ProposalStatus} from '../../../stores/governance/types';
@@ -12,6 +12,7 @@ import {Gutter} from '../../../components/gutter';
 import {EmptyView} from '../../../components/empty-view';
 import {FormattedMessage} from 'react-intl';
 import {useStyle} from '../../../styles';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
 
 const DEFAULT_PARAMS = {
   'pagination.offset': 0,
@@ -27,6 +28,8 @@ export const GovernanceListScreen: FunctionComponent = observer(() => {
   const governanceV1 = queriesStore.get(chainId).governanceV1.queryGovernance;
   const governanceLegacy = queriesStore.get(chainId).governance.queryGovernance;
   const isGovV1SupportedRef = useRef(isGovV1Supported || false);
+
+  const insects = useSafeAreaInsets();
 
   const governance = (() => {
     if (typeof isGovV1Supported === 'boolean') {
@@ -73,7 +76,10 @@ export const GovernanceListScreen: FunctionComponent = observer(() => {
   return (
     <FlatList
       data={sections}
-      style={style.flatten(['padding-x-12'])}
+      style={StyleSheet.flatten([
+        style.flatten(['padding-x-12']),
+        {marginBottom: insects.bottom},
+      ])}
       ListHeaderComponent={
         <React.Fragment>
           <Gutter size={12} />

--- a/packages/mobile/src/screen/setting/index.tsx
+++ b/packages/mobile/src/screen/setting/index.tsx
@@ -7,7 +7,6 @@ import {ArrowRightIcon} from '../../components/icon/arrow-right';
 import {useStyle} from '../../styles';
 import {useIntl} from 'react-intl';
 import {Box} from '../../components/box';
-import {Gutter} from '../../components/gutter';
 import {Stack} from '../../components/stack';
 import {SettingIcon} from '../../components/icon';
 import {KeyIcon} from '../../components/icon/key';
@@ -18,8 +17,7 @@ export const SettingScreen: FunctionComponent = () => {
   const intl = useIntl();
   return (
     <PageWithScrollView backgroundMode={'default'}>
-      <Box padding={12} paddingTop={0}>
-        <Gutter size={8} />
+      <Box paddingX={12} paddingTop={8}>
         <Stack gutter={8}>
           <PageButton
             title={intl.formatMessage({id: 'page.setting.general-title'})}

--- a/packages/mobile/src/screen/setting/screens/contacts/add/index.tsx
+++ b/packages/mobile/src/screen/setting/screens/contacts/add/index.tsx
@@ -15,7 +15,7 @@ import {Stack} from '../../../../../components/stack';
 import {RootStackParamList} from '../../../../../navigation';
 import {Button} from '../../../../../components/button';
 import {Column} from '../../../../../components/column';
-import {TextInput as NativeTextInput} from 'react-native';
+import {TextInput as NativeTextInput, StyleSheet} from 'react-native';
 import {PageWithScrollView} from '../../../../../components/page';
 import {useStyle} from '../../../../../styles';
 
@@ -123,10 +123,9 @@ export const SettingContactsAddScreen: FunctionComponent = observer(() => {
   return (
     <PageWithScrollView
       backgroundMode="default"
-      contentContainerStyle={style.flatten([
-        'flex-grow-1',
-        'padding-x-12',
-        'padding-y-8',
+      contentContainerStyle={StyleSheet.flatten([
+        style.flatten(['flex-grow-1', 'padding-x-12', 'padding-top-8']),
+        {paddingBottom: 23},
       ])}>
       <Stack gutter={16}>
         <TextInput

--- a/packages/mobile/src/screen/setting/screens/general/delete-suggest-chain/index.tsx
+++ b/packages/mobile/src/screen/setting/screens/general/delete-suggest-chain/index.tsx
@@ -25,7 +25,7 @@ export const SettingGeneralDeleteSuggestChainScreen: FunctionComponent =
     const style = useStyle();
 
     return (
-      <Box paddingX={12} paddingTop={8} style={style.flatten(['flex-grow-1'])}>
+      <Box paddingX={12} paddingY={8} style={style.flatten(['flex-grow-1'])}>
         <FlatList
           data={suggestedChains}
           ListHeaderComponent={() => {

--- a/packages/mobile/src/screen/setting/screens/general/fiat/index.tsx
+++ b/packages/mobile/src/screen/setting/screens/general/fiat/index.tsx
@@ -17,7 +17,7 @@ export const SettingGeneralFiatScreen: FunctionComponent = observer(() => {
   return (
     <PageWithScrollView
       backgroundMode="default"
-      style={style.flatten(['padding-x-12', 'padding-bottom-12'])}>
+      contentContainerStyle={style.flatten(['padding-x-12', 'padding-y-8'])}>
       <Stack gutter={8}>
         {Object.entries(uiConfigStore.supportedFiatCurrencies).map(
           ([fiat, fiatCurrency]) => {
@@ -50,6 +50,7 @@ export const SettingGeneralFiatScreen: FunctionComponent = observer(() => {
           },
         )}
       </Stack>
+      {/* <Gutter size={16} /> */}
     </PageWithScrollView>
   );
 });

--- a/packages/mobile/src/screen/setting/screens/general/fiat/index.tsx
+++ b/packages/mobile/src/screen/setting/screens/general/fiat/index.tsx
@@ -50,7 +50,6 @@ export const SettingGeneralFiatScreen: FunctionComponent = observer(() => {
           },
         )}
       </Stack>
-      {/* <Gutter size={16} /> */}
     </PageWithScrollView>
   );
 });

--- a/packages/mobile/src/screen/setting/screens/general/general.tsx
+++ b/packages/mobile/src/screen/setting/screens/general/general.tsx
@@ -20,7 +20,7 @@ export const SettingGeneralScreen: FunctionComponent = observer(() => {
 
   return (
     <React.Fragment>
-      <Box padding={12} paddingTop={0}>
+      <Box paddingX={12} paddingY={8}>
         <Stack gutter={8}>
           <PageButton
             title={intl.formatMessage({

--- a/packages/mobile/src/screen/setting/screens/general/language/index.tsx
+++ b/packages/mobile/src/screen/setting/screens/general/language/index.tsx
@@ -17,7 +17,7 @@ export const SettingGeneralLanguageScreen: FunctionComponent = observer(() => {
   const style = useStyle();
 
   return (
-    <Box paddingX={12} paddingBottom={12}>
+    <Box paddingX={12} paddingTop={8}>
       <Stack gutter={8}>
         <PageButton
           title={intl.formatMessage({

--- a/packages/mobile/src/screen/setting/screens/security/bio-authentication/index.tsx
+++ b/packages/mobile/src/screen/setting/screens/security/bio-authentication/index.tsx
@@ -131,7 +131,7 @@ export const SettingSecurityBio: FunctionComponent = observer(() => {
           onPress={submit}
         />
       </Stack>
-      <Gutter size={24} />
+      <Gutter size={19} />
     </PageWithScrollView>
   );
 });

--- a/packages/mobile/src/screen/setting/screens/security/change-password/index.tsx
+++ b/packages/mobile/src/screen/setting/screens/security/change-password/index.tsx
@@ -60,7 +60,7 @@ export const SettingSecurityChangePasswordScreen: FunctionComponent = observer(
       }
     });
     return (
-      <Box paddingX={12} paddingTop={12} height={'100%'} paddingBottom={28}>
+      <Box paddingX={12} paddingTop={8} height={'100%'} paddingBottom={23}>
         <Stack gutter={16}>
           <Controller
             name="password"

--- a/packages/mobile/src/screen/setting/screens/security/permission/index.tsx
+++ b/packages/mobile/src/screen/setting/screens/security/permission/index.tsx
@@ -26,7 +26,7 @@ export const SettingSecurityPermissionScreen: FunctionComponent = observer(
 
     return (
       <PageWithScrollView backgroundMode={'default'}>
-        <Box padding={12}>
+        <Box paddingX={12} paddingY={8}>
           <Stack gutter={8}>
             <SearchTextInput
               placeholder={intl.formatMessage({

--- a/packages/mobile/src/screen/setting/screens/security/security.tsx
+++ b/packages/mobile/src/screen/setting/screens/security/security.tsx
@@ -20,7 +20,7 @@ export const SettingSecurityAndPrivacyScreen: FunctionComponent = observer(
 
     return (
       <React.Fragment>
-        <Box padding={12} paddingTop={0}>
+        <Box paddingX={12} paddingTop={8}>
           <Stack gutter={8}>
             <PageButton
               title={intl.formatMessage({

--- a/packages/mobile/src/screen/setting/screens/token/add/index.tsx
+++ b/packages/mobile/src/screen/setting/screens/token/add/index.tsx
@@ -34,6 +34,7 @@ import {
   SelectModalCommonButton,
 } from '../../../../../components/select-modal';
 import {Modal} from '../../../../../components/modal';
+import {useNotification} from '../../../../../hooks/notification';
 
 interface FormData {
   contractAddress: string;
@@ -52,6 +53,7 @@ export const SettingTokenAddScreen: FunctionComponent = observer(() => {
   const paramChainId = route.params?.chainId;
   const contractModalRef = useRef<BottomSheetModal>(null);
   const selectChainModalRef = useRef<BottomSheetModal>(null);
+  const notification = useNotification();
 
   const [isOpenChainSelectModal, setIsOpenChainSelectModal] = useState(false);
 
@@ -197,18 +199,15 @@ export const SettingTokenAddScreen: FunctionComponent = observer(() => {
             blockRejectAll.current = true;
             viewingKey = await createViewingKey();
           } catch (e) {
-            //TODO 토스트 작성해야함
-            // notification.show(
-            //   'failed',
-            //   intl.formatMessage({
-            //     id: 'error.failed-to-create-viewing-key',
-            //   }),
-            //   e.message || e.toString(),
-            // );
+            notification.show(
+              'failed',
+              intl.formatMessage({
+                id: 'error.failed-to-create-viewing-key',
+              }),
+              e.message || e.toString(),
+            );
 
             await new Promise(resolve => setTimeout(resolve, 2000));
-
-            // window.close();
             return;
           }
         }

--- a/packages/mobile/src/screen/sign/claim-rewards.tsx
+++ b/packages/mobile/src/screen/sign/claim-rewards.tsx
@@ -8,6 +8,7 @@ import {useStore} from '../../stores';
 import {Staking} from '@keplr-wallet/stores';
 import {Bech32Address} from '@keplr-wallet/cosmos';
 import {Text} from 'react-native';
+import {useStyle} from '../../styles';
 
 export const ClaimRewardsMessage: IMessageRenderer = {
   process(chainId: string, msg) {
@@ -60,6 +61,7 @@ const ClaimRewardsMessagePretty: FunctionComponent<{
   validatorAddress: string;
 }> = observer(({chainId, validatorAddress}) => {
   const {queriesStore} = useStore();
+  const style = useStyle();
 
   const moniker = queriesStore
     .get(chainId)
@@ -67,15 +69,17 @@ const ClaimRewardsMessagePretty: FunctionComponent<{
     .getValidator(validatorAddress)?.description.moniker;
 
   return (
-    <FormattedMessage
-      id="page.sign.components.messages.claim-rewards.paragraph"
-      values={{
-        validator:
-          moniker || Bech32Address.shortenAddress(validatorAddress, 28),
-        b: (...chunks: any) => (
-          <Text style={{fontWeight: 'bold'}}>{chunks}</Text>
-        ),
-      }}
-    />
+    <Text style={style.flatten(['body3', 'color-text-middle'])}>
+      <FormattedMessage
+        id="page.sign.components.messages.claim-rewards.paragraph"
+        values={{
+          validator:
+            moniker || Bech32Address.shortenAddress(validatorAddress, 28),
+          b: (...chunks: any) => (
+            <Text style={{fontWeight: 'bold'}}>{chunks}</Text>
+          ),
+        }}
+      />
+    </Text>
   );
 });

--- a/packages/mobile/src/screen/sign/custom-message.tsx
+++ b/packages/mobile/src/screen/sign/custom-message.tsx
@@ -1,6 +1,7 @@
 import React, {FunctionComponent, PropsWithChildren} from 'react';
 import FastImage from 'react-native-fast-image';
 import {Text} from 'react-native';
+import {useStyle} from '../../styles';
 
 export const CustomIcon: FunctionComponent = () => {
   return (
@@ -14,5 +15,11 @@ export const CustomIcon: FunctionComponent = () => {
 export const UnknownMessageContent: FunctionComponent<PropsWithChildren> = ({
   children,
 }) => {
-  return <Text>{children}</Text>;
+  const style = useStyle();
+
+  return (
+    <Text style={style.flatten(['body3', 'color-text-middle'])}>
+      {children}
+    </Text>
+  );
 };

--- a/packages/mobile/src/screen/sign/delegate.tsx
+++ b/packages/mobile/src/screen/sign/delegate.tsx
@@ -9,6 +9,7 @@ import {IMessageRenderer} from './types';
 import FastImage from 'react-native-fast-image';
 import {useStore} from '../../stores';
 import {Text} from 'react-native';
+import {useStyle} from '../../styles';
 
 export const DelegateMessage: IMessageRenderer = {
   process(chainId: string, msg) {
@@ -62,6 +63,7 @@ const DelegateMessagePretty: FunctionComponent<{
   validatorAddress: string;
 }> = observer(({chainId, amount, validatorAddress}) => {
   const {chainStore, queriesStore} = useStore();
+  const style = useStyle();
 
   const currency = chainStore.getChain(chainId).forceFindCurrency(amount.denom);
   const coinpretty = new CoinPretty(currency, amount.amount);
@@ -71,7 +73,7 @@ const DelegateMessagePretty: FunctionComponent<{
     .getValidator(validatorAddress)?.description.moniker;
 
   return (
-    <React.Fragment>
+    <Text style={style.flatten(['body3', 'color-text-middle'])}>
       <FormattedMessage
         id="page.sign.components.messages.delegate.paragraph"
         values={{
@@ -83,6 +85,6 @@ const DelegateMessagePretty: FunctionComponent<{
           ),
         }}
       />
-    </React.Fragment>
+    </Text>
   );
 });

--- a/packages/mobile/src/screen/sign/message-item.tsx
+++ b/packages/mobile/src/screen/sign/message-item.tsx
@@ -23,9 +23,7 @@ export const MessageItem: FunctionComponent<{
         <Box style={{flexShrink: 1}}>
           <Text style={style.flatten(['color-text-high', 'h5'])}>{title}</Text>
           <Gutter size={2} />
-          <Text style={style.flatten(['color-text-middle', 'body3'])}>
-            {content}
-          </Text>
+          <Box>{content}</Box>
         </Box>
       </Columns>
     </Box>

--- a/packages/mobile/src/screen/sign/message-registry.tsx
+++ b/packages/mobile/src/screen/sign/message-registry.tsx
@@ -10,6 +10,8 @@ import {SendMessage} from './send';
 import {DelegateMessage} from './delegate';
 import {UndelegateMessage} from './undelegate';
 import {RedelegateMessage} from './redelegate';
+import {VoteMessage} from './renders/vote';
+import {ExecuteContractMessage} from './renders/execute-contract';
 
 export class MessageRenderRegistry implements IMessageRenderRegistry {
   protected renderers: IMessageRenderer[] = [];
@@ -72,3 +74,5 @@ defaultRegistry.register(SendMessage);
 defaultRegistry.register(DelegateMessage);
 defaultRegistry.register(UndelegateMessage);
 defaultRegistry.register(RedelegateMessage);
+defaultRegistry.register(VoteMessage);
+defaultRegistry.register(ExecuteContractMessage);

--- a/packages/mobile/src/screen/sign/redelegate.tsx
+++ b/packages/mobile/src/screen/sign/redelegate.tsx
@@ -10,6 +10,7 @@ import {IMessageRenderer} from './types';
 import {useStore} from '../../stores';
 import FastImage from 'react-native-fast-image';
 import {Text} from 'react-native';
+import {useStyle} from '../../styles';
 
 export const RedelegateMessage: IMessageRenderer = {
   process(chainId: string, msg) {
@@ -67,7 +68,7 @@ const RedelegateMessagePretty: FunctionComponent<{
   amount: Coin;
 }> = observer(({chainId, validatorSrcAddress, validatorDstAddress, amount}) => {
   const {chainStore, queriesStore} = useStore();
-
+  const style = useStyle();
   const currency = chainStore.getChain(chainId).forceFindCurrency(amount.denom);
   const coinPretty = new CoinPretty(currency, amount.amount);
 
@@ -83,20 +84,23 @@ const RedelegateMessagePretty: FunctionComponent<{
 
   return (
     <React.Fragment>
-      <FormattedMessage
-        id="page.sign.components.messages.redelegate.paragraph"
-        values={{
-          coin: coinPretty.trim(true).toString(),
-          from:
-            srcMoniker || Bech32Address.shortenAddress(validatorSrcAddress, 28),
-          to:
-            sdstMoniker ||
-            Bech32Address.shortenAddress(validatorDstAddress, 28),
-          b: (...chunks: any) => (
-            <Text style={{fontWeight: 'bold'}}>{chunks}</Text>
-          ),
-        }}
-      />
+      <Text style={style.flatten(['body3', 'color-text-middle'])}>
+        <FormattedMessage
+          id="page.sign.components.messages.redelegate.paragraph"
+          values={{
+            coin: coinPretty.trim(true).toString(),
+            from:
+              srcMoniker ||
+              Bech32Address.shortenAddress(validatorSrcAddress, 28),
+            to:
+              sdstMoniker ||
+              Bech32Address.shortenAddress(validatorDstAddress, 28),
+            b: (...chunks: any) => (
+              <Text style={{fontWeight: 'bold'}}>{chunks}</Text>
+            ),
+          }}
+        />
+      </Text>
     </React.Fragment>
   );
 });

--- a/packages/mobile/src/screen/sign/renders/execute-contract.tsx
+++ b/packages/mobile/src/screen/sign/renders/execute-contract.tsx
@@ -1,0 +1,123 @@
+import {IMessageRenderer} from '../types';
+import React, {FunctionComponent} from 'react';
+import {Coin} from '@keplr-wallet/types';
+import {observer} from 'mobx-react-lite';
+import {CoinPretty} from '@keplr-wallet/unit';
+import {Bech32Address} from '@keplr-wallet/cosmos';
+import {MsgExecuteContract} from '@keplr-wallet/proto-types/cosmwasm/wasm/v1/tx';
+import {MsgExecuteContract as MsgExecuteSecretContract} from '@keplr-wallet/proto-types/secret/compute/v1beta1/msg';
+import {Buffer} from 'buffer/';
+import {WasmMessageView} from './wasm-message-view';
+import {FormattedMessage} from 'react-intl';
+import FastImage from 'react-native-fast-image';
+import {useStore} from '../../../stores';
+import {Gutter} from '../../../components/gutter';
+import {Text} from 'react-native';
+import {useStyle} from '../../../styles';
+
+export const ExecuteContractMessage: IMessageRenderer = {
+  process(chainId: string, msg) {
+    const d = (() => {
+      if ('type' in msg && msg.type === 'wasm/MsgExecuteContract') {
+        return {
+          funds: msg.value.funds ?? msg.value.sent_funds ?? [],
+          contract: msg.value.contract,
+          sender: msg.value.sender,
+          msg: msg.value.msg,
+          callbackCodeHash: msg.value.callback_code_hash,
+        };
+      }
+
+      if (
+        'unpacked' in msg &&
+        (msg.typeUrl === '/cosmwasm.wasm.v1.MsgExecuteContract' ||
+          msg.typeUrl === '/secret.compute.v1beta1.MsgExecuteContract')
+      ) {
+        return {
+          funds: (msg.unpacked as MsgExecuteContract).funds,
+          contract: (msg.unpacked as MsgExecuteContract).contract,
+          sender: (msg.unpacked as MsgExecuteContract).sender,
+          msg: JSON.parse(
+            Buffer.from((msg.unpacked as MsgExecuteContract).msg).toString(),
+          ),
+          callbackCodeHash: (msg.unpacked as MsgExecuteSecretContract)
+            .callbackCodeHash,
+        };
+      }
+    })();
+
+    if (d) {
+      return {
+        icon: (
+          <FastImage
+            style={{width: 48, height: 48}}
+            source={require('../../../public/assets/img/sign/sign-execute-contract.png')}
+          />
+        ),
+        title: (
+          <FormattedMessage id="page.sign.components.messages.execute-wasm-contract.title" />
+        ),
+        content: (
+          <ExecuteContractMessagePretty
+            chainId={chainId}
+            funds={d.funds}
+            contract={d.contract}
+            sender={d.sender}
+            msg={d.msg}
+            callbackCodeHash={d.callbackCodeHash}
+          />
+        ),
+      };
+    }
+  },
+};
+
+const ExecuteContractMessagePretty: FunctionComponent<{
+  chainId: string;
+  funds: Coin[];
+  contract: string;
+  sender: string;
+  msg: object | string;
+  callbackCodeHash: string | undefined;
+}> = observer(({chainId, funds, contract, msg}) => {
+  const {chainStore} = useStore();
+  const style = useStyle();
+
+  const coins = funds.map(coin => {
+    const currency = chainStore.getChain(chainId).forceFindCurrency(coin.denom);
+
+    return new CoinPretty(currency, coin.amount);
+  });
+
+  const isSecretWasm = chainStore.getChain(chainId).hasFeature('secretwasm');
+
+  return (
+    <React.Fragment>
+      <Text style={style.flatten(['body3', 'color-text-middle'])}>
+        <FormattedMessage
+          id="page.sign.components.messages.execute-wasm-contract.paragraph"
+          values={{
+            address: Bech32Address.shortenAddress(contract, 26),
+            b: (...chunks: any) => (
+              <Text style={{fontWeight: 'bold'}}>{chunks}</Text>
+            ),
+            ['only-sent-exist']: (...chunks: any[]) =>
+              coins.length > 0 ? chunks : '',
+            sent: coins
+              .map(coinPretty => {
+                return coinPretty.trim(true).toString();
+              })
+              .join(','),
+          }}
+        />
+      </Text>
+
+      <Gutter size={6} />
+      <WasmMessageView
+        chainId={chainId}
+        msg={msg}
+        isSecretWasm={isSecretWasm}
+      />
+    </React.Fragment>
+  );
+});

--- a/packages/mobile/src/screen/sign/renders/vote.tsx
+++ b/packages/mobile/src/screen/sign/renders/vote.tsx
@@ -1,0 +1,109 @@
+import {IMessageRenderer} from '../types';
+import React, {FunctionComponent} from 'react';
+import {MsgVote} from '@keplr-wallet/proto-types/cosmos/gov/v1beta1/tx';
+import {VoteOption} from '@keplr-wallet/proto-types/cosmos/gov/v1beta1/gov';
+import {FormattedMessage, useIntl} from 'react-intl';
+import FastImage from 'react-native-fast-image';
+import {Text} from 'react-native';
+import {useStyle} from '../../../styles';
+
+export const VoteMessage: IMessageRenderer = {
+  process(chainId: string, msg) {
+    const d = (() => {
+      if ('type' in msg && msg.type === 'cosmos-sdk/MsgVote') {
+        return {
+          proposalId: msg.value.proposal_id,
+          voter: msg.value.voter,
+          option: msg.value.option,
+        };
+      }
+
+      if ('unpacked' in msg && msg.typeUrl === '/cosmos.gov.v1beta1.MsgVote') {
+        return {
+          proposalId: (msg.unpacked as MsgVote).proposalId,
+          voter: (msg.unpacked as MsgVote).voter,
+          option: (msg.unpacked as MsgVote).option,
+        };
+      }
+    })();
+
+    if (d) {
+      return {
+        icon: (
+          <FastImage
+            style={{width: 48, height: 48}}
+            source={require('../../../public/assets/img/sign/sign-vote.png')}
+          />
+        ),
+        title: (
+          <FormattedMessage id="page.sign.components.messages.vote.title" />
+        ),
+        content: (
+          <VoteMessagePretty
+            chainId={chainId}
+            proposalId={d.proposalId}
+            voter={d.voter}
+            option={d.option}
+          />
+        ),
+      };
+    }
+  },
+};
+
+const VoteMessagePretty: FunctionComponent<{
+  chainId: string;
+  proposalId: string;
+  voter: string;
+  option: VoteOption | string;
+}> = ({proposalId, option}) => {
+  const intl = useIntl();
+  const style = useStyle();
+  const textualOption = (() => {
+    if (typeof option === 'string') {
+      return option;
+    }
+
+    switch (option) {
+      case 0:
+        return intl.formatMessage({
+          id: 'page.sign.components.messages.vote.empty',
+        });
+      case 1:
+        return intl.formatMessage({
+          id: 'page.sign.components.messages.vote.yes',
+        });
+      case 2:
+        return intl.formatMessage({
+          id: 'page.sign.components.messages.vote.abstain',
+        });
+      case 3:
+        return intl.formatMessage({
+          id: 'page.sign.components.messages.vote.no',
+        });
+      case 4:
+        return intl.formatMessage({
+          id: 'page.sign.components.messages.vote.no-with-veto',
+        });
+      default:
+        return intl.formatMessage({
+          id: 'page.sign.components.messages.vote.unspecified',
+        });
+    }
+  })();
+
+  return (
+    <Text style={style.flatten(['body3', 'color-text-middle'])}>
+      <FormattedMessage
+        id="page.sign.components.messages.vote.paragraph"
+        values={{
+          textualOption,
+          proposalId,
+          b: (...chunks: any) => (
+            <Text style={{fontWeight: 'bold'}}>{chunks}</Text>
+          ),
+        }}
+      />
+    </Text>
+  );
+};

--- a/packages/mobile/src/screen/sign/renders/wasm-message-view.tsx
+++ b/packages/mobile/src/screen/sign/renders/wasm-message-view.tsx
@@ -1,0 +1,101 @@
+import React, {FunctionComponent, useEffect, useState} from 'react';
+import {observer} from 'mobx-react-lite';
+import {Buffer} from 'buffer/';
+import {useIntl} from 'react-intl';
+import {useStore} from '../../../stores';
+import {Box} from '../../../components/box';
+import {XAxis} from '../../../components/axis';
+import {Button} from '../../../components/button';
+import {StyleSheet, Text, View} from 'react-native';
+import {useStyle} from '../../../styles';
+
+export const WasmMessageView: FunctionComponent<{
+  chainId: string;
+  msg: object | string;
+  isSecretWasm?: boolean;
+}> = observer(({chainId, msg, isSecretWasm}) => {
+  const {accountStore} = useStore();
+  const intl = useIntl();
+  const style = useStyle();
+
+  const [isOpen, setIsOpen] = useState(false);
+  const toggleOpen = () => setIsOpen(isOpen => !isOpen);
+
+  const [detailsMsg, setDetailsMsg] = useState(() =>
+    JSON.stringify(msg, null, 2),
+  );
+  const [warningMsg, setWarningMsg] = useState('');
+
+  useEffect(() => {
+    // If msg is string, it will be the message for secret-wasm.
+    // So, try to decrypt.
+    // But, if this msg is not encrypted via Keplr, Keplr cannot decrypt it.
+    // TODO: Handle the error case. If an error occurs, rather than rejecting the signing, it informs the user that Keplr cannot decrypt it and allows the user to choose.
+    if (isSecretWasm && typeof msg === 'string') {
+      (async () => {
+        try {
+          let cipherText = Buffer.from(Buffer.from(msg, 'base64'));
+          // Msg is start with 32 bytes nonce and 32 bytes public key.
+          const nonce = cipherText.slice(0, 32);
+          cipherText = cipherText.slice(64);
+
+          const keplr = await accountStore.getAccount(chainId).getKeplr();
+          if (!keplr) {
+            throw new Error("Can't get the keplr API");
+          }
+
+          const enigmaUtils = keplr.getEnigmaUtils(chainId);
+          let plainText = Buffer.from(
+            await enigmaUtils.decrypt(cipherText, nonce),
+          );
+
+          plainText = plainText.slice(64);
+
+          setDetailsMsg(
+            JSON.stringify(JSON.parse(plainText.toString()), null, 2),
+          );
+          setWarningMsg('');
+        } catch {
+          setWarningMsg(
+            "Failed to decrypt Secret message. This may be due to Keplr's encrypt/decrypt seed not matching the transaction seed.",
+          );
+        }
+      })();
+    }
+  }, [accountStore, chainId, isSecretWasm, msg]);
+
+  return (
+    <Box>
+      {isOpen ? (
+        <React.Fragment>
+          <Text
+            style={StyleSheet.flatten([
+              style.flatten(['body3', 'color-text-middle']),
+              {width: 240, margin: 0, marginBottom: 8},
+            ])}>
+            {isOpen ? detailsMsg : ''}
+          </Text>
+          {warningMsg ? <View>{warningMsg}</View> : null}
+        </React.Fragment>
+      ) : null}
+      <XAxis>
+        <Button
+          size="extra-small"
+          color="secondary"
+          text={
+            isOpen
+              ? intl.formatMessage({
+                  id: 'page.sign.components.messages.wasm-message-view.close-button',
+                })
+              : intl.formatMessage({
+                  id: 'page.sign.components.messages.wasm-message-view.details-button',
+                })
+          }
+          onPress={() => {
+            toggleOpen();
+          }}
+        />
+      </XAxis>
+    </Box>
+  );
+});

--- a/packages/mobile/src/screen/sign/send.tsx
+++ b/packages/mobile/src/screen/sign/send.tsx
@@ -9,6 +9,7 @@ import FastImage from 'react-native-fast-image';
 import {FormattedMessage} from 'react-intl';
 import {useStore} from '../../stores';
 import {Text} from 'react-native';
+import {useStyle} from '../../styles';
 
 export const SendMessage: IMessageRenderer = {
   process(chainId: string, msg) {
@@ -59,6 +60,7 @@ const SendMessagePretty: FunctionComponent<{
   toAddress: string;
 }> = observer(({chainId, amount, toAddress}) => {
   const {chainStore} = useStore();
+  const style = useStyle();
   const coins = amount.map(coin => {
     const currency = chainStore.getChain(chainId).forceFindCurrency(coin.denom);
 
@@ -66,7 +68,7 @@ const SendMessagePretty: FunctionComponent<{
   });
 
   return (
-    <React.Fragment>
+    <Text style={style.flatten(['body3', 'color-text-middle'])}>
       <FormattedMessage
         id="page.sign.components.messages.send.paragraph"
         values={{
@@ -82,6 +84,6 @@ const SendMessagePretty: FunctionComponent<{
           br: '\n',
         }}
       />
-    </React.Fragment>
+    </Text>
   );
 });

--- a/packages/mobile/src/screen/sign/undelegate.tsx
+++ b/packages/mobile/src/screen/sign/undelegate.tsx
@@ -10,6 +10,7 @@ import {IMessageRenderer} from './types';
 import FastImage from 'react-native-fast-image';
 import {useStore} from '../../stores';
 import {Text} from 'react-native';
+import {useStyle} from '../../styles';
 
 export const UndelegateMessage: IMessageRenderer = {
   process(chainId: string, msg) {
@@ -61,6 +62,7 @@ const UndelegateMessagePretty: FunctionComponent<{
   amount: Coin;
 }> = observer(({chainId, validatorAddress, amount}) => {
   const {chainStore, queriesStore} = useStore();
+  const style = useStyle();
 
   const currency = chainStore.getChain(chainId).forceFindCurrency(amount.denom);
   const coinPretty = new CoinPretty(currency, amount.amount);
@@ -71,7 +73,7 @@ const UndelegateMessagePretty: FunctionComponent<{
     .getValidator(validatorAddress)?.description.moniker;
 
   return (
-    <React.Fragment>
+    <Text style={style.flatten(['body3', 'color-text-middle'])}>
       <FormattedMessage
         id="page.sign.components.messages.undelegate.paragraph"
         values={{
@@ -83,6 +85,6 @@ const UndelegateMessagePretty: FunctionComponent<{
           br: '\n',
         }}
       />
-    </React.Fragment>
+    </Text>
   );
 });

--- a/packages/mobile/src/styles/index.tsx
+++ b/packages/mobile/src/styles/index.tsx
@@ -691,7 +691,7 @@ export const {StyleProvider, useStyle, useStyleThemeController} =
             ],
           },
 
-          'status-bar-style': 'dark-content' as StatusBarStyle,
+          'status-bar-style': 'light-content' as StatusBarStyle,
 
           'header-on-gradient-screen': {
             blurOnIOS: {


### PR DESCRIPTION
# 구현 사항
0d9527fef4a4ddb56d61789845c12658216f6faa
-> https://www.notion.so/chainapsis/Mobile-2-0-Design-QA-4d17f1de86764d999f98e6c1bed7ee7f?p=d1827e3cdf0d406ba84478b3176aa87e&pm=s
proposals에서 chip 배경색 변경 및 voting period일때 파란색 dot 추가


4d4e9335709cb2279954183471b96086cb628b19
e1588f521252844135511f384a585f1947e41d4b
bc5f017bbd2d21a03455dd331219f1da0a771997
-> https://www.notion.so/chainapsis/Mobile-2-0-Design-QA-4d17f1de86764d999f98e6c1bed7ee7f?p=4dff3b685c2c45bc9338d50059ff4796&pm=s
해당 이슈 및 다른 전체 셋팅페이지에서 디자인과 같을수 있게 패딩값을 다 수정 했습니다

aee3220c2f3761b32c71f5e40f351fddc6549257
-> 시크릿에서 토큰 추가 할때 뷰잉키 생성 트랜잭션 실패시 토스트 띄우는 로직 추가

9512bc289be1a460067a9ac72956a76270160d82
-> sign modal에서 메세지를 예쁘게 보여줄때 content를 text 에서 box 컴포넌트로 수정 했습니다
그리고 각 메세지에서 폰트 사이즈및 컬러를 지정 해줬습니다 이렇게 한 이유는 아래 커밋에서 기술 하겠습니다

420e436b5c557c2013f6342009d9bf87c975cd9c
-> vote,wasm excute 트랜잭션 messga 추가
wasm excute 메세지의 경우 메세지안  `상세보기` 버튼이 있는데 만약 content를 `Text` 컴포넌트로 감쌀 경우 
상세보기 후 접었을때 부모 컴포넌트의 크기가 줄어들지 않음 해서 위 커밋에서 box로 변경함



0f11511fe989411f694924a84a50428c8349cb39
-> status bar가 다크모드 일때 보이지 않아서 light-content로 변경함
현재 라이트모드를 고려하고 있지 않기때문에 그냥 `light-content` 설정함

마지막 커밋은
proposals에 바텀 마진이 없는것 같아서 추가 했습니다.
gutter 지운건 그냥 리팩토링 입니다