### PR TITLE
[KM-146] 거버넌스 페이지에서 empty text 수정, suggect체인은 vote에서 안보이게 수정

### DIFF
--- a/packages/mobile/src/languages/en.json
+++ b/packages/mobile/src/languages/en.json
@@ -26,8 +26,8 @@
   "error.simulating-secret-wasm-not-supported": "Simulating secret wasm not supported",
 
   "page.governance.proposal-list.empty-text": "No records of past or ongoing proposals found on this chain.",
-  "page.governance.main.empty-text-1": "No records of past or",
-  "page.governance.main.empty-text-2": "ongoing proposals found",
+  "page.governance.main.empty-title": "No Proposals Awaiting Your Vote",
+  "page.governance.main.empty-text": "Stake your assets first to start voting on proposals. Your voting power is determined by the amount of staked tokens.",
   "page.governance.chain-item-proposal-length": "{len} Proposals",
 
   "page.governance.components.select-chain-modal.input-placeholder": "Search for a chain",

--- a/packages/mobile/src/languages/ko.json
+++ b/packages/mobile/src/languages/ko.json
@@ -26,8 +26,8 @@
   "error.simulating-secret-wasm-not-supported": "Simulating secret wasm not supported",
 
   "page.governance.proposal-list.empty-text": "No records of past or ongoing proposals found.",
-  "page.governance.main.empty-text-1": "No records of past or",
-  "page.governance.main.empty-text-2": "ongoing proposals found",
+  "page.governance.main.empty-title": "No Proposals Awaiting Your Vote",
+  "page.governance.main.empty-text": "Stake your assets first to start voting on proposals. Your voting power is determined by the amount of staked tokens.",
   "page.governance.chain-item-proposal-length": "{len} Proposals",
 
   "page.governance.components.select-chain-modal.input-placeholder": "Search for a chain",

--- a/packages/mobile/src/screen/governance/index.tsx
+++ b/packages/mobile/src/screen/governance/index.tsx
@@ -208,12 +208,13 @@ export const GovernanceScreen: FunctionComponent = observer(() => {
             <Box alignX="center">
               <EmptyViewText
                 text={intl.formatMessage({
-                  id: 'page.governance.main.empty-text-1',
+                  id: 'page.governance.main.empty-title',
                 })}
               />
+              <Gutter size={12} />
               <EmptyViewText
                 text={intl.formatMessage({
-                  id: 'page.governance.main.empty-text-2',
+                  id: 'page.governance.main.empty-text',
                 })}
               />
             </Box>

--- a/packages/mobile/src/screen/governance/index.tsx
+++ b/packages/mobile/src/screen/governance/index.tsx
@@ -21,6 +21,7 @@ import {ChainImageFallback} from '../../components/image';
 import {Stack} from '../../components/stack';
 import {XAxis} from '../../components/axis';
 import {
+  EmbedChainInfos,
   GovernanceV1ChainIdentifiers,
   NoDashboardLinkIdentifiers,
 } from '../../config';
@@ -29,6 +30,10 @@ import {EmptyView, EmptyViewText} from '../../components/empty-view';
 import {Box} from '../../components/box';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {Skeleton} from '../../components/skeleton';
+
+const embedChainInfosIdentifiers = EmbedChainInfos.map(
+  item => ChainIdHelper.parse(item.chainId).identifier,
+);
 
 export const GovernanceScreen: FunctionComponent = observer(() => {
   const style = useStyle();
@@ -40,13 +45,25 @@ export const GovernanceScreen: FunctionComponent = observer(() => {
 
   const delegations: ViewToken[] = useMemo(
     () =>
-      hugeQueriesStore.delegations.filter(token => {
-        return token.token.toDec().gt(new Dec(0));
-      }),
+      hugeQueriesStore.delegations
+        .filter(viewToken =>
+          embedChainInfosIdentifiers.includes(
+            ChainIdHelper.parse(viewToken.chainInfo.chainId).identifier,
+          ),
+        )
+        .filter(token => {
+          return token.token.toDec().gt(new Dec(0));
+        }),
     [hugeQueriesStore.delegations],
   );
+
   const modalItems: SelectModalItem[] = useMemo(() => {
     return hugeQueriesStore.stakables
+      .filter(viewToken =>
+        embedChainInfosIdentifiers.includes(
+          ChainIdHelper.parse(viewToken.chainInfo.chainId).identifier,
+        ),
+      )
       .filter(
         viewToken =>
           !NoDashboardLinkIdentifiers.includes(


### PR DESCRIPTION
# 구현사항

![Screenshot 2024-01-03 at 4 37 27 PM](https://github.com/chainapsis/keplr-wallet/assets/10705018/9b2c0687-34c6-41d3-8b22-ffdbbd76bc55)

거버넌스 리스트 페이지에서 empty 텍스트 수정
suggest 체인은 vote에서 안보일수 있게 수정


https://www.notion.so/chainapsis/Mobile-2-0-QA-Table-68368a2934ca45d7a8e113adf790f478?p=c30ec33aa9964ed3b2d08da5663cfc01&pm=s
해당 이슈는 해당 체인이 체인레지스트리에서 등록할때 stakeCurrency에 이미지를 등록하지 않아서 발생하는 문제여서 안고치기로 했습니다