### PR TITLE
[Fix] 기능 qa 사항들 수정

### DIFF
--- a/packages/mobile/src/components/modal/infoModal.tsx
+++ b/packages/mobile/src/components/modal/infoModal.tsx
@@ -4,7 +4,6 @@ import {Box} from '../../components/box';
 import {useStyle} from '../../styles';
 import {Columns} from '../../components/column';
 import {InformationOutlinedIcon} from '../../components/icon/information-outlined';
-import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {registerCardModal} from './card';
 import {Gutter} from '../gutter';
 export interface InformationModalProps {
@@ -15,9 +14,8 @@ export interface InformationModalProps {
 export const InformationModal = registerCardModal(
   ({title, paragraph, bottomButton}: InformationModalProps) => {
     const style = useStyle();
-    const insects = useSafeAreaInsets();
     return (
-      <Box paddingX={12} paddingBottom={40 + insects.bottom}>
+      <Box paddingX={12} paddingBottom={40}>
         <Box>
           <Box>
             <Box paddingBottom={21} paddingTop={9} paddingX={8} alignY="center">

--- a/packages/mobile/src/screen/home/components/deposit-modal/copy-address-scene.tsx
+++ b/packages/mobile/src/screen/home/components/deposit-modal/copy-address-scene.tsx
@@ -150,7 +150,9 @@ export const CopyAddressScene: FunctionComponent<{
         </Box>
 
         <Gutter size={12} />
-        <ScrollView isGestureScrollView={true} style={{height: 270}}>
+        <ScrollView
+          isGestureScrollView={true}
+          style={style.flatten(['height-400'])}>
           {addresses.length === 0 ? (
             <Box
               alignX="center"

--- a/packages/mobile/src/screen/home/components/deposit-modal/copy-address-scene.tsx
+++ b/packages/mobile/src/screen/home/components/deposit-modal/copy-address-scene.tsx
@@ -150,9 +150,7 @@ export const CopyAddressScene: FunctionComponent<{
         </Box>
 
         <Gutter size={12} />
-        <ScrollView
-          isGestureScrollView={true}
-          style={style.flatten(['height-400'])}>
+        <ScrollView isGestureScrollView={true} style={{height: 270}}>
           {addresses.length === 0 ? (
             <Box
               alignX="center"

--- a/packages/mobile/src/screen/home/staked.tsx
+++ b/packages/mobile/src/screen/home/staked.tsx
@@ -188,6 +188,18 @@ export const StakedTabView: FunctionComponent<{
                         },
                       });
                     }}
+                    onClickError={(errorKind, errorMsg) => {
+                      if (errorKind === 'common') {
+                        setInfoModalState({
+                          title: intl.formatMessage({
+                            id: 'page.main.components.error-modal-title',
+                          }),
+                          paragraph: errorMsg,
+                        });
+                        setIsInfoModalOpen(true);
+                        return;
+                      }
+                    }}
                   />
                 );
               })}

--- a/packages/mobile/src/screen/staking/components/validator-item/index.tsx
+++ b/packages/mobile/src/screen/staking/components/validator-item/index.tsx
@@ -93,6 +93,7 @@ export const ValidatorItem: FunctionComponent<{
                   {viewValidator.coin
                     .maxDecimals(6)
                     .trim(true)
+                    .inequalitySymbol(true)
                     .shrink(true)
                     .toString()}
                 </Text>

--- a/packages/mobile/src/screen/staking/dashboard/dashboard.tsx
+++ b/packages/mobile/src/screen/staking/dashboard/dashboard.tsx
@@ -148,11 +148,6 @@ export const StakingDashboardScreen: FunctionComponent = observer(() => {
       const amount = queryDelegations.getDelegationTo(
         validator.operator_address,
       );
-      //NOTE 인젝티브에서만 delegation양이 0인데 getDelegationTo으로 부터 값이 오는 문제가 있어서
-      //amount가 0이면 무시함
-      if (amount?.toCoin().amount === '0') {
-        continue;
-      }
 
       res.push({
         coin: amount,

--- a/packages/mobile/src/screen/staking/dashboard/dashboard.tsx
+++ b/packages/mobile/src/screen/staking/dashboard/dashboard.tsx
@@ -166,16 +166,19 @@ export const StakingDashboardScreen: FunctionComponent = observer(() => {
     title: string;
     validators: ViewValidator[];
     lenAlwaysShown: number;
+    key: 'delegations' | 'unbondings';
   }[] = [
     {
       title: intl.formatMessage({id: 'page.stake.staked-balance-title'}),
       validators: delegations,
       lenAlwaysShown: 4,
+      key: 'delegations',
     },
     {
       title: intl.formatMessage({id: 'page.stake.unstaking-balance-title'}),
       validators: unbondings,
       lenAlwaysShown: 4,
+      key: 'unbondings',
     },
   ];
   const onRefresh = async () => {
@@ -330,12 +333,13 @@ export const StakingDashboardScreen: FunctionComponent = observer(() => {
           />
         </Box>
       ) : (
-        ValidatorViewData.map(({title, validators, lenAlwaysShown}) => {
+        ValidatorViewData.map(({title, validators, lenAlwaysShown, key}) => {
           if (validators.length === 0) {
             return null;
           }
+
           return (
-            <React.Fragment key={title}>
+            <React.Fragment key={key}>
               <Gutter size={12} />
               <CollapsibleList
                 title={<TokenTitleView title={title} />}
@@ -351,6 +355,7 @@ export const StakingDashboardScreen: FunctionComponent = observer(() => {
                         name: validator.name,
                         validatorAddress: validator.validatorAddress,
                         subString: validator.subString,
+                        isDelegation: key === 'delegations' ? true : false,
                       }}
                       key={validator.validatorAddress + validator.subString}
                       afterSelect={() => {

--- a/packages/mobile/src/screen/staking/dashboard/dashboard.tsx
+++ b/packages/mobile/src/screen/staking/dashboard/dashboard.tsx
@@ -148,6 +148,11 @@ export const StakingDashboardScreen: FunctionComponent = observer(() => {
       const amount = queryDelegations.getDelegationTo(
         validator.operator_address,
       );
+      //NOTE 인젝티브에서만 delegation양이 0인데 getDelegationTo으로 부터 값이 오는 문제가 있어서
+      //amount가 0이면 무시함
+      if (amount?.toCoin().amount === '0') {
+        continue;
+      }
 
       res.push({
         coin: amount,

--- a/packages/mobile/src/screen/staking/validator-detail/index.tsx
+++ b/packages/mobile/src/screen/staking/validator-detail/index.tsx
@@ -22,14 +22,16 @@ import {Button} from '../../../components/button';
 import {FormattedMessage, useIntl} from 'react-intl';
 
 export const ValidatorDetailScreen: FunctionComponent = observer(() => {
-  const {queriesStore, chainStore} = useStore();
-
+  const {queriesStore, chainStore, accountStore} = useStore();
   const route = useRoute<RouteProp<StakeNavigation, 'Stake.ValidateDetail'>>();
+
+  const {validatorAddress, chainId, validatorSelector} = route.params;
+
   const navigation = useNavigation<StackNavProp>();
   const style = useStyle();
   const intl = useIntl();
+  const account = accountStore.getAccount(chainId);
 
-  const {validatorAddress, chainId, validatorSelector} = route.params;
   const queries = queriesStore.get(chainId);
   const bondedValidators = queries.cosmos.queryValidators.getQueryStatus(
     Staking.BondStatus.Bonded,
@@ -74,6 +76,10 @@ export const ValidatorDetailScreen: FunctionComponent = observer(() => {
   const isTop10Validator = validatorInfo?.rank
     ? validatorInfo.rank <= 10
     : false;
+
+  const staked = queries.cosmos.queryDelegations
+    .getQueryBech32Address(account.bech32Address)
+    .getDelegationTo(validatorAddress);
 
   return (
     <PageWithScrollView
@@ -144,6 +150,7 @@ export const ValidatorDetailScreen: FunctionComponent = observer(() => {
                   size={40}
                   imageUrl={thumbnail}
                   name={validatorInfo?.description.moniker}
+                  isDelegation={staked && !staked.toDec().isZero()}
                 />
                 <Text
                   numberOfLines={1}


### PR DESCRIPTION
# 구현사항

9890ccaec1c65835fb6e65c94f4bbdd6ea16cbe8
-> https://www.notion.so/chainapsis/Mobile-2-0-QA-Table-68368a2934ca45d7a8e113adf790f478?p=8eb923b2700a4b32be695e9bdf886e37&pm=s 

54c16093b4fdf4797346414f38a1af01027481b9 08abebce37df8ade59066a6c44553e036e8de457
-> 스테이킹한 자산이 0.000001 이하일때 `< 0.000001` 형태로 표시 

50641636f010e6dd06dfc45e5f32e651197b857d
-> 스테이킹 탭에서 에러가 발생한 token 아이템 클릭시 에러모달이 보일수 있게 수정

eacce1510523b866c7207d60b03608d0002f9355
-> 벨리데이터 디테일 페이지와 스테이킹 대시보드 페이지에서 스테이킹 뱃지 추가


