### PR TITLE
[KM-127] approve 버튼 스페셜 버튼으로 교체

### DIFF
--- a/packages/mobile/src/components/special-button/button.tsx
+++ b/packages/mobile/src/components/special-button/button.tsx
@@ -34,6 +34,7 @@ export const SpecialButton: FunctionComponent<SpecialButtonProps> = ({
   isLoading,
   disabled,
   textOverrideIcon,
+  innerButtonStyle,
 }) => {
   const style = useStyle();
   const height = style.get(`height-button-${size}`).height as number;
@@ -166,6 +167,7 @@ export const SpecialButton: FunctionComponent<SpecialButtonProps> = ({
               transform: [{scale: scaleSize as any}],
               height,
             },
+            innerButtonStyle,
           ])}
           animatedProps={animatedProps}
           colors={colors}>

--- a/packages/mobile/src/components/special-button/types.ts
+++ b/packages/mobile/src/components/special-button/types.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import {ViewStyle} from 'react-native';
 
 export interface SpecialButtonProps {
   size?: 'extra-small' | 'small' | 'medium' | 'large';
@@ -9,4 +10,5 @@ export interface SpecialButtonProps {
   onPress?: () => void;
   isLoading?: boolean;
   textOverrideIcon?: React.ReactNode;
+  innerButtonStyle?: ViewStyle;
 }

--- a/packages/mobile/src/screen/sign/sign-modal.tsx
+++ b/packages/mobile/src/screen/sign/sign-modal.tsx
@@ -25,7 +25,6 @@ import {Text} from 'react-native';
 import {Gutter} from '../../components/gutter';
 import {Box} from '../../components/box';
 import {FeeControl} from '../../components/input/fee-control';
-import {Button} from '../../components/button';
 import {XAxis} from '../../components/axis';
 import {CloseIcon} from '../../components/icon';
 import {CodeBracketIcon} from '../../components/icon/code-bracket';
@@ -36,6 +35,7 @@ import {ScrollView, FlatList} from 'react-native-gesture-handler';
 import {GuideBox} from '../../components/guide-box';
 import {Checkbox} from '../../components/checkbox';
 import {registerCardModal} from '../../components/modal/card';
+import {SpecialButton} from '../../components/special-button';
 
 export const SignModal = registerCardModal(
   observer<{
@@ -427,11 +427,14 @@ export const SignModal = registerCardModal(
           </React.Fragment>
         ) : null}
 
-        <Button
+        <SpecialButton
           size="large"
-          text="Approve"
+          text={intl.formatMessage({
+            id: 'button.approve',
+          })}
           onPress={approve}
           disabled={buttonDisabled}
+          innerButtonStyle={style.flatten(['width-full'])}
         />
 
         <Gutter size={24} />


### PR DESCRIPTION
# 구현사항
 
![Kapture 2023-12-14 at 11 23 11](https://github.com/chainapsis/keplr-wallet/assets/10705018/5e522a25-aa8e-4e12-82fc-76bdd9ae9c8e)


# 참고사항
AnimatedLinearGradient에서 width 100%를 줄 경우 제일위 부모인 AnimatedView가 아닌 그 위 부모의 width를 따라가서
일단 스페셜버튼에 width 100%를 필요할때만 줄수 있게 props로 외부 스타일을 받을수 있게 했습니다