### PR TITLE
[KM-119] 기존 헤더에 있던 step 스트링을 container 안으로 이동 했습니다

### DIFF
--- a/packages/mobile/src/components/pageHeader/header-register.tsx
+++ b/packages/mobile/src/components/pageHeader/header-register.tsx
@@ -5,7 +5,6 @@ import React, {
 } from 'react';
 import {ColorPalette, useStyle} from '../../styles';
 import {Pressable, Text} from 'react-native';
-import {Gutter} from '../gutter';
 import {HeaderBackButtonIcon} from './icon/back';
 import {RouteProp, useNavigation, useRoute} from '@react-navigation/native';
 import {Box} from '../box';
@@ -27,7 +26,6 @@ export const RegisterHeaderTitle: FunctionComponent<PropsWithChildren> = ({
     >
   >();
   const navigation = useNavigation();
-  const paragraph = route.params?.paragraph;
   const hideBackButton = route.params?.hideBackButton;
 
   useLayoutEffect(() => {
@@ -41,17 +39,8 @@ export const RegisterHeaderTitle: FunctionComponent<PropsWithChildren> = ({
       alignY="center"
       //NOTE 240을 준 이유는 왼쪽에 아이콘이 생길 경우 자체적인 header 길이가 제목을 짜를때가 있음
       //해서 그냥 find 튜닝으로 안짤리는 최소 값을 지정함
-      minWidth={240}
-      marginBottom={paragraph ? 2 : 0}>
+      minWidth={240}>
       <Text style={style.flatten(['h3', 'color-text-high'])}>{children}</Text>
-      {paragraph ? (
-        <React.Fragment>
-          <Gutter size={4} />
-          <Text style={style.flatten(['body2', 'color-text-low'])}>
-            {paragraph}
-          </Text>
-        </React.Fragment>
-      ) : null}
     </Box>
   );
 };

--- a/packages/mobile/src/navigation.tsx
+++ b/packages/mobile/src/navigation.tsx
@@ -94,7 +94,6 @@ import {SettingGeneralManageWalletConnectScreen} from './screen/setting/screens/
 import {registerHeaderOptions} from './components/pageHeader/header-register';
 
 type DefaultRegisterParams = {
-  paragraph?: string;
   hideBackButton?: boolean;
 };
 

--- a/packages/mobile/src/screen/register/components/register-container.tsx
+++ b/packages/mobile/src/screen/register/components/register-container.tsx
@@ -1,32 +1,28 @@
 import React, {FunctionComponent, PropsWithChildren} from 'react';
 import {useStyle} from '../../../styles';
 import {Box} from '../../../components/box';
-import {KeyboardAvoidingView, Platform} from 'react-native';
-import {RouteProp, useRoute} from '@react-navigation/native';
+import {KeyboardAvoidingView, Platform, Text} from 'react-native';
 
 export const RegisterContainer: FunctionComponent<
   PropsWithChildren<{
     bottom?: React.ReactNode;
+    paragraph?: string;
   }>
-> = ({children, bottom}) => {
+> = ({children, bottom, paragraph}) => {
   const style = useStyle();
-  const route = useRoute<
-    RouteProp<
-      Record<
-        string,
-        {
-          paragraph?: string;
-        }
-      >,
-      string
-    >
-  >();
-  const paragraph = route.params?.paragraph;
 
   return (
     <KeyboardAvoidingView
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
       style={{flex: 1}}>
+      {paragraph ? (
+        <React.Fragment>
+          <Text
+            style={style.flatten(['body2', 'text-center', 'color-text-low'])}>
+            {paragraph}
+          </Text>
+        </React.Fragment>
+      ) : null}
       <Box style={{flex: 1}} marginTop={paragraph ? 18 : 0}>
         {children}
       </Box>

--- a/packages/mobile/src/screen/register/components/register-container.tsx
+++ b/packages/mobile/src/screen/register/components/register-container.tsx
@@ -1,7 +1,7 @@
 import React, {FunctionComponent, PropsWithChildren} from 'react';
 import {useStyle} from '../../../styles';
 import {Box} from '../../../components/box';
-import {KeyboardAvoidingView, Platform, Text} from 'react-native';
+import {KeyboardAvoidingView, Platform, StyleSheet, Text} from 'react-native';
 
 export const RegisterContainer: FunctionComponent<
   PropsWithChildren<{
@@ -18,7 +18,10 @@ export const RegisterContainer: FunctionComponent<
       {paragraph ? (
         <React.Fragment>
           <Text
-            style={style.flatten(['body2', 'text-center', 'color-text-low'])}>
+            style={StyleSheet.flatten([
+              style.flatten(['body2', 'text-center', 'color-text-low']),
+              {marginTop: -3},
+            ])}>
             {paragraph}
           </Text>
         </React.Fragment>

--- a/packages/mobile/src/screen/register/connect-hardware/index.tsx
+++ b/packages/mobile/src/screen/register/connect-hardware/index.tsx
@@ -1,4 +1,4 @@
-import React, {FunctionComponent, useLayoutEffect, useState} from 'react';
+import React, {FunctionComponent, useState} from 'react';
 import {RegisterContainer} from '../components';
 import {useIntl} from 'react-intl';
 import {observer} from 'mobx-react-lite';
@@ -62,14 +62,9 @@ export const ConnectHardwareWalletScreen: FunctionComponent = observer(() => {
     });
   });
 
-  useLayoutEffect(() => {
-    navigation.setParams({
-      paragraph: 'Step 1/3',
-    });
-  }, [navigation]);
-
   return (
     <RegisterContainer
+      paragraph="Step 1/3"
       bottom={
         <Button
           text={intl.formatMessage({

--- a/packages/mobile/src/screen/register/connect-ledger/index.tsx
+++ b/packages/mobile/src/screen/register/connect-ledger/index.tsx
@@ -46,10 +46,6 @@ export const ConnectLedgerScreen: FunctionComponent = observer(() => {
 
   useLayoutEffect(() => {
     navigation.setParams({
-      paragraph:
-        appendModeInfo === undefined
-          ? `Step ${stepPrevious + 1}/${stepTotal}`
-          : undefined,
       hideBackButton: appendModeInfo !== undefined,
     });
   }, [appendModeInfo, navigation, stepPrevious, stepTotal]);
@@ -105,6 +101,11 @@ export const ConnectLedgerScreen: FunctionComponent = observer(() => {
 
   return (
     <RegisterContainer
+      paragraph={
+        appendModeInfo === undefined
+          ? `Step ${stepPrevious + 1}/${stepTotal}`
+          : undefined
+      }
       bottom={
         <Button
           text={intl.formatMessage({

--- a/packages/mobile/src/screen/register/enable-chains/index.tsx
+++ b/packages/mobile/src/screen/register/enable-chains/index.tsx
@@ -83,11 +83,12 @@ export const EnableChainsScreen: FunctionComponent = observer(() => {
     return keyInfo.type;
   }, [keyRingStore.keyInfos, vaultId]);
 
+  const paragraph = isFresh
+    ? `Step ${(stepPrevious ?? 0) + 1}/${stepTotal}`
+    : undefined;
+
   useLayoutEffect(() => {
     navigation.setParams({
-      paragraph: isFresh
-        ? `Step ${(stepPrevious ?? 0) + 1}/${stepTotal}`
-        : undefined,
       hideBackButton,
     });
   }, [hideBackButton, isFresh, navigation, stepPrevious, stepTotal]);
@@ -497,6 +498,16 @@ export const EnableChainsScreen: FunctionComponent = observer(() => {
     <KeyboardAvoidingView
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
       style={{flex: 1}}>
+      {paragraph ? (
+        <React.Fragment>
+          <Text
+            style={style.flatten(['body2', 'text-center', 'color-text-low'])}>
+            {paragraph}
+          </Text>
+          <Gutter size={18} />
+        </React.Fragment>
+      ) : null}
+
       <Box padding={12} alignX="center" style={{flex: 1}}>
         <Text
           style={StyleSheet.flatten([

--- a/packages/mobile/src/screen/register/intro-new-user/index.tsx
+++ b/packages/mobile/src/screen/register/intro-new-user/index.tsx
@@ -60,9 +60,7 @@ export const RegisterIntroNewUserScreen: FunctionComponent = () => {
             })}
             size="large"
             onPress={() => {
-              navigation.navigate('Register.NewMnemonic', {
-                paragraph: 'Step 1/3',
-              });
+              navigation.navigate('Register.NewMnemonic');
             }}
           />
 

--- a/packages/mobile/src/screen/register/new-mnemonic/index.tsx
+++ b/packages/mobile/src/screen/register/new-mnemonic/index.tsx
@@ -1,9 +1,4 @@
-import React, {
-  FunctionComponent,
-  useEffect,
-  useLayoutEffect,
-  useState,
-} from 'react';
+import React, {FunctionComponent, useEffect, useState} from 'react';
 import {observer} from 'mobx-react-lite';
 import {useIntl} from 'react-intl';
 import {useStyle} from '../../../styles';
@@ -32,12 +27,6 @@ export const NewMnemonicScreen: FunctionComponent = observer(() => {
   const [words, setWords] = useState<string[]>([]);
   const [wordsType, setWordsType] = useState<WordsType>('12words');
 
-  useLayoutEffect(() => {
-    navigation.setParams({
-      paragraph: 'Step 1/3',
-    });
-  }, [navigation]);
-
   useEffect(() => {
     const rng = (array: any) => {
       return Promise.resolve(Crypto.getRandomValues(array));
@@ -54,6 +43,7 @@ export const NewMnemonicScreen: FunctionComponent = observer(() => {
 
   return (
     <RegisterContainer
+      paragraph="Step 1/3"
       bottom={
         <Button
           text={intl.formatMessage({

--- a/packages/mobile/src/screen/register/recover-mnemonic/index.tsx
+++ b/packages/mobile/src/screen/register/recover-mnemonic/index.tsx
@@ -1,4 +1,4 @@
-import React, {FunctionComponent, useLayoutEffect} from 'react';
+import React, {FunctionComponent} from 'react';
 import {observer} from 'mobx-react-lite';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {RegisterContainer} from '../components';
@@ -109,14 +109,9 @@ export const RecoverMnemonicScreen: FunctionComponent = observer(() => {
     }
   });
 
-  useLayoutEffect(() => {
-    navigation.setParams({
-      paragraph: 'Step 1/3',
-    });
-  }, [navigation]);
-
   return (
     <RegisterContainer
+      paragraph="Step 1/3"
       bottom={
         <Button
           text={intl.formatMessage({

--- a/packages/mobile/src/screen/register/verify-mnemonic/index.tsx
+++ b/packages/mobile/src/screen/register/verify-mnemonic/index.tsx
@@ -1,9 +1,4 @@
-import React, {
-  FunctionComponent,
-  useLayoutEffect,
-  useMemo,
-  useState,
-} from 'react';
+import React, {FunctionComponent, useMemo, useState} from 'react';
 import {observer} from 'mobx-react-lite';
 import {ScrollView, Text} from 'react-native';
 import {RouteProp, useNavigation, useRoute} from '@react-navigation/native';
@@ -117,16 +112,11 @@ export const VerifyMnemonicScreen: FunctionComponent = observer(() => {
     }
   });
 
-  useLayoutEffect(() => {
-    navigation.setParams({
-      paragraph: `Step ${route.params.stepPrevious + 1}/${
-        route.params.stepTotal
-      }`,
-    });
-  }, [navigation, route.params.stepPrevious, route.params.stepTotal]);
-
   return (
     <RegisterContainer
+      paragraph={`Step ${route.params.stepPrevious + 1}/${
+        route.params.stepTotal
+      }`}
       bottom={
         <Button
           text={intl.formatMessage({


### PR DESCRIPTION
# 구현 사항
<img width="420" alt="Screenshot 2023-12-13 at 2 45 32 PM" src="https://github.com/chainapsis/keplr-wallet/assets/10705018/a33f3ad9-6727-4495-b296-a573d2331ed8">

 기존 헤더에 있던 step 스트링을 container 안으로 이동 했습니다

