### PR TITLE
[QA] 레지스터 페이지에서 헤더와 가이드 텍스트 간격 추가

### DIFF
--- a/packages/mobile/src/screen/register/recover-mnemonic/index.tsx
+++ b/packages/mobile/src/screen/register/recover-mnemonic/index.tsx
@@ -131,6 +131,7 @@ export const RecoverMnemonicScreen: FunctionComponent = observer(() => {
         onPress: onSubmit,
       }}
       paddingX={20}>
+      <Gutter size={12} />
       <Box paddingX={8}>
         <XAxis>
           <Text
@@ -161,7 +162,7 @@ export const RecoverMnemonicScreen: FunctionComponent = observer(() => {
         </XAxis>
       </Box>
 
-      <Gutter size={12} />
+      <Gutter size={20} />
 
       <Text style={style.flatten(['subtitle3', 'color-label-default'])}>
         Recovery Phrase

--- a/packages/mobile/src/screen/register/verify-mnemonic/index.tsx
+++ b/packages/mobile/src/screen/register/verify-mnemonic/index.tsx
@@ -146,7 +146,9 @@ export const VerifyMnemonicScreen: FunctionComponent = observer(() => {
         onPress: onSubmit,
       }}
       paddingX={20}>
-      <Text style={style.flatten(['color-text-low', 'body1'])}>
+      <Gutter size={12} />
+
+      <Text style={style.flatten(['color-text-low', 'body1', 'text-center'])}>
         <FormattedMessage id="pages.register.verify-mnemonic.paragraph" />
       </Text>
 


### PR DESCRIPTION
# 구현사항
https://www.figma.com/file/QcgTPzrxekdaH4gGrMEnRh/Mobile-2.0?node-id=7850:67443&mode=dev
해당 디자인에서 헤더와 가이드테스트 사이의 간격을 좀더 넓혀달라고 해서 적용했습니다

verify mnemonic에서도 비슷한 디자인이라서 여기도 간격을 넓히고, 기존 디자인에서 text가 center라서 수정했습니다