### PR TITLE
fix: display error message of signing with Keystone

### DIFF
--- a/packages/extension/src/pages/sign/components/keystone/index.tsx
+++ b/packages/extension/src/pages/sign/components/keystone/index.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useState } from "react";
+import React, { FunctionComponent, useEffect, useState } from "react";
 import { Modal } from "../../../../components/modal";
 import { HeaderLayout } from "../../../../layouts/header";
 import { KeystoneDisplay } from "./display";
@@ -15,10 +15,17 @@ export const KeystoneSign: FunctionComponent<{
   isOpen: boolean;
   close: () => void;
   onScan: (ur: KeystoneUR) => void;
-}> = ({ ur, isOpen, close, onScan }) => {
+  error: Error | undefined;
+  onCloseError: () => void;
+}> = ({ ur, isOpen, close, onScan, error, onCloseError }) => {
   const [step, setStep] = useState("display");
   const theme = useTheme();
   const intl = useIntl();
+  useEffect(() => {
+    if (isOpen) {
+      setStep("display");
+    }
+  }, [isOpen]);
   return (
     <Modal isOpen={isOpen} close={close} align="bottom">
       <HeaderLayout
@@ -55,7 +62,11 @@ export const KeystoneSign: FunctionComponent<{
               }}
             />
           ) : (
-            <KeystoneScan onScan={onScan} />
+            <KeystoneScan
+              onScan={onScan}
+              error={error}
+              onCloseError={onCloseError}
+            />
           )}
         </Box>
       </HeaderLayout>

--- a/packages/extension/src/pages/sign/components/keystone/scan.tsx
+++ b/packages/extension/src/pages/sign/components/keystone/scan.tsx
@@ -14,7 +14,9 @@ import { Progress } from "../../../../components/keystone/progress";
 
 export const KeystoneScan: FunctionComponent<{
   onScan: (ur: KeystoneUR) => void;
-}> = ({ onScan }) => {
+  error: Error | undefined;
+  onCloseError: () => void;
+}> = ({ onScan, error, onCloseError }) => {
   const { AnimatedQRScanner, hasPermission, setIsDone, isDone } =
     useAnimatedQRScanner();
   const [isErrorOpen, setIsErrorOpen] = useState(false);
@@ -39,11 +41,17 @@ export const KeystoneScan: FunctionComponent<{
     setIsErrorOpen(false);
     setIsDone(false);
     setProgress(0);
+    onCloseError();
   };
 
   const cameraSize = useMemo(
     () => (hasPermission ? "16.625rem" : "15rem"),
     [hasPermission]
+  );
+
+  const isError = useMemo(
+    () => error !== undefined || isErrorOpen,
+    [error, isErrorOpen]
   );
 
   return (
@@ -135,7 +143,7 @@ export const KeystoneScan: FunctionComponent<{
         </Box>
       )}
       <KeystoneErrorModal
-        isOpen={isErrorOpen}
+        isOpen={isError}
         close={handleClose}
         title={intl.formatMessage({
           id: "page.sign.keystone.invalid-qrcode",

--- a/packages/extension/src/pages/sign/cosmos/adr36.tsx
+++ b/packages/extension/src/pages/sign/cosmos/adr36.tsx
@@ -18,7 +18,7 @@ import { LedgerGuideBox } from "../components/ledger-guide-box";
 import { GuideBox } from "../../../components/guide-box";
 import { FormattedMessage, useIntl } from "react-intl";
 import { Image } from "../../../components/image";
-import { KeystoneUR } from "../utils/keystone";
+import { ErrModuleKeystoneSign, KeystoneUR } from "../utils/keystone";
 import { KeystoneSign } from "../components/keystone";
 import { useTheme } from "styled-components";
 import { KeyRingService } from "@keplr-wallet/background";
@@ -109,6 +109,9 @@ export const SignCosmosADR36Page: FunctionComponent = observer(() => {
   const [isKeystoneInteracting, setIsKeystoneInteracting] = useState(false);
   const [keystoneUR, setKeystoneUR] = useState<KeystoneUR>();
   const keystoneScanResolve = useRef<(ur: KeystoneUR) => void>();
+  const [keystoneInteractingError, setKeystoneInteractingError] = useState<
+    Error | undefined
+  >(undefined);
 
   return (
     <HeaderLayout
@@ -198,16 +201,20 @@ export const SignCosmosADR36Page: FunctionComponent = observer(() => {
                 }
               );
             } catch (e) {
-              console.log(e);
+              console.error(e);
 
               if (e instanceof KeplrError) {
                 if (e.module === ErrModuleLedgerSign) {
                   setLedgerInteractingError(e);
+                } else if (e.module === ErrModuleKeystoneSign) {
+                  setKeystoneInteractingError(e);
                 } else {
                   setLedgerInteractingError(undefined);
+                  setKeystoneInteractingError(undefined);
                 }
               } else {
                 setLedgerInteractingError(undefined);
+                setKeystoneInteractingError(undefined);
               }
             } finally {
               setIsLedgerInteracting(false);
@@ -416,6 +423,11 @@ export const SignCosmosADR36Page: FunctionComponent = observer(() => {
             throw new Error("Keystone Scan Error");
           }
           keystoneScanResolve.current(ur);
+        }}
+        error={keystoneInteractingError}
+        onCloseError={() => {
+          keystoneInteractingError && setIsKeystoneInteracting(false);
+          setKeystoneInteractingError(undefined);
         }}
       />
     </HeaderLayout>

--- a/packages/extension/src/pages/sign/cosmos/tx/view.tsx
+++ b/packages/extension/src/pages/sign/cosmos/tx/view.tsx
@@ -37,7 +37,7 @@ import { GuideBox } from "../../../../components/guide-box";
 import { FormattedMessage, useIntl } from "react-intl";
 import SimpleBar from "simplebar-react";
 import { KeystoneSign } from "../../components/keystone";
-import { KeystoneUR } from "../../utils/keystone";
+import { ErrModuleKeystoneSign, KeystoneUR } from "../../utils/keystone";
 import { KeyRingService } from "@keplr-wallet/background";
 import { useTheme } from "styled-components";
 import { defaultProtoCodec } from "@keplr-wallet/cosmos";
@@ -323,6 +323,9 @@ export const CosmosTxView: FunctionComponent<{
   const [isKeystoneInteracting, setIsKeystoneInteracting] = useState(false);
   const [keystoneUR, setKeystoneUR] = useState<KeystoneUR>();
   const keystoneScanResolve = useRef<(ur: KeystoneUR) => void>();
+  const [keystoneInteractingError, setKeystoneInteractingError] = useState<
+    Error | undefined
+  >(undefined);
 
   const buttonDisabled =
     txConfigsValidate.interactionBlocked ||
@@ -398,16 +401,20 @@ export const CosmosTxView: FunctionComponent<{
           }
         );
       } catch (e) {
-        console.log(e);
+        console.error(e);
 
         if (e instanceof KeplrError) {
           if (e.module === ErrModuleLedgerSign) {
             setLedgerInteractingError(e);
+          } else if (e.module === ErrModuleKeystoneSign) {
+            setKeystoneInteractingError(e);
           } else {
             setLedgerInteractingError(undefined);
+            setKeystoneInteractingError(undefined);
           }
         } else {
           setLedgerInteractingError(undefined);
+          setKeystoneInteractingError(undefined);
         }
       } finally {
         setIsLedgerInteracting(false);
@@ -631,6 +638,11 @@ export const CosmosTxView: FunctionComponent<{
             throw new Error("Keystone Scan Error");
           }
           keystoneScanResolve.current(ur);
+        }}
+        error={keystoneInteractingError}
+        onCloseError={() => {
+          keystoneInteractingError && setIsKeystoneInteracting(false);
+          setKeystoneInteractingError(undefined);
         }}
       />
     </HeaderLayout>

--- a/packages/extension/src/pages/sign/ethereum/view.tsx
+++ b/packages/extension/src/pages/sign/ethereum/view.tsx
@@ -19,7 +19,7 @@ import {
   handleEthereumPreSignByLedger,
 } from "../utils/handle-eth-sign";
 import { FormattedMessage, useIntl } from "react-intl";
-import { KeystoneUR } from "../utils/keystone";
+import { ErrModuleKeystoneSign, KeystoneUR } from "../utils/keystone";
 import { KeystoneSign } from "../components/keystone";
 import { useTheme } from "styled-components";
 
@@ -70,6 +70,9 @@ export const EthereumSigningView: FunctionComponent<{
   const [isKeystoneInteracting, setIsKeystoneInteracting] = useState(false);
   const [keystoneUR, setKeystoneUR] = useState<KeystoneUR>();
   const keystoneScanResolve = useRef<(ur: KeystoneUR) => void>();
+  const [keystoneInteractingError, setKeystoneInteractingError] = useState<
+    Error | undefined
+  >(undefined);
 
   return (
     <HeaderLayout
@@ -130,16 +133,20 @@ export const EthereumSigningView: FunctionComponent<{
               }
             );
           } catch (e) {
-            console.log(e);
+            console.error(e);
 
             if (e instanceof KeplrError) {
               if (e.module === ErrModuleLedgerSign) {
                 setLedgerInteractingError(e);
+              } else if (e.module === ErrModuleKeystoneSign) {
+                setKeystoneInteractingError(e);
               } else {
                 setLedgerInteractingError(undefined);
+                setKeystoneInteractingError(undefined);
               }
             } else {
               setLedgerInteractingError(undefined);
+              setKeystoneInteractingError(undefined);
             }
           } finally {
             setIsLedgerInteracting(false);
@@ -236,6 +243,11 @@ export const EthereumSigningView: FunctionComponent<{
             throw new Error("Keystone Scan Error");
           }
           keystoneScanResolve.current(ur);
+        }}
+        error={keystoneInteractingError}
+        onCloseError={() => {
+          keystoneInteractingError && setIsKeystoneInteracting(false);
+          setKeystoneInteractingError(undefined);
         }}
       />
     </HeaderLayout>

--- a/packages/extension/src/pages/sign/utils/keystone.ts
+++ b/packages/extension/src/pages/sign/utils/keystone.ts
@@ -67,3 +67,9 @@ export function encodeEthMessage(
       return Buffer.from(message);
   }
 }
+
+export const ErrModuleKeystoneSign = "keystone-sign";
+export const ErrInvalidSigner = 1;
+export const ErrInvalidRequestId = 2;
+export const ErrInvalidPublicKey = 3;
+export const ErrInvalidSignature = 4;


### PR DESCRIPTION
When sign with Keystone and error in some cases, the error message does not display.