### PR TITLE
[QA] reigister 페이지의 Text qa 및 디자인 qa적용

### DIFF
--- a/packages/mobile/src/components/input/text-input/text-input.tsx
+++ b/packages/mobile/src/components/input/text-input/text-input.tsx
@@ -58,7 +58,7 @@ export const TextInput = forwardRef<
 
     const disableStyle = [
       'background-color-gray-650',
-      'border-color-gray-300',
+      'border-color-gray-400',
     ] as const;
 
     const iconColor = 'color-gray-400';

--- a/packages/mobile/src/languages/en.json
+++ b/packages/mobile/src/languages/en.json
@@ -47,7 +47,7 @@
 
   "pages.register.intro.create-wallet-button": "Create a new wallet",
   "pages.register.intro.import-wallet-button": "Import an existing wallet",
-  "pages.register.intro.connect-hardware-wallet-button": "Connect Hardware Wallet",
+  "pages.register.intro.connect-hardware-wallet-button": "Connect Ledger",
 
   "pages.register.intro-new-user.title": "Welcome to Keplr",
   "pages.register.intro-new-user.paragraph": "Select the way you want to create your wallet",
@@ -56,8 +56,8 @@
   "pages.register.intro-new-user.new-recovery-path-button": "Create new recovery phrase",
   "pages.register.intro-new-user.import-recovery-path-button": "Import existing recovery phrase",
   "pages.register.intro-new-user.high-security-text": "Higher Security",
-  "pages.register.intro-new-user.sign-up-social-title": "Sign-up with Google",
-  "pages.register.intro-new-user.sign-up-social-paragraph": "Simple & easy registration",
+  "pages.register.intro-new-user.sign-up-social-title": "Use Social IDs",
+  "pages.register.intro-new-user.sign-up-social-paragraph": "Log in with your social IDs to import an existing account to Keplr",
   "pages.register.intro-new-user.sign-up-google-button": "Connect with Google",
   "pages.register.intro-new-user.sign-up-apple-button": "Connect with Apple ID",
   "pages.register.intro-new-user.more-convenience-text": "More Convenience",
@@ -102,8 +102,8 @@
   "pages.register.name-password-hardware.connect-to-secret": "Secret app",
 
   "pages.register.recover-mnemonic.title": "Import Existing Wallet",
-  "pages.register.recover-mnemonic.paragraph-1": "Enter your recovery phrase here to restore your wallet. Or click on any blank and paste the entire phrase.",
-  "pages.register.recover-mnemonic.paragraph-2": "Enter the phrase in the right order without capitalization, punctuation symbols, or spaces.",
+  "pages.register.recover-mnemonic.paragraph-1": "Enter your recovery phrase or private key to restore your wallet. Tap the blank below to paste the full phrase.",
+  "pages.register.recover-mnemonic.paragraph-2": "Enter your phrase it in lowercase, in the correct order.",
   "pages.register.recover-mnemonic.12-words-tab": "12 words",
   "pages.register.recover-mnemonic.24-words-tab": "24 words",
   "pages.register.recover-mnemonic.private-key-tab": "Private key",
@@ -142,7 +142,7 @@
   "pages.register.connect-keystone.unsupported": "Unsupported",
 
   "pages.register.enable-chains.title": "Select Chains",
-  "pages.register.enable-chains.paragraph": "Don’t worry, you can change your selections anytime in the Manage Chain Visibility in the sidebar menu.",
+  "pages.register.enable-chains.paragraph": "Select which chains you’d like to enable on your account.",
   "pages.register.enable-chains.search-input-placeholder": "Search networks",
   "pages.register.enable-chains.chain-selected-count": "{numSelected} chain(s) selected",
   "pages.register.enable-chains.skip-button": "Skip",

--- a/packages/mobile/src/screen/register/connect-hardware/index.tsx
+++ b/packages/mobile/src/screen/register/connect-hardware/index.tsx
@@ -110,7 +110,7 @@ export const ConnectHardwareWalletScreen: FunctionComponent = observer(() => {
         <XAxis alignY="center">
           <Text style={style.flatten(['body2', 'color-gray-50', 'flex-1'])}>
             {selectedApp}
-            {selectedApp === 'Cosmos' ? ' (Recommend)' : null}
+            {selectedApp === 'Cosmos' ? ' (Recommended)' : null}
           </Text>
 
           <ArrowDownFillIcon

--- a/packages/mobile/src/screen/register/finalize-key/index.tsx
+++ b/packages/mobile/src/screen/register/finalize-key/index.tsx
@@ -416,6 +416,9 @@ export const FinalizeKeyScreen: FunctionComponent = observer(() => {
       <Box marginTop={21} marginBottom={12} paddingX={28} width="100%">
         <SimpleProgressBar progress={queryProgress} />
       </Box>
+      <Text style={style.flatten(['body2', 'color-text-low', 'text-center'])}>
+        ({(queryProgress * 100).toFixed(0)}%/ 100%)
+      </Text>
       <View
         style={{
           flex: 1,

--- a/packages/mobile/src/screen/register/recover-mnemonic/index.tsx
+++ b/packages/mobile/src/screen/register/recover-mnemonic/index.tsx
@@ -145,7 +145,7 @@ export const RecoverMnemonicScreen: FunctionComponent = observer(() => {
             <FormattedMessage id="pages.register.recover-mnemonic.paragraph-1" />
           </Text>
         </XAxis>
-
+        <Gutter size={8} />
         <XAxis>
           <Text
             style={style.flatten([

--- a/packages/mobile/src/screen/register/recover-mnemonic/index.tsx
+++ b/packages/mobile/src/screen/register/recover-mnemonic/index.tsx
@@ -181,7 +181,7 @@ export const RecoverMnemonicScreen: FunctionComponent = observer(() => {
               }
 
               if (!bip39.validateMnemonic(value)) {
-                return 'Invalid mnemonic';
+                return 'Invalid Phrase';
               }
             } else {
               value = value.replace('0x', '');


### PR DESCRIPTION
# 구현사항

register 페이지의 현재 구현된 페이지의 text qa진행 및 finalize-key 애니메이션에서 밑의 progress 퍼센트 추가
디자인 qa이 적용
: https://www.notion.so/chainapsis/Mobile-2-0-Design-QA-4d17f1de86764d999f98e6c1bed7ee7f?p=1bb5a93e330a475e8e9603b0aff2f536&pm=s
https://www.notion.so/chainapsis/Mobile-2-0-Design-QA-4d17f1de86764d999f98e6c1bed7ee7f?p=1e07ce2c965a4b18ab2024934459ee43&pm=s