### PR TITLE
[QA] 전반적인 card 색상 수정 및 기타 스타일 변경

### DIFF
--- a/packages/mobile/src/components/button/button.tsx
+++ b/packages/mobile/src/components/button/button.tsx
@@ -60,7 +60,7 @@ export const Button: FunctionComponent<{
       case 'danger':
         return [`background-color-${baseColor}-300@30%`];
       case 'secondary':
-        return [`background-color-${baseColor}-400`];
+        return [`background-color-${baseColor}-500`];
       //default는 기본적으로 primary 색상으로 적용
       default:
         return [

--- a/packages/mobile/src/components/collapsible-list/collapsible-list.tsx
+++ b/packages/mobile/src/components/collapsible-list/collapsible-list.tsx
@@ -69,8 +69,8 @@ export const CollapsibleList: FunctionComponent<CollapsibleListProps> = ({
           <Gutter size={12} />
           <TextButton
             containerStyle={style.flatten(['padding-y-12'])}
-            textColor="gray-300"
-            pressingColor="gray-400"
+            textColor={style.get('color-gray-300').color}
+            pressingColor={style.get('color-gray-400').color}
             text={
               isCollapsed
                 ? intl.formatMessage(

--- a/packages/mobile/src/components/collapsible-list/collapsible-list.tsx
+++ b/packages/mobile/src/components/collapsible-list/collapsible-list.tsx
@@ -11,6 +11,13 @@ import {ArrowUpIcon} from '../icon/arrow-up';
 import {TextButton} from '../text-button';
 import {useIntl} from 'react-intl';
 
+const ArrowDownIconFunc = (color: string) => (
+  <ArrowDownIcon size={16} color={color} />
+);
+const ArrowUpIconFunc = (color: string) => (
+  <ArrowUpIcon size={16} color={color} />
+);
+
 export const CollapsibleList: FunctionComponent<CollapsibleListProps> = ({
   title,
   items,
@@ -62,6 +69,8 @@ export const CollapsibleList: FunctionComponent<CollapsibleListProps> = ({
           <Gutter size={12} />
           <TextButton
             containerStyle={style.flatten(['padding-y-12'])}
+            textColor="gray-300"
+            pressingColor="gray-400"
             text={
               isCollapsed
                 ? intl.formatMessage(
@@ -72,19 +81,7 @@ export const CollapsibleList: FunctionComponent<CollapsibleListProps> = ({
                     id: 'components.collapsible-list.collapse',
                   })
             }
-            rightIcon={
-              isCollapsed ? (
-                <ArrowDownIcon
-                  size={16}
-                  color={style.get('color-gray-300').color}
-                />
-              ) : (
-                <ArrowUpIcon
-                  size={16}
-                  color={style.get('color-gray-300').color}
-                />
-              )
-            }
+            rightIcon={isCollapsed ? ArrowDownIconFunc : ArrowUpIconFunc}
             onPress={() => {
               setIsCollapsed(!isCollapsed);
             }}

--- a/packages/mobile/src/components/input/text-input/text-input.tsx
+++ b/packages/mobile/src/components/input/text-input/text-input.tsx
@@ -57,7 +57,7 @@ export const TextInput = forwardRef<
     })();
 
     const disableStyle = [
-      'background-color-gray-600',
+      'background-color-gray-650',
       'border-color-gray-300',
     ] as const;
 

--- a/packages/mobile/src/components/pageHeader/header.tsx
+++ b/packages/mobile/src/components/pageHeader/header.tsx
@@ -154,8 +154,10 @@ export const defaultHeaderOptions = {
   headerTitle: DefaultScreenHeaderTitle,
   headerTitleAlign: 'center' as 'center' | 'left',
   headerBackVisible: false,
+
   headerStyle: {
     backgroundColor: ColorPalette['gray-700'],
   },
+  headerShadowVisible: false,
   headerLeft: (props: any) => <DefaultScreenHeaderLeft {...props} />,
 };

--- a/packages/mobile/src/components/rect-button/index.tsx
+++ b/packages/mobile/src/components/rect-button/index.tsx
@@ -1,10 +1,11 @@
 import React, {FunctionComponent} from 'react';
-import {View, ViewStyle} from 'react-native';
+import {StyleSheet, View, ViewStyle} from 'react-native';
 import {
   RectButton as NativeRectButton,
   RectButtonProps,
 } from 'react-native-gesture-handler';
 import {useStyle} from '../../styles';
+import {Box} from '../box';
 
 /**
  * RectButton replaces the "RectButton" of "react-native-gesture-handler".
@@ -18,6 +19,8 @@ import {useStyle} from '../../styles';
 export const RectButton: FunctionComponent<
   RectButtonProps & {
     style?: ViewStyle;
+    disabled?: boolean;
+    disabledStyle?: ViewStyle;
   }
 > = props => {
   const style = useStyle();
@@ -28,6 +31,8 @@ export const RectButton: FunctionComponent<
     rippleColor,
     underlayColor,
     activeOpacity,
+    disabled,
+    disabledStyle,
     ...rest
   } = props;
 
@@ -94,18 +99,26 @@ export const RectButton: FunctionComponent<
         flexWrap,
         backgroundColor,
       }}>
-      <NativeRectButton
-        style={restStyle}
-        rippleColor={
-          rippleColor || style.get('color-rect-button-default-ripple').color
-        }
-        underlayColor={
-          underlayColor || style.get('color-rect-button-default-underlay').color
-        }
-        activeOpacity={activeOpacity ?? 0.2}
-        {...rest}>
-        {children}
-      </NativeRectButton>
+      {/* NOTE disabled 일때는 rect button의 rippleColor 스타일이 들어가면 안되기 때문에 box로 렌더링함*/}
+      {disabled ? (
+        <Box style={StyleSheet.flatten([restStyle, disabledStyle])}>
+          {children}
+        </Box>
+      ) : (
+        <NativeRectButton
+          style={restStyle}
+          rippleColor={
+            rippleColor || style.get('color-rect-button-default-ripple').color
+          }
+          underlayColor={
+            underlayColor ||
+            style.get('color-rect-button-default-underlay').color
+          }
+          activeOpacity={activeOpacity ?? 0.2}
+          {...rest}>
+          {children}
+        </NativeRectButton>
+      )}
     </View>
   );
 };

--- a/packages/mobile/src/components/text-button/text-button.tsx
+++ b/packages/mobile/src/components/text-button/text-button.tsx
@@ -4,7 +4,7 @@ import React, {
   isValidElement,
   useState,
 } from 'react';
-import {ColorPalette, useStyle} from '../../styles';
+import {useStyle} from '../../styles';
 import {Text, StyleSheet, TextStyle, Pressable, ViewStyle} from 'react-native';
 import {Box} from '../box';
 
@@ -18,9 +18,10 @@ export const TextButton: FunctionComponent<{
   rightIcon?: ReactElement | ((color: string) => ReactElement);
   disabled?: boolean;
   onPress?: () => void;
-  textStyle?: TextStyle;
-  textColor?: keyof typeof ColorPalette;
-  pressingColor?: keyof typeof ColorPalette;
+  //NOTE textStyle에서 색상을 변경하면 pressing 컬러가 먹히지 않기 떄문에 Omit으로 color만 제거함
+  textStyle?: Omit<TextStyle, 'color'>;
+  textColor?: string;
+  pressingColor?: string;
   textButtonSize?: number;
   containerStyle?: ViewStyle;
 }> = ({
@@ -38,29 +39,29 @@ export const TextButton: FunctionComponent<{
   const style = useStyle();
   const [isPressIn, setIsPressIn] = useState(false);
 
-  const textColorDefinition: string = (() => {
+  const textColorDefinition = (() => {
     if (textColor) {
-      return `color-${textColor}`;
+      return textColor;
     }
     switch (color) {
       case 'faint':
         if (disabled) {
-          return 'color-gray-300';
+          return style.get('color-gray-300').color;
         }
-        return 'color-gray-200';
+        return style.get('color-gray-200').color;
       default:
         if (disabled) {
-          return 'color-gray-300';
+          return style.get('color-gray-300').color;
         }
-        return 'color-white';
+        return style.get('color-white').color;
     }
   })();
 
-  const pressingColorDefinition: string = (() => {
+  const pressingColorDefinition = (() => {
     if (pressingColor) {
-      return `color-${pressingColor}`;
+      return pressingColor;
     }
-    return 'color-gray-300';
+    return style.get('color-gray-300').color;
   })();
 
   return (
@@ -72,7 +73,6 @@ export const TextButton: FunctionComponent<{
           'justify-center',
           'items-center',
           'padding-x-8',
-          isPressIn ? 'color-gray-300' : (textColorDefinition as any),
         ]),
         containerStyle,
       ])}
@@ -84,10 +84,10 @@ export const TextButton: FunctionComponent<{
           style.flatten([
             'text-center',
             size === 'large' ? 'text-button1' : 'text-button2',
-            isPressIn
-              ? (pressingColorDefinition as any)
-              : (textColorDefinition as any),
           ]),
+          {
+            color: isPressIn ? pressingColorDefinition : textColorDefinition,
+          },
           textStyle,
         ])}>
         {text}
@@ -98,9 +98,7 @@ export const TextButton: FunctionComponent<{
         !(typeof rightIcon === 'function')
           ? rightIcon
           : rightIcon(
-              isPressIn
-                ? style.get(pressingColorDefinition as any).color
-                : style.get(textColorDefinition as any).color,
+              isPressIn ? pressingColorDefinition : textColorDefinition,
             )}
       </Box>
     </Pressable>

--- a/packages/mobile/src/components/text-button/text-button.tsx
+++ b/packages/mobile/src/components/text-button/text-button.tsx
@@ -4,7 +4,7 @@ import React, {
   isValidElement,
   useState,
 } from 'react';
-import {useStyle} from '../../styles';
+import {ColorPalette, useStyle} from '../../styles';
 import {Text, StyleSheet, TextStyle, Pressable, ViewStyle} from 'react-native';
 import {Box} from '../box';
 
@@ -19,6 +19,8 @@ export const TextButton: FunctionComponent<{
   disabled?: boolean;
   onPress?: () => void;
   textStyle?: TextStyle;
+  textColor?: keyof typeof ColorPalette;
+  pressingColor?: keyof typeof ColorPalette;
   textButtonSize?: number;
   containerStyle?: ViewStyle;
 }> = ({
@@ -30,11 +32,16 @@ export const TextButton: FunctionComponent<{
   onPress,
   textStyle,
   containerStyle,
+  textColor,
+  pressingColor,
 }) => {
   const style = useStyle();
   const [isPressIn, setIsPressIn] = useState(false);
 
   const textColorDefinition: string = (() => {
+    if (textColor) {
+      return `color-${textColor}`;
+    }
     switch (color) {
       case 'faint':
         if (disabled) {
@@ -47,6 +54,13 @@ export const TextButton: FunctionComponent<{
         }
         return 'color-white';
     }
+  })();
+
+  const pressingColorDefinition: string = (() => {
+    if (pressingColor) {
+      return `color-${pressingColor}`;
+    }
+    return 'color-gray-300';
   })();
 
   return (
@@ -70,7 +84,9 @@ export const TextButton: FunctionComponent<{
           style.flatten([
             'text-center',
             size === 'large' ? 'text-button1' : 'text-button2',
-            isPressIn ? 'color-gray-300' : (textColorDefinition as any),
+            isPressIn
+              ? (pressingColorDefinition as any)
+              : (textColorDefinition as any),
           ]),
           textStyle,
         ])}>
@@ -83,7 +99,7 @@ export const TextButton: FunctionComponent<{
           ? rightIcon
           : rightIcon(
               isPressIn
-                ? style.get('color-gray-300').color
+                ? style.get(pressingColorDefinition as any).color
                 : style.get(textColorDefinition as any).color,
             )}
       </Box>

--- a/packages/mobile/src/components/token-view/index.tsx
+++ b/packages/mobile/src/components/token-view/index.tsx
@@ -1,6 +1,6 @@
 import React, {FunctionComponent, useMemo} from 'react';
 import {observer} from 'mobx-react-lite';
-import {Pressable, StyleSheet, Text} from 'react-native';
+import {StyleSheet, Text} from 'react-native';
 import {useStyle} from '../../styles';
 import {Column, Columns} from '../column';
 import {useStore} from '../../stores';
@@ -12,6 +12,7 @@ import {CoinPretty} from '@keplr-wallet/unit';
 import {IChainInfoImpl, QueryError} from '@keplr-wallet/stores';
 import {Box} from '../box';
 import {ArrowRightIcon} from '../icon/arrow-right';
+import {RectButton} from '../rect-button';
 
 export interface ViewToken {
   token: CoinPretty;
@@ -51,83 +52,164 @@ export const TokenItem: FunctionComponent<TokenItemProps> = observer(
     }, [viewToken.token.currency]);
 
     return (
-      <Pressable
-        onPress={onClick}
-        disabled={disabled}
-        style={StyleSheet.flatten([
-          style.flatten([
-            'padding-16',
-            'border-radius-6',
-            'background-color-gray-600',
-          ]),
-        ])}>
-        <Columns sum={1} alignY="center">
-          <FastImage
-            style={style.flatten(['width-32', 'height-32'])}
-            source={
-              viewToken.token.currency.coinImageUrl
-                ? {uri: viewToken.token.currency.coinImageUrl}
-                : require('../../public/assets/img/chain-icon-alt.png')
-            }
-            resizeMode={FastImage.resizeMode.contain}
-          />
+      <React.Fragment>
+        {disabled ? (
+          <Box
+            style={StyleSheet.flatten([
+              style.flatten([
+                'padding-16',
+                'border-radius-6',
+                'background-color-card-default',
+              ]),
+            ])}>
+            <Columns sum={1} alignY="center">
+              <FastImage
+                style={style.flatten(['width-32', 'height-32'])}
+                source={
+                  viewToken.token.currency.coinImageUrl
+                    ? {uri: viewToken.token.currency.coinImageUrl}
+                    : require('../../public/assets/img/chain-icon-alt.png')
+                }
+                resizeMode={FastImage.resizeMode.contain}
+              />
 
-          <Gutter size={12} />
+              <Gutter size={12} />
 
-          <Box style={style.flatten(['flex-column', 'flex-shrink-1'])}>
-            <XAxis>
-              <Text
-                style={{
-                  ...style.flatten(['color-gray-10', 'subtitle2']),
-                }}>
-                {coinDenom}
-              </Text>
+              <Box style={style.flatten(['flex-column', 'flex-shrink-1'])}>
+                <XAxis>
+                  <Text
+                    style={{
+                      ...style.flatten(['color-gray-10', 'subtitle2']),
+                    }}>
+                    {coinDenom}
+                  </Text>
+
+                  <Gutter size={4} />
+                  {isIBC ? <Tag text="IBC" /> : null}
+                </XAxis>
+
+                <Text style={style.flatten(['color-gray-300', 'body3'])}>
+                  {viewToken.chainInfo.chainName}
+                </Text>
+              </Box>
+
+              <Column weight={1} />
+
+              <Box
+                style={style.flatten([
+                  'flex-column',
+                  'flex-shrink-1',
+                  'items-end',
+                ])}>
+                <Text style={style.flatten(['color-gray-10', 'subtitle1'])}>
+                  {viewToken.token
+                    .hideDenom(true)
+                    .maxDecimals(6)
+                    .inequalitySymbol(true)
+                    .shrink(true)
+                    .toString()}
+                </Text>
+
+                <Text style={style.flatten(['color-gray-300', 'subtitle2'])}>
+                  {pricePretty
+                    ? pricePretty.inequalitySymbol(true).toString()
+                    : '-'}
+                </Text>
+              </Box>
 
               <Gutter size={4} />
-              {isIBC ? <Tag text="IBC" /> : null}
-            </XAxis>
 
-            <Text style={style.flatten(['color-gray-300', 'body3'])}>
-              {viewToken.chainInfo.chainName}
-            </Text>
+              {forChange ? (
+                <Box>
+                  <ArrowRightIcon
+                    size={24}
+                    color={style.get('color-gray-300').color}
+                  />
+                </Box>
+              ) : null}
+            </Columns>
           </Box>
-
-          <Column weight={1} />
-
-          <Box
-            style={style.flatten([
-              'flex-column',
-              'flex-shrink-1',
-              'items-end',
-            ])}>
-            <Text style={style.flatten(['color-gray-10', 'subtitle1'])}>
-              {viewToken.token
-                .hideDenom(true)
-                .maxDecimals(6)
-                .inequalitySymbol(true)
-                .shrink(true)
-                .toString()}
-            </Text>
-
-            <Text style={style.flatten(['color-gray-300', 'subtitle2'])}>
-              {pricePretty
-                ? pricePretty.inequalitySymbol(true).toString()
-                : '-'}
-            </Text>
-          </Box>
-
-          <Gutter size={4} />
-
-          {forChange ? (
-            <Box>
-              <ArrowRightIcon
-                size={24}
-                color={style.get('color-gray-300').color}
+        ) : (
+          <RectButton
+            onPress={onClick}
+            style={StyleSheet.flatten([
+              style.flatten([
+                'padding-16',
+                'border-radius-6',
+                'background-color-card-default',
+              ]),
+            ])}
+            rippleColor={style.get('color-card-pressing-default').color}
+            underlayColor={style.get('color-card-pressing-default').color}>
+            <Columns sum={1} alignY="center">
+              <FastImage
+                style={style.flatten(['width-32', 'height-32'])}
+                source={
+                  viewToken.token.currency.coinImageUrl
+                    ? {uri: viewToken.token.currency.coinImageUrl}
+                    : require('../../public/assets/img/chain-icon-alt.png')
+                }
+                resizeMode={FastImage.resizeMode.contain}
               />
-            </Box>
-          ) : null}
-        </Columns>
-      </Pressable>
+
+              <Gutter size={12} />
+
+              <Box style={style.flatten(['flex-column', 'flex-shrink-1'])}>
+                <XAxis>
+                  <Text
+                    style={{
+                      ...style.flatten(['color-gray-10', 'subtitle2']),
+                    }}>
+                    {coinDenom}
+                  </Text>
+
+                  <Gutter size={4} />
+                  {isIBC ? <Tag text="IBC" /> : null}
+                </XAxis>
+
+                <Text style={style.flatten(['color-gray-300', 'body3'])}>
+                  {viewToken.chainInfo.chainName}
+                </Text>
+              </Box>
+
+              <Column weight={1} />
+
+              <Box
+                style={style.flatten([
+                  'flex-column',
+                  'flex-shrink-1',
+                  'items-end',
+                ])}>
+                <Text style={style.flatten(['color-gray-10', 'subtitle1'])}>
+                  {viewToken.token
+                    .hideDenom(true)
+                    .maxDecimals(6)
+                    .inequalitySymbol(true)
+                    .shrink(true)
+                    .toString()}
+                </Text>
+
+                <Text style={style.flatten(['color-gray-300', 'subtitle2'])}>
+                  {pricePretty
+                    ? pricePretty.inequalitySymbol(true).toString()
+                    : '-'}
+                </Text>
+              </Box>
+
+              <Gutter size={4} />
+
+              {forChange ? (
+                <Box>
+                  <ArrowRightIcon
+                    size={24}
+                    color={style.get('color-gray-300').color}
+                  />
+                </Box>
+              ) : null}
+            </Columns>
+          </RectButton>
+        )}
+      </React.Fragment>
     );
   },
 );

--- a/packages/mobile/src/components/token-view/index.tsx
+++ b/packages/mobile/src/components/token-view/index.tsx
@@ -52,164 +52,85 @@ export const TokenItem: FunctionComponent<TokenItemProps> = observer(
     }, [viewToken.token.currency]);
 
     return (
-      <React.Fragment>
-        {disabled ? (
-          <Box
-            style={StyleSheet.flatten([
-              style.flatten([
-                'padding-16',
-                'border-radius-6',
-                'background-color-card-default',
-              ]),
-            ])}>
-            <Columns sum={1} alignY="center">
-              <FastImage
-                style={style.flatten(['width-32', 'height-32'])}
-                source={
-                  viewToken.token.currency.coinImageUrl
-                    ? {uri: viewToken.token.currency.coinImageUrl}
-                    : require('../../public/assets/img/chain-icon-alt.png')
-                }
-                resizeMode={FastImage.resizeMode.contain}
-              />
+      <RectButton
+        disabled={disabled}
+        onPress={onClick}
+        style={StyleSheet.flatten([
+          style.flatten([
+            'padding-16',
+            'border-radius-6',
+            'background-color-card-default',
+          ]),
+        ])}
+        rippleColor={style.get('color-card-pressing-default').color}
+        underlayColor={style.get('color-card-pressing-default').color}>
+        <Columns sum={1} alignY="center">
+          <FastImage
+            style={style.flatten(['width-32', 'height-32'])}
+            source={
+              viewToken.token.currency.coinImageUrl
+                ? {uri: viewToken.token.currency.coinImageUrl}
+                : require('../../public/assets/img/chain-icon-alt.png')
+            }
+            resizeMode={FastImage.resizeMode.contain}
+          />
 
-              <Gutter size={12} />
+          <Gutter size={12} />
 
-              <Box style={style.flatten(['flex-column', 'flex-shrink-1'])}>
-                <XAxis>
-                  <Text
-                    style={{
-                      ...style.flatten(['color-gray-10', 'subtitle2']),
-                    }}>
-                    {coinDenom}
-                  </Text>
-
-                  <Gutter size={4} />
-                  {isIBC ? <Tag text="IBC" /> : null}
-                </XAxis>
-
-                <Text style={style.flatten(['color-gray-300', 'body3'])}>
-                  {viewToken.chainInfo.chainName}
-                </Text>
-              </Box>
-
-              <Column weight={1} />
-
-              <Box
-                style={style.flatten([
-                  'flex-column',
-                  'flex-shrink-1',
-                  'items-end',
-                ])}>
-                <Text style={style.flatten(['color-gray-10', 'subtitle1'])}>
-                  {viewToken.token
-                    .hideDenom(true)
-                    .maxDecimals(6)
-                    .inequalitySymbol(true)
-                    .shrink(true)
-                    .toString()}
-                </Text>
-
-                <Text style={style.flatten(['color-gray-300', 'subtitle2'])}>
-                  {pricePretty
-                    ? pricePretty.inequalitySymbol(true).toString()
-                    : '-'}
-                </Text>
-              </Box>
+          <Box style={style.flatten(['flex-column', 'flex-shrink-1'])}>
+            <XAxis>
+              <Text
+                style={{
+                  ...style.flatten(['color-gray-10', 'subtitle2']),
+                }}>
+                {coinDenom}
+              </Text>
 
               <Gutter size={4} />
+              {isIBC ? <Tag text="IBC" /> : null}
+            </XAxis>
 
-              {forChange ? (
-                <Box>
-                  <ArrowRightIcon
-                    size={24}
-                    color={style.get('color-gray-300').color}
-                  />
-                </Box>
-              ) : null}
-            </Columns>
+            <Text style={style.flatten(['color-gray-300', 'body3'])}>
+              {viewToken.chainInfo.chainName}
+            </Text>
           </Box>
-        ) : (
-          <RectButton
-            onPress={onClick}
-            style={StyleSheet.flatten([
-              style.flatten([
-                'padding-16',
-                'border-radius-6',
-                'background-color-card-default',
-              ]),
-            ])}
-            rippleColor={style.get('color-card-pressing-default').color}
-            underlayColor={style.get('color-card-pressing-default').color}>
-            <Columns sum={1} alignY="center">
-              <FastImage
-                style={style.flatten(['width-32', 'height-32'])}
-                source={
-                  viewToken.token.currency.coinImageUrl
-                    ? {uri: viewToken.token.currency.coinImageUrl}
-                    : require('../../public/assets/img/chain-icon-alt.png')
-                }
-                resizeMode={FastImage.resizeMode.contain}
+
+          <Column weight={1} />
+
+          <Box
+            style={style.flatten([
+              'flex-column',
+              'flex-shrink-1',
+              'items-end',
+            ])}>
+            <Text style={style.flatten(['color-gray-10', 'subtitle1'])}>
+              {viewToken.token
+                .hideDenom(true)
+                .maxDecimals(6)
+                .inequalitySymbol(true)
+                .shrink(true)
+                .toString()}
+            </Text>
+
+            <Text style={style.flatten(['color-gray-300', 'subtitle2'])}>
+              {pricePretty
+                ? pricePretty.inequalitySymbol(true).toString()
+                : '-'}
+            </Text>
+          </Box>
+
+          <Gutter size={4} />
+
+          {forChange ? (
+            <Box>
+              <ArrowRightIcon
+                size={24}
+                color={style.get('color-gray-300').color}
               />
-
-              <Gutter size={12} />
-
-              <Box style={style.flatten(['flex-column', 'flex-shrink-1'])}>
-                <XAxis>
-                  <Text
-                    style={{
-                      ...style.flatten(['color-gray-10', 'subtitle2']),
-                    }}>
-                    {coinDenom}
-                  </Text>
-
-                  <Gutter size={4} />
-                  {isIBC ? <Tag text="IBC" /> : null}
-                </XAxis>
-
-                <Text style={style.flatten(['color-gray-300', 'body3'])}>
-                  {viewToken.chainInfo.chainName}
-                </Text>
-              </Box>
-
-              <Column weight={1} />
-
-              <Box
-                style={style.flatten([
-                  'flex-column',
-                  'flex-shrink-1',
-                  'items-end',
-                ])}>
-                <Text style={style.flatten(['color-gray-10', 'subtitle1'])}>
-                  {viewToken.token
-                    .hideDenom(true)
-                    .maxDecimals(6)
-                    .inequalitySymbol(true)
-                    .shrink(true)
-                    .toString()}
-                </Text>
-
-                <Text style={style.flatten(['color-gray-300', 'subtitle2'])}>
-                  {pricePretty
-                    ? pricePretty.inequalitySymbol(true).toString()
-                    : '-'}
-                </Text>
-              </Box>
-
-              <Gutter size={4} />
-
-              {forChange ? (
-                <Box>
-                  <ArrowRightIcon
-                    size={24}
-                    color={style.get('color-gray-300').color}
-                  />
-                </Box>
-              ) : null}
-            </Columns>
-          </RectButton>
-        )}
-      </React.Fragment>
+            </Box>
+          ) : null}
+        </Columns>
+      </RectButton>
     );
   },
 );

--- a/packages/mobile/src/screen/governance/components/card.tsx
+++ b/packages/mobile/src/screen/governance/components/card.tsx
@@ -129,7 +129,10 @@ export const GovernanceCardBody: FunctionComponent<{
   return (
     <Box
       borderRadius={6}
-      style={style.flatten(['overflow-hidden', 'background-color-gray-600'])}>
+      style={style.flatten([
+        'overflow-hidden',
+        'background-color-card-default',
+      ])}>
       {proposal ? (
         <RectButton
           style={style.flatten(['padding-16'])}

--- a/packages/mobile/src/screen/governance/index.tsx
+++ b/packages/mobile/src/screen/governance/index.tsx
@@ -199,7 +199,7 @@ export const ChainItem: FunctionComponent<ChainItemProps> = observer(
     const style = useStyle();
 
     const containerStyle: ViewStyle = {
-      backgroundColor: style.get('color-gray-600').color,
+      backgroundColor: style.get('color-card-default').color,
       paddingVertical: 18,
       paddingLeft: 16,
       paddingRight: 8,
@@ -209,8 +209,8 @@ export const ChainItem: FunctionComponent<ChainItemProps> = observer(
     return (
       <RectButton
         style={StyleSheet.flatten([containerStyle])}
-        rippleColor={style.get('color-gray-550').color}
-        underlayColor={style.get('color-gray-550').color}
+        rippleColor={style.get('color-card-pressing-default').color}
+        underlayColor={style.get('color-card-pressing-default').color}
         activeOpacity={1}
         onPress={() => {
           if (onClick) {

--- a/packages/mobile/src/screen/home/components/claim-all/index.tsx
+++ b/packages/mobile/src/screen/home/components/claim-all/index.tsx
@@ -397,7 +397,7 @@ export const ClaimAll: FunctionComponent<{isNotReady?: boolean}> = observer(
       <Box
         borderRadius={6}
         paddingTop={12}
-        style={style.flatten(['dark:background-color-gray-600'])}>
+        style={style.flatten(['background-color-card-default'])}>
         <Box paddingX={16} paddingBottom={4}>
           <Columns sum={1} alignY="center">
             <Stack gutter={8}>
@@ -411,12 +411,7 @@ export const ClaimAll: FunctionComponent<{isNotReady?: boolean}> = observer(
 
               <YAxis alignX="left">
                 <Skeleton layer={1} isNotReady={isNotReady} dummyMinWidth={82}>
-                  <Text
-                    style={style.flatten([
-                      'subtitle2',
-                      'dark:color-gray-700',
-                      'color-gray-10',
-                    ])}>
+                  <Text style={style.flatten(['subtitle2', 'color-text-high'])}>
                     {totalPrice ? totalPrice.separator(' ').toString() : '?'}
                   </Text>
                 </Skeleton>

--- a/packages/mobile/src/screen/home/components/token/index.tsx
+++ b/packages/mobile/src/screen/home/components/token/index.tsx
@@ -125,7 +125,7 @@ export const TokenItem: FunctionComponent<TokenItemProps> = observer(
     }, [viewToken.token.currency]);
 
     const containerStyle: ViewStyle = {
-      backgroundColor: style.get('color-gray-600').color,
+      backgroundColor: style.get('color-card-default').color,
       paddingTop: 16,
       paddingBottom: 16,
       paddingLeft: 16,
@@ -143,9 +143,11 @@ export const TokenItem: FunctionComponent<TokenItemProps> = observer(
             borderColor: style.get('color-yellow-400@50%').color,
           },
         ])}
-        rippleColor={!disabled ? style.get('color-gray-550').color : undefined}
+        rippleColor={
+          !disabled ? style.get('color-card-pressing-default').color : undefined
+        }
         underlayColor={
-          !disabled ? style.get('color-gray-550').color : undefined
+          !disabled ? style.get('color-card-pressing-default').color : undefined
         }
         activeOpacity={0.2}
         onPress={() => {

--- a/packages/mobile/src/screen/setting/components/page-button/index.tsx
+++ b/packages/mobile/src/screen/setting/components/page-button/index.tsx
@@ -26,8 +26,8 @@ export const PageButton: FunctionComponent<PageButtonProps> = ({
   if (onClick) {
     return (
       <RectButton
-        rippleColor={style.get('color-gray-550').color}
-        underlayColor={style.get('color-gray-550').color}
+        rippleColor={style.get('color-card-pressing-default').color}
+        underlayColor={style.get('color-card-pressing-default').color}
         style={style.flatten([
           'background-color-card-default',
           'border-radius-6',

--- a/packages/mobile/src/screen/setting/components/setting-address-item/index.tsx
+++ b/packages/mobile/src/screen/setting/components/setting-address-item/index.tsx
@@ -38,7 +38,7 @@ export const AddressItem: FunctionComponent<{
     <Box
       paddingX={16}
       paddingY={20}
-      backgroundColor={style.get('color-gray-600').color}
+      backgroundColor={style.get('color-card-default').color}
       borderRadius={6}
       borderWidth={highlight ? 1 : undefined}
       borderColor={highlight ? style.get('color-gray-400').color : undefined}

--- a/packages/mobile/src/screen/setting/screens/security/permission/index.tsx
+++ b/packages/mobile/src/screen/setting/screens/security/permission/index.tsx
@@ -96,7 +96,7 @@ const OriginView: FunctionComponent<{
     <Box
       padding={12}
       borderRadius={6}
-      backgroundColor={style.get('color-gray-600').color}
+      backgroundColor={style.get('color-card-default').color}
       style={style.flatten(['gap-12'])}
       onClick={() => setIsCollapsed(!isCollapsed)}>
       <Columns sum={1} alignY="center">
@@ -104,7 +104,7 @@ const OriginView: FunctionComponent<{
           padding={10}
           marginRight={10}
           borderRadius={6}
-          backgroundColor={style.get('color-gray-500').color}>
+          backgroundColor={style.get('color-gray-550').color}>
           <Columns sum={1} gutter={12} alignY="center">
             <Text style={style.flatten(['body2', 'color-text-high'])}>
               {origin}
@@ -163,7 +163,7 @@ const OriginView: FunctionComponent<{
                   padding={10}
                   marginRight={10}
                   borderRadius={6}
-                  backgroundColor={style.get('color-gray-500').color}
+                  backgroundColor={style.get('color-gray-550').color}
                   cursor="pointer"
                   onClick={async e => {
                     e.preventDefault();
@@ -198,7 +198,7 @@ const OriginView: FunctionComponent<{
                   padding={10}
                   marginRight={10}
                   borderRadius={6}
-                  backgroundColor={style.get('color-gray-500').color}
+                  backgroundColor={style.get('color-gray-550').color}
                   onClick={async e => {
                     e.preventDefault();
                     e.stopPropagation();

--- a/packages/mobile/src/screen/setting/screens/token/add/index.tsx
+++ b/packages/mobile/src/screen/setting/screens/token/add/index.tsx
@@ -357,6 +357,7 @@ export const SettingTokenAddScreen: FunctionComponent = observer(() => {
         <Column weight={1} />
         {isSecretWasm ? (
           <Stack gutter={12}>
+            <Gutter size={16} />
             <Box
               backgroundColor={style.get('color-card-default').color}
               borderRadius={6}

--- a/packages/mobile/src/screen/setting/screens/token/add/index.tsx
+++ b/packages/mobile/src/screen/setting/screens/token/add/index.tsx
@@ -358,7 +358,7 @@ export const SettingTokenAddScreen: FunctionComponent = observer(() => {
         {isSecretWasm ? (
           <Stack gutter={12}>
             <Box
-              backgroundColor={style.get('color-gray-600').color}
+              backgroundColor={style.get('color-card-default').color}
               borderRadius={6}
               padding={16}>
               <Columns sum={1} alignY="center" gutter={4}>

--- a/packages/mobile/src/screen/setting/screens/token/manage/index.tsx
+++ b/packages/mobile/src/screen/setting/screens/token/manage/index.tsx
@@ -293,7 +293,9 @@ const TokenItem: FunctionComponent<{
   return (
     <Box
       padding={16}
-      backgroundColor={style.get('background-color-gray-600').backgroundColor}
+      backgroundColor={
+        style.get('background-color-card-default').backgroundColor
+      }
       borderRadius={6}>
       <Columns sum={1}>
         <Stack gutter={4}>

--- a/packages/mobile/src/screen/staking/components/validator-item/index.tsx
+++ b/packages/mobile/src/screen/staking/components/validator-item/index.tsx
@@ -43,9 +43,12 @@ export const ValidatorItem: FunctionComponent<{
 
   return (
     <RectButton
-      underlayColor={style.get('color-gray-550').color}
-      rippleColor={style.get('color-gray-550').color}
-      style={style.flatten(['border-radius-6', 'background-color-gray-600'])}
+      underlayColor={style.get('color-card-pressing-default').color}
+      rippleColor={style.get('color-card-pressing-default').color}
+      style={style.flatten([
+        'border-radius-6',
+        'background-color-card-default',
+      ])}
       activeOpacity={0.5}
       onPress={async () => {
         afterSelect();
@@ -209,11 +212,11 @@ export const ValidatorListItem: FunctionComponent<{
       <React.Fragment>
         {viewValidator ? (
           <RectButton
-            underlayColor={style.get('color-gray-550').color}
-            rippleColor={style.get('color-gray-550').color}
+            underlayColor={style.get('color-card-pressing-default').color}
+            rippleColor={style.get('color-card-pressing-default').color}
             style={style.flatten([
               'border-radius-6',
-              'background-color-gray-600',
+              'background-color-card-default',
             ])}
             activeOpacity={0.5}
             onPress={() => {

--- a/packages/mobile/src/screen/staking/dashboard/dashboard.tsx
+++ b/packages/mobile/src/screen/staking/dashboard/dashboard.tsx
@@ -213,7 +213,7 @@ export const StakingDashboardScreen: FunctionComponent = observer(() => {
       <Box
         padding={16}
         borderRadius={8}
-        backgroundColor={style.get('color-gray-600').color}>
+        backgroundColor={style.get('color-card-default').color}>
         <Columns sum={1} alignY="center" gutter={8}>
           <Columns sum={1} gutter={12} alignY="center">
             <LinearGradient

--- a/packages/mobile/src/screen/staking/redelegate/index.tsx
+++ b/packages/mobile/src/screen/staking/redelegate/index.tsx
@@ -228,9 +228,12 @@ export const ValidatorItem: FunctionComponent<{
 
   return (
     <RectButton
-      underlayColor={style.get('color-gray-550').color}
-      rippleColor={style.get('color-gray-550').color}
-      style={style.flatten(['border-radius-6', 'background-color-gray-600'])}
+      underlayColor={style.get('color-card-pressing-default').color}
+      rippleColor={style.get('color-card-pressing-default').color}
+      style={style.flatten([
+        'border-radius-6',
+        'background-color-card-default',
+      ])}
       activeOpacity={0.5}
       onPress={async () => {
         afterSelect();

--- a/packages/mobile/src/screen/staking/validator-detail/delegated-card.tsx
+++ b/packages/mobile/src/screen/staking/validator-detail/delegated-card.tsx
@@ -46,7 +46,7 @@ export const DelegatedCard: FunctionComponent<{
         paddingX={16}
         paddingY={20}
         borderRadius={6}
-        backgroundColor={style.get('color-gray-600').color}>
+        backgroundColor={style.get('color-card-default').color}>
         <Columns sum={1} alignY="center">
           <Text style={style.flatten(['body1', 'color-text-middle'])}>
             Staked

--- a/packages/mobile/src/screen/staking/validator-detail/index.tsx
+++ b/packages/mobile/src/screen/staking/validator-detail/index.tsx
@@ -85,7 +85,7 @@ export const ValidatorDetailScreen: FunctionComponent = observer(() => {
           <Box
             paddingX={16}
             paddingY={20}
-            backgroundColor={style.get('color-gray-600').color}
+            backgroundColor={style.get('color-card-default').color}
             borderRadius={6}>
             <Stack gutter={20}>
               <Columns sum={1} alignY="center" gutter={12}>

--- a/packages/mobile/src/screen/staking/validator-detail/unbonding-card.tsx
+++ b/packages/mobile/src/screen/staking/validator-detail/unbonding-card.tsx
@@ -46,7 +46,7 @@ export const UnbondingCard: FunctionComponent<{
         paddingX={16}
         paddingY={20}
         borderRadius={6}
-        backgroundColor={style.get('color-gray-600').color}>
+        backgroundColor={style.get('color-card-default').color}>
         <Stack gutter={24}>
           {unbonding.entries.map((entry, i) => {
             const remainingText = formatRelativeTimeString(

--- a/packages/mobile/src/screen/wallet/select/index.tsx
+++ b/packages/mobile/src/screen/wallet/select/index.tsx
@@ -587,7 +587,7 @@ const KeyringItem: FunctionComponent<{
       borderRadius={6}
       alignY="center"
       style={StyleSheet.flatten([
-        style.flatten(['background-color-gray-600']),
+        style.flatten(['background-color-card-default']),
         isSelected &&
           style.flatten([
             'border-width-1',

--- a/packages/mobile/src/screen/web/components/header/index.tsx
+++ b/packages/mobile/src/screen/web/components/header/index.tsx
@@ -7,8 +7,8 @@ import {RectButton} from '../../../../components/rect-button';
 import {observer} from 'mobx-react-lite';
 import {useStore} from '../../../../stores';
 import {useWebViewState} from '../../context';
-import {useNavigation} from '@react-navigation/native';
-import {StackNavProp} from '../../../../navigation';
+import {RouteProp, useNavigation, useRoute} from '@react-navigation/native';
+import {RootStackParamList, StackNavProp} from '../../../../navigation';
 import {Box} from '../../../../components/box';
 import {Columns} from '../../../../components/column';
 
@@ -100,6 +100,8 @@ export const OnScreenWebpageScreenHeader: FunctionComponent = observer(() => {
   const safeAreaInsets = useSafeAreaInsets();
   const headerHeight = 48;
   const navigation = useNavigation<StackNavProp>();
+  const route = useRoute<RouteProp<RootStackParamList, 'Web'>>();
+  const {isExternal} = route.params;
 
   const webViewState = useWebViewState();
   return (
@@ -204,19 +206,21 @@ export const OnScreenWebpageScreenHeader: FunctionComponent = observer(() => {
               }
             />
           </RectButton>
-          <RectButton
-            style={style.flatten(['border-radius-4'])}
-            rippleColor={style.get('color-gray-550').color}
-            underlayColor={style.get('color-gray-550').color}
-            activeOpacity={1}
-            onPress={() => {
-              navigation.navigate('WebTab', {screen: 'Web.Intro'});
-            }}>
-            <HomeIcon
-              size={32}
-              color={style.flatten(['color-gray-100']).color}
-            />
-          </RectButton>
+          {!isExternal ? (
+            <RectButton
+              style={style.flatten(['border-radius-4'])}
+              rippleColor={style.get('color-gray-550').color}
+              underlayColor={style.get('color-gray-550').color}
+              activeOpacity={1}
+              onPress={() => {
+                navigation.navigate('WebTab', {screen: 'Web.Intro'});
+              }}>
+              <HomeIcon
+                size={32}
+                color={style.flatten(['color-gray-100']).color}
+              />
+            </RectButton>
+          ) : null}
         </Columns>
       </View>
     </Box>

--- a/packages/mobile/src/screen/web/index.tsx
+++ b/packages/mobile/src/screen/web/index.tsx
@@ -14,7 +14,7 @@ import {useStore} from '../../stores';
 import {RectButton} from '../../components/rect-button';
 import {GlobeIcon} from '../../components/icon/globe';
 import {Box} from '../../components/box';
-import {TrashCanIcon} from '../../components/icon';
+import {CloseIcon} from '../../components/icon';
 import {EmptyView} from '../../components/empty-view';
 import {TouchableOpacity} from 'react-native-gesture-handler';
 import {RectButton as NativeRectButton} from 'react-native-gesture-handler';
@@ -176,7 +176,7 @@ export const WebScreen: FunctionComponent = observer(() => {
                 onPress={() => {
                   favoriteWebpageStore.removeUrl(url);
                 }}>
-                <TrashCanIcon
+                <CloseIcon
                   color={style.get('color-text-low').color}
                   size={24}
                 />

--- a/packages/mobile/src/screen/web/index.tsx
+++ b/packages/mobile/src/screen/web/index.tsx
@@ -144,7 +144,7 @@ export const WebScreen: FunctionComponent = observer(() => {
                 'padding-16',
                 'margin-bottom-8',
                 'border-radius-8',
-                'background-color-gray-600',
+                'background-color-card-default',
               ])}
               onPress={() => {
                 navigation.navigate('WebTab', {

--- a/packages/mobile/src/screen/web/webpage.tsx
+++ b/packages/mobile/src/screen/web/webpage.tsx
@@ -38,7 +38,6 @@ export const useInjectedSourceCode = () => {
   return code;
 };
 
-// TODO: 커스텀 헤더구현 해야함
 export const WebpageScreen: FunctionComponent = observer(() => {
   const {chainStore} = useStore();
 

--- a/packages/mobile/src/styles/index.tsx
+++ b/packages/mobile/src/styles/index.tsx
@@ -439,6 +439,7 @@ export const {StyleProvider, useStyle, useStyleThemeController} =
           'loading-spinner': '#BABAC1',
           'skeleton-layer-0': '#ECEBF1',
           'skeleton-layer-1': '#F9F9FC',
+          'card-pressing-default': ColorPalette['gray-600'],
         },
       },
       widths: {


### PR DESCRIPTION
3ee981fffab31b3e71f52ab6b8561cc2e1dbb6a6
-> https://www.notion.so/chainapsis/Mobile-2-0-Design-QA-4d17f1de86764d999f98e6c1bed7ee7f?p=1da44183faab42eebf3408bd4d594a8b&pm=s 해당이슈의 버튼 색상 변경

1fe64770a8d47a8acd8d7b4929a68ab7c3818b86
-> pressing 상태의 색상값을 하나 만들었습니다

e89bc036c63f34a28aac67a10ca59f8f4d171632
8b9b19ea09317be8ec8838b18a16cf34dea7c2ff
674a54b381a1482da8c21189695132b75e439f5a
-> main, select wallet의 카드들 color-card-default로 변경

07ca1e616fa6e74721c9be56cc5f1dda555f51eb
e9abeb0ca076fde4971a5cde3c2cd132af5d76ef
5b93ba3e671d4ae7ea6097440121ed80e36df983
dda17d680d6a58e6a0cf105f4963483704ce71fd
-> 각 커밋 제목에 맞는 페이지들의 카드들 color-card-default로 변경
card-default가 아닌데 변경된 스타일들은 해당 페이지의 디자인대로 약간의 색상을 같이 변경했습니다

83537093c270d1cc7333b9537dcb754f2b5234c5
-> 외부에서 들어온 웹뷰일때 home 아이콘 제거 
ex) vote에서 프로포절 디테일

711bd2adc2842b424c6342207325206347e9c7d9
-> 토큰 추가 페이지에서 뷰잉키 토클이 켜졌을때 여백이 없는 부분 추가

914272afb963f3b74036d5525c1b4fc09ee83db3
->  헤더 바텀보더가 계속 보이는 버그 수정

179fb2764ca1e2c7fa0406f7a5dc1a123d43aacd
-> view more tokens에서 해당 텍스트버튼만 색상이 다르기 때문에
기존 텍스트 버튼의 색상을 커스텀 할 수있게 수정 하고 적용함

97f55551d2fb2a306d064c2e8637a2af3c30492a
617e280a9074b970694e35cfbe26703856528eb4
-> 웹뷰 페이지의 쓰레기통 아이콘을 close 아이콘으로 변경과  input 컴포넌트 disabled 되었을시 색상 변경