### PR TITLE
익스텐션과 로직이 맞을수 있게 claimAll 수정

### DIFF
--- a/packages/mobile/src/screen/setting/screens/security/security.tsx
+++ b/packages/mobile/src/screen/setting/screens/security/security.tsx
@@ -98,7 +98,7 @@ export const SettingSecurityAndPrivacyScreen: FunctionComponent = observer(
                 </Box>
               }
             />
-            <PageButton
+            {/* <PageButton
               title={intl.formatMessage({
                 id: 'page.setting.security.analytics-title',
               })}
@@ -106,31 +106,12 @@ export const SettingSecurityAndPrivacyScreen: FunctionComponent = observer(
                 id: 'page.setting.security.analytics-paragraph',
               })}
               endIcon={
-                <Box marginLeft={8}>
-                  {/* TODO analytics추가후 설정 해야함 */}
-                  <Toggle
-                    isOpen={false}
-                    // isOpen={!disableAnalytics}
-                    setIsOpen={() => {
-                      // const disableAnalytics =
-                      //   localStorage.getItem('disable-analytics') === 'true';
-                      // new InExtensionMessageRequester()
-                      //   .sendMessage(
-                      //     BACKGROUND_PORT,
-                      //     new SetDisableAnalyticsMsg(!disableAnalytics),
-                      //   )
-                      //   .then(analyticsDisabled => {
-                      //     localStorage.setItem(
-                      //       'disable-analytics',
-                      //       analyticsDisabled ? 'true' : 'false',
-                      //     );
-                      //     setDisableAnalytics(analyticsDisabled);
-                      //   });
-                    }}
-                  />
+                <Box marginLeft={8}> */}
+            {/* TODO analytics추가후 설정 해야함 */}
+            {/* <Toggle isOpen={false} setIsOpen={() => {}} />
                 </Box>
               }
-            />
+            /> */}
           </Stack>
         </Box>
       </React.Fragment>

--- a/packages/mobile/src/screen/staking/validator-detail/delegated-card.tsx
+++ b/packages/mobile/src/screen/staking/validator-detail/delegated-card.tsx
@@ -10,6 +10,8 @@ import {Column, Columns} from '../../../components/column';
 import {useNavigation} from '@react-navigation/native';
 import {StackNavProp} from '../../../navigation';
 import {FormattedMessage, useIntl} from 'react-intl';
+import {ChainIdHelper} from '@keplr-wallet/cosmos';
+import {CoinPretty} from '@keplr-wallet/unit';
 
 export const DelegatedCard: FunctionComponent<{
   chainId: string;
@@ -29,9 +31,34 @@ export const DelegatedCard: FunctionComponent<{
     .getQueryBech32Address(account.bech32Address)
     .getDelegationTo(validatorAddress);
 
-  const rewards = queries.cosmos.queryRewards
-    .getQueryBech32Address(account.bech32Address)
-    .getStakableRewardOf(validatorAddress);
+  const queryRewards = queries.cosmos.queryRewards.getQueryBech32Address(
+    account.bech32Address,
+  );
+
+  const rewards = (() => {
+    let reward: CoinPretty | undefined;
+    const isDydx = ChainIdHelper.parse(chainId).identifier === 'dydx-mainnet';
+    if (isDydx) {
+      const denom =
+        'ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5';
+      reward = queryRewards
+        .getRewardsOf(validatorAddress)
+        .find(r => r.currency.coinMinimalDenom === denom);
+    } else {
+      reward = queryRewards.getStakableRewardOf(validatorAddress);
+    }
+    //NOTE reward가 stake currency가 아닐경우 reward가 없을때 undefined로 반환될 떄가 있음
+    //현재 usdc가 유일한 경우라서 하드코딩된 문자열로 처리함
+    return !reward && isDydx
+      ? '0 USDC'
+      : reward
+          ?.trim(true)
+          .shrink(true)
+          .maxDecimals(6)
+          .inequalitySymbol(true)
+          .hideIBCMetadata(true)
+          .toString();
+  })();
 
   return staked && !staked.toDec().isZero() ? (
     <Box>
@@ -73,12 +100,7 @@ export const DelegatedCard: FunctionComponent<{
           </Text>
           <Column weight={1} />
           <Text style={style.flatten(['body1', 'color-text-high'])}>
-            {rewards
-              ?.trim(true)
-              .shrink(true)
-              .maxDecimals(6)
-              .inequalitySymbol(true)
-              .toString()}
+            {rewards}
           </Text>
         </Columns>
 


### PR DESCRIPTION
# 구현사항
1. 익스텐션의 로직과 같을수 있게 모바일의 claim all 로직 수정
2. dydx의 경우 스테이킹 리워드를 usdc로 표기해야 돼서 벨리데이터 디테일 페이지, delegated card에서 dydx일때만 리워드를 usdc로 보여줄수 있게 수정

# 참고사항
claim all 할때 dydx는 테스트 해봤는데 오스모의 경우 claim all을 할때 claim 될만큼 리워드를 가진 지갑이 없어서 테스트를 못했습니다