### PR TITLE
Adding new fields for price impact to objects

### DIFF
--- a/packages/extension/src/stores/skip/route.ts
+++ b/packages/extension/src/stores/skip/route.ts
@@ -36,6 +36,7 @@ const Schema = Joi.object<RouteResponse>({
               )
               .required(),
             swap_amount_in: Joi.string().required(),
+            price_impact_percent: Joi.string(),
           },
           estimated_affiliate_fee: Joi.string().required(),
         }).unknown(true),
@@ -59,6 +60,7 @@ const Schema = Joi.object<RouteResponse>({
     name: Joi.string().required(),
     chain_id: Joi.string().required(),
   }),
+  swap_price_impact_percent: Joi.string(),
   txs_required: Joi.number().required(),
 }).unknown(true);
 

--- a/packages/extension/src/stores/skip/types.ts
+++ b/packages/extension/src/stores/skip/types.ts
@@ -68,6 +68,7 @@ export interface RouteResponse {
               denom_out: string;
             }[];
             swap_amount_in: string;
+            price_impact_percent?: string;
           };
           estimated_affiliate_fee: string;
         };
@@ -76,6 +77,7 @@ export interface RouteResponse {
   chain_ids: string[];
   does_swap?: boolean;
   estimated_amount_out?: string;
+  swap_price_impact_percent?: string;
   swap_venue?: {
     name: string;
     chain_id: string;


### PR DESCRIPTION
We pushed a small additive change to the route response and to the swap operation object: 

* At the top level of the route response, we added `swap_price_impact_percent`
* We also add `price_impact_percent` in the swap operation object. This appears to cause some kind of type validation error in the widget. 

Our best guess is that there's some kind of strict validation taking place that's checking that the swap operation object matches specification exactly -- not allowing additional fields. 

![Screen Shot 2023-12-13 at 7 47 33 PM](https://github.com/chainapsis/keplr-wallet/assets/26175258/368a9a9e-1fb9-44af-b686-75525656ff87)

I built the extension and tested this in Chrome + Firefox, and it fixed the problem in both. 
