### PR TITLE
[KM-129] tx-result 페이지에서 toast 보여주지 않기

### DIFF
--- a/packages/mobile/src/hooks/notification/internal/provider.tsx
+++ b/packages/mobile/src/hooks/notification/internal/provider.tsx
@@ -28,6 +28,7 @@ export const NotificationProvider: FunctionComponent<PropsWithChildren> = ({
       paragraph: string;
     }[]
   >([]);
+  const [isDisable, setIsDisable] = useState(false);
 
   const clearDetached = (id: string) => {
     const find = notifications.find(notification => notification.id === id);
@@ -88,6 +89,7 @@ export const NotificationProvider: FunctionComponent<PropsWithChildren> = ({
         return {
           show: showFnRef.current,
           hide: hideFnRef.current,
+          disable: setIsDisable,
         };
       }, [])}>
       {children}
@@ -101,26 +103,28 @@ export const NotificationProvider: FunctionComponent<PropsWithChildren> = ({
         }}
         pointerEvents="box-none">
         <React.Fragment>
-          {notifications
-            .slice()
-            .reverse()
-            .map(notification => {
-              return (
-                <NotificationView
-                  key={notification.id}
-                  mode={notification.mode}
-                  title={notification.title}
-                  paragraph={notification.paragraph}
-                  detached={notification.detached}
-                  onTransitionEnd={() => {
-                    clearDetached(notification.id);
-                  }}
-                  onClickClose={() => {
-                    hideFn(notification.id);
-                  }}
-                />
-              );
-            })}
+          {isDisable
+            ? null
+            : notifications
+                .slice()
+                .reverse()
+                .map(notification => {
+                  return (
+                    <NotificationView
+                      key={notification.id}
+                      mode={notification.mode}
+                      title={notification.title}
+                      paragraph={notification.paragraph}
+                      detached={notification.detached}
+                      onTransitionEnd={() => {
+                        clearDetached(notification.id);
+                      }}
+                      onClickClose={() => {
+                        hideFn(notification.id);
+                      }}
+                    />
+                  );
+                })}
         </React.Fragment>
       </View>
     </NotificationContext.Provider>

--- a/packages/mobile/src/hooks/notification/types.ts
+++ b/packages/mobile/src/hooks/notification/types.ts
@@ -5,4 +5,5 @@ export interface Notification {
     paragraph?: string,
   ): string;
   hide(id: string): void;
+  disable(isDisable: boolean): void;
 }

--- a/packages/mobile/src/screen/tx-result/failed.tsx
+++ b/packages/mobile/src/screen/tx-result/failed.tsx
@@ -17,12 +17,14 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 import {TextButton} from '../../components/text-button';
+import {useNotification} from '../../hooks/notification';
 
 const AnimatedLottieView = Animated.createAnimatedComponent(LottieView);
 
 export const TxFailedResultScreen: FunctionComponent = observer(() => {
   const animationRef = useRef<LottieView>(null);
   const failedAnimProgress = useSharedValue(0);
+  const notification = useNotification();
   const animatedProps = useAnimatedProps(() => {
     return {
       progress: failedAnimProgress.value,
@@ -49,6 +51,15 @@ export const TxFailedResultScreen: FunctionComponent = observer(() => {
 
   const style = useStyle();
   const navigation = useNavigation<StackNavProp>();
+
+  useEffect(() => {
+    notification.disable(true);
+    return () => {
+      //NOTE setTimeout을 건이유는 해당 페이지가 보이자 말자 바로 main으로 이동하면 토스트가 보임해서
+      //해당 토스트가 사라지는 시간을 대강 계산해서 800밀리초 후 disable을 false로 설정
+      setTimeout(() => notification.disable(false), 800);
+    };
+  }, [notification]);
 
   useEffect(() => {
     const animateLottie = () => {

--- a/packages/mobile/src/screen/tx-result/success.tsx
+++ b/packages/mobile/src/screen/tx-result/success.tsx
@@ -17,6 +17,7 @@ import Animated, {
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated';
+import {useNotification} from '../../hooks/notification';
 
 const AnimatedLottieView = Animated.createAnimatedComponent(LottieView);
 
@@ -28,6 +29,7 @@ export const TxSuccessResultScreen: FunctionComponent = observer(() => {
       progress: successAnimProgress.value,
     };
   });
+  const notification = useNotification();
 
   useEffect(() => {
     const animateLottie = () => {
@@ -39,6 +41,18 @@ export const TxSuccessResultScreen: FunctionComponent = observer(() => {
     return () => clearTimeout(timeoutId);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    notification.disable(true);
+
+    return () => {
+      //NOTE setTimeout을 건이유는 해당 페이지가 보이자 말자 바로 main으로 이동하면 토스트가 보임해서
+      //해당 토스트가 사라지는 시간을 대강 계산해서 800밀리초 후 disable을 false로 설정
+      setTimeout(() => {
+        notification.disable(false);
+      }, 800);
+    };
+  }, [notification]);
 
   const route = useRoute<
     RouteProp<


### PR DESCRIPTION
# 구현사항
![Kapture 2023-12-14 at 12 37 01](https://github.com/chainapsis/keplr-wallet/assets/10705018/6e0ea79a-612b-4d4f-9c32-2213368c03e8)

tx 결과페이지 에서 토스트를 보여주지 않게 notification에 disable 값을 추가 했습니다

pending 페이지에서 home으로 갈때 home이 렌더링이 안되어있을때 tx결과가 나오면 결과 페이지로 다시 이동 하는 버그가 있어서
페이지 이동중일때는 가지 않을수 있게 수정 하였습니다.