### PR TITLE
[QA] home에서 토큰 이미지에서 placeholder가 안보이는 버그 수정

### DIFF
--- a/packages/mobile/src/components/image/index.tsx
+++ b/packages/mobile/src/components/image/index.tsx
@@ -16,10 +16,14 @@ export const Image: FunctionComponent<{
 
   return (
     <FastImage
-      source={{
-        uri: propSrc,
-        cache: cache || FastImage.cacheControl.web,
-      }}
+      source={
+        propSrc
+          ? {
+              uri: propSrc,
+              cache: cache || FastImage.cacheControl.web,
+            }
+          : defaultSrc
+      }
       style={style}
       defaultSource={defaultSrc}
     />
@@ -30,16 +34,19 @@ export const ChainImageFallback: FunctionComponent<{
   src: string | undefined; // 얘는 undefined더라도 일단 넣으라고 일부로 ?를 안붙인거임.
   alt: string;
   style: Object;
-}> = ({src, alt, style}) => {
+}> = ({src, style}) => {
   return (
-    <Image
-      defaultSrc={require('../../public/assets/img/chain-icon-alt.png')}
+    <FastImage
       style={{
-        borderRadius: 1000000,
         ...style,
+        borderRadius: 99999,
       }}
-      src={src}
-      alt={alt}
+      source={
+        src
+          ? {uri: src, cache: FastImage.cacheControl.web}
+          : require('../../public/assets/img/chain-icon-alt.png')
+      }
+      resizeMode={FastImage.resizeMode.contain}
     />
   );
 };


### PR DESCRIPTION
# 구현사항
token item에서 2 deps로 ChainImageFallback-> Image 컴포넌트로 가서 FastImage를 호출 할 경우 대체이미지가 안보이는 문제가 있었습니다
정확한 원리는 파악을 못하고 일단 FastImage를 ChainImageFallback에서 바로 쓰면 해결이 되서 일단 그렇게 처리를 했습니다