### PR TITLE
[QA]  기능qa와 sign페이지의 text qa 적용

### DIFF
--- a/packages/mobile/src/components/pageHeader/header.tsx
+++ b/packages/mobile/src/components/pageHeader/header.tsx
@@ -114,10 +114,13 @@ const DefaultScreenHeaderTitle: FunctionComponent<PropsWithChildren> = ({
 const DefaultScreenHeaderLeft: FunctionComponent = () => {
   const style = useStyle();
   const nav = useNavigation();
+  const isSettingIntro =
+    nav.getState().routes[0].name === 'Setting.Intro' &&
+    nav.getState().routes.length === 1;
 
   return (
     <React.Fragment>
-      {nav.canGoBack() ? (
+      {nav.canGoBack() && !isSettingIntro ? (
         <Pressable
           onPress={() => {
             if (nav.canGoBack()) {

--- a/packages/mobile/src/languages/en.json
+++ b/packages/mobile/src/languages/en.json
@@ -582,7 +582,7 @@
   "components.input.amount-input.max-button": "Max",
   "components.input.memo-input.memo-label": "Memo",
   "components.input.fee-control.title": "Transaction Fee: ",
-  "components.input.fee-control.error.insufficient-fee": "Insufficient fee",
+  "components.input.fee-control.error.insufficient-fee": "Insufficient balance to cover the fees",
   "components.input.fee-control.modal.title": "Fee Options",
   "components.input.fee-control.modal.fee-title": "Fee",
   "components.input.fee-control.modal.fee-token-dropdown-label": "Fee Token",

--- a/packages/mobile/src/languages/en.json
+++ b/packages/mobile/src/languages/en.json
@@ -180,7 +180,7 @@
 
   "page.setting.title": "Settings",
   "page.setting.general-title": "General",
-  "page.setting.general-paragraph": "Language, Currency, Contacts...",
+  "page.setting.general-paragraph": "Currency, Contacts...",
   "page.setting.advanced-title": "Advanced",
   "page.setting.advanced-paragraph": "Developer Mode, Change Endpoints...",
   "page.setting.security-privacy-title": "Security & Privacy",

--- a/packages/mobile/src/languages/index.tsx
+++ b/packages/mobile/src/languages/index.tsx
@@ -11,7 +11,6 @@ import MessagesEn from './en.json';
 import MessagesKo from './ko.json';
 import {useStore} from '../stores';
 import {observer} from 'mobx-react-lite';
-import {I18nManager, Platform, Settings} from 'react-native';
 
 export type IntlMessage = Record<string, string>;
 export type IntlMessages = {
@@ -36,32 +35,33 @@ interface Language {
   clearLanguage: () => void;
 }
 
-const defaultLangMap: Record<string, string> = {
-  ko: 'ko',
-  en: 'en',
-};
+// const defaultLangMap: Record<string, string> = {
+//   ko: 'ko',
+//   en: 'en',
+// };
 
 const initLanguage = (): string => {
-  let language = 'en';
+  return 'en';
+  // let language = 'en';
 
-  if (Platform.OS === 'ios') {
-    const settings = Settings.get('AppleLocale');
-    const locale: string = settings || settings?.[0];
-    if (locale) {
-      language = locale.split('-')[0];
-    }
-  } else {
-    const locale = I18nManager.getConstants().localeIdentifier;
-    if (locale) {
-      language = locale.split('_')[0];
-    }
-  }
+  // if (Platform.OS === 'ios') {
+  //   const settings = Settings.get('AppleLocale');
+  //   const locale: string = settings || settings?.[0];
+  //   if (locale) {
+  //     language = locale.split('-')[0];
+  //   }
+  // } else {
+  //   const locale = I18nManager.getConstants().localeIdentifier;
+  //   if (locale) {
+  //     language = locale.split('_')[0];
+  //   }
+  // }
 
-  if (!defaultLangMap[language]) {
-    return 'en';
-  }
+  // if (!defaultLangMap[language]) {
+  //   return 'en';
+  // }
 
-  return language;
+  // return language;
 };
 
 const LanguageContext = createContext<Language | null>(null);
@@ -86,47 +86,37 @@ export const AppIntlProvider: FunctionComponent<PropsWithChildren> = observer(
         : getMessages(uiConfigStore.language),
     );
     useLayoutEffect(() => {
-      if (isAutomatic) {
-        uiConfigStore.selectLanguageOptions({
-          language: initLanguage(),
-          isAutomatic,
-        });
-      }
-      setMessages(getMessages(language));
+      // if (isAutomatic) {
+      //   uiConfigStore.selectLanguageOptions({
+      //     language: initLanguage(),
+      //     isAutomatic,
+      //   });
+      // }
+      setMessages(getMessages('en'));
     }, [isAutomatic, language, uiConfigStore]);
 
-    const clearLanguage = () => {
-      const language = initLanguage();
-      uiConfigStore.selectLanguageOptions({language, isAutomatic: true});
-    };
+    // const clearLanguage = () => {
+    //   const language = initLanguage();
+    //   uiConfigStore.selectLanguageOptions({language, isAutomatic: true});
+    // };
 
-    const setLanguage = (language: string) => {
-      uiConfigStore.selectLanguageOptions({language, isAutomatic: false});
-    };
+    // const setLanguage = (language: string) => {
+    //   uiConfigStore.selectLanguageOptions({language, isAutomatic: false});
+    // };
 
-    const getLanguageFullName = (language: string) => {
-      switch (language) {
-        case 'ko':
-          return '한국어';
-        default:
-          return 'English';
-      }
-    };
+    // const getLanguageFullName = (language: string) => {
+    //   switch (language) {
+    //     case 'ko':
+    //       return '한국어';
+    //     default:
+    //       return 'English';
+    //   }
+    // };
 
     return (
-      <LanguageContext.Provider
-        value={{
-          language,
-          getLanguageFullName,
-          languageFullName: getLanguageFullName(language),
-          setLanguage,
-          automatic: isAutomatic,
-          clearLanguage,
-        }}>
-        <IntlProvider locale={language} messages={messages}>
-          {children}
-        </IntlProvider>
-      </LanguageContext.Provider>
+      <IntlProvider locale={language} messages={messages}>
+        {children}
+      </IntlProvider>
     );
   },
 );

--- a/packages/mobile/src/screen/governance/list/index.tsx
+++ b/packages/mobile/src/screen/governance/list/index.tsx
@@ -28,12 +28,16 @@ export const GovernanceListScreen: FunctionComponent = observer(() => {
   const governanceV1 = queriesStore.get(chainId).governanceV1.queryGovernance;
   const governanceLegacy = queriesStore.get(chainId).governance.queryGovernance;
   const isGovV1SupportedRef = useRef(isGovV1Supported || false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
   //NOTE refresh를 했을때에만 자식인 GovernanceCardBody에서 refetch를 해야 되기 때문에 숫자값으로 순차적으로 증가하게 하고
   //무한스크롤에 의해서 렌더링 될경우 다시 refreshing값을 0으로 만들어서 하위 GovernanceCardBody에서
   //refetch 되지 않게 구현함
   const [refreshing, setRefreshing] = useState(0);
   const onRefresh = () => {
+    setIsRefreshing(true);
     setRefreshing(refreshing + 1);
+    setIsRefreshing(false);
   };
 
   const insects = useSafeAreaInsets();
@@ -86,7 +90,11 @@ export const GovernanceListScreen: FunctionComponent = observer(() => {
     <FlatList
       data={sections}
       refreshControl={
-        <RefreshControl refreshing={false} onRefresh={onRefresh} />
+        <RefreshControl
+          refreshing={isRefreshing}
+          onRefresh={onRefresh}
+          tintColor={style.get('color-gray-200').color}
+        />
       }
       style={StyleSheet.flatten([
         style.flatten(['padding-x-12']),

--- a/packages/mobile/src/screen/setting/screens/general/general.tsx
+++ b/packages/mobile/src/screen/setting/screens/general/general.tsx
@@ -3,7 +3,6 @@ import {Box} from '../../../../components/box';
 import {Stack} from '../../../../components/stack';
 import {PageButton} from '../../components';
 import {useIntl} from 'react-intl';
-import {useLanguage} from '../../../../languages';
 import {ArrowRightIcon} from '../../../../components/icon/arrow-right';
 import {useStyle} from '../../../../styles';
 import {useNavigation} from '@react-navigation/native';
@@ -13,7 +12,6 @@ import {observer} from 'mobx-react-lite';
 
 export const SettingGeneralScreen: FunctionComponent = observer(() => {
   const intl = useIntl();
-  const language = useLanguage();
   const style = useStyle();
   const navigate = useNavigation<StackNavProp>();
   const {uiConfigStore, keyRingStore} = useStore();
@@ -22,7 +20,7 @@ export const SettingGeneralScreen: FunctionComponent = observer(() => {
     <React.Fragment>
       <Box paddingX={12} paddingY={8}>
         <Stack gutter={8}>
-          <PageButton
+          {/* <PageButton
             title={intl.formatMessage({
               id: 'page.setting.general.language-title',
             })}
@@ -34,7 +32,7 @@ export const SettingGeneralScreen: FunctionComponent = observer(() => {
               />
             }
             onClick={() => navigate.navigate('Setting.General.Lang')}
-          />
+          /> */}
 
           <PageButton
             title={intl.formatMessage({

--- a/packages/mobile/src/screen/sign/sign-modal.tsx
+++ b/packages/mobile/src/screen/sign/sign-modal.tsx
@@ -352,7 +352,7 @@ export const SignModal = registerCardModal(
             backgroundColor={style.get('color-gray-500').color}
             padding={16}
             borderRadius={6}>
-            <ScrollView>
+            <ScrollView persistentScrollbar={true}>
               <Text style={style.flatten(['body3', 'color-text-middle'])}>
                 {JSON.stringify(signDocHelper.signDocJson, null, 2)}
               </Text>

--- a/packages/mobile/src/stores/ui-config/index.ts
+++ b/packages/mobile/src/stores/ui-config/index.ts
@@ -220,6 +220,7 @@ export class UIConfigStore {
   @action
   selectFiatCurrency(value: string) {
     this._fiatCurrency = value;
+    this.priceStore.setDefaultVsCurrency(value);
   }
 
   get language(): string {


### PR DESCRIPTION
# 구현사항

896f6d8bc83fa86846db3e4c1205da7a8ae9696f
-> sign 페이지 text qa 적용

f75008114f75c6c906654dd11264999a91760498
-> https://www.notion.so/chainapsis/Mobile-2-0-QA-Table-68368a2934ca45d7a8e113adf790f478?p=1fce9f2630aa41818b7ef7296b0919b8&pm=s : 스크롤바 계속 보여주기 (android 일때만)

[6624414](https://github.com/chainapsis/keplr-wallet/pull/974/commits/662441477fc765e56c97c4dddb81159f274ae9f9)
-> proposals에서 refresh 했을때 색상 추가

[0ee2464](https://github.com/chainapsis/keplr-wallet/pull/974/commits/0ee24645893fd484f783570ded887c24e67e3f03)
-> language 버튼 setting에서 제거

[f4173ac](https://github.com/chainapsis/keplr-wallet/pull/974/commits/f4173acf80aa147aef1c8d596df2fd071d255fe7)
-> fiat가 작동하지 않는 버그수정

[79894d1](https://github.com/chainapsis/keplr-wallet/pull/974/commits/79894d1774ede9c36b6d0cf147efc02901a15466)
-> setting intro 페이지에서는 헤더의 back 버튼이 보여지지 않도록 수정