### PR TITLE
[Fix] 거버넌스 페이지 로딩 버그 수정

### DIFF
--- a/packages/mobile/src/screen/governance/index.tsx
+++ b/packages/mobile/src/screen/governance/index.tsx
@@ -38,7 +38,7 @@ export const GovernanceScreen: FunctionComponent = observer(() => {
   const [isOpenSelectChainModal, setIsOpenSelectChainModal] = useState(false);
   const navigation = useNavigation<StackNavProp>();
   const intl = useIntl();
-  const isFetching = useRef(1);
+  const isFetching = useRef(true);
 
   const delegations: ViewToken[] = useMemo(
     () =>
@@ -47,6 +47,12 @@ export const GovernanceScreen: FunctionComponent = observer(() => {
           embedChainInfosIdentifiers.includes(
             ChainIdHelper.parse(viewToken.chainInfo.chainId).identifier,
           ),
+        )
+        .filter(
+          viewToken =>
+            !NoDashboardLinkIdentifiers.includes(
+              ChainIdHelper.parse(viewToken.chainInfo.chainId).identifier,
+            ),
         )
         .filter(token => {
           return token.token.toDec().gt(new Dec(0));
@@ -83,7 +89,7 @@ export const GovernanceScreen: FunctionComponent = observer(() => {
           ChainIdHelper.parse(viewToken.chainInfo.chainId).identifier,
         ),
     )
-    .map((delegation, index) => {
+    .map(delegation => {
       const isGovV1Supported =
         GovernanceV1ChainIdentifiers.includes(
           ChainIdHelper.parse(delegation.chainInfo.chainId).identifier,
@@ -115,13 +121,9 @@ export const GovernanceScreen: FunctionComponent = observer(() => {
               status: 'PROPOSAL_STATUS_VOTING_PERIOD',
             });
 
-      //NOTE delegations 모두 fetch가 끝났을때 스켈레톤을 지우기 위해서 해당 로직을 통해서 isFetch을 설정함
-      isFetching.current += Number(queryGovernance.isFetching);
-      if (index + 1 === delegations.length) {
-        isFetching.current > 1
-          ? (isFetching.current = 1)
-          : (isFetching.current = 0);
-      }
+      //NOTE delegations중 하나라도 완료가 되면 isFetching을 false로 설정하고 변경하지 않음
+      isFetching.current =
+        !isFetching.current || !queryGovernance.isFetching ? false : true;
 
       return isGovV1Supported
         ? {

--- a/packages/mobile/src/screen/staking/dashboard/dashboard.tsx
+++ b/packages/mobile/src/screen/staking/dashboard/dashboard.tsx
@@ -192,12 +192,10 @@ export const StakingDashboardScreen: FunctionComponent = observer(() => {
     setRefreshing(false);
   };
 
+  //NOTE bondedValidators.isFetching값으로 지정할 경우 방문시 마다 캐싱이 안돼서
+  //skeleton이 매번 보이게됨, 해서 한번 로딩을 했으면 그때부터는 isNotReady를 false로 설정함
   const isNotReady =
-    queryDelegations.isFetching ||
-    queryUnbondings.isFetching ||
-    bondedValidators.isFetching ||
-    unbondedValidators.isFetching ||
-    unbondingValidators.isFetching;
+    (!delegations.length && !unbondings.length) || !validators.length;
 
   return (
     <PageWithScrollView


### PR DESCRIPTION
# 구현사항
거버넌스 페이지에서 스켈레톤이 안사라지는 버그를 수정 했습니다
- 스테이킹중인 체인이 많을경우 전체 체인에 대해서 isFetching을 검사하면 시간이 너무 오래 걸리는것 같아서 하나만 완료 돼도 보여줄수 있게 수정했습니다

staking 페이지에서 기존 isNotReady는 isFetching값을 사용하는데 해당값은 캐싱이 안되서 접근시 마다 다른 데이터들이 케싱이 되어있어도 스켈레톤이 보이는 문제가 있어서 로직을 수정 했습니다