### PR TITLE
[QA] 자산이 없을때 send 페이지 수정

### DIFF
--- a/packages/mobile/src/languages/en.json
+++ b/packages/mobile/src/languages/en.json
@@ -496,7 +496,8 @@
 
   "page.send.select-asset.title": "Select Asset",
   "page.send.select-asset.search-placeholder": "Search by a chain or asset name",
-  "page.send.select-asset.hide-ibc-token": "Hide IBC token",
+  "page.send.select-asset.hide-ibc-token": "No available asset",
+  "page.send.select-asset.empty-text": "Hide IBC token",
   "page.send.type.send": "Send",
   "page.send.type.ibc-transfer": "IBC Send",
   "page.send.amount.ibc-transfer.destination-chain": "Destination Chain",

--- a/packages/mobile/src/screen/home/components/claim-all/index.tsx
+++ b/packages/mobile/src/screen/home/components/claim-all/index.tsx
@@ -864,7 +864,17 @@ const ClaimTokenItem: FunctionComponent<{
                 'color-gray-700',
                 'dark:color-gray-300',
               ])}>
-              {viewToken.token.currency.coinDenom}
+              {(() => {
+                if ('paths' in viewToken.token.currency) {
+                  const originDenom =
+                    viewToken.token.currency.originCurrency?.coinDenom;
+                  if (originDenom) {
+                    return `${originDenom} (${viewToken.chainInfo.chainName})`;
+                  }
+                }
+
+                return viewToken.token.currency.coinDenom;
+              })()}
             </Text>
             <Text
               style={style.flatten([

--- a/packages/mobile/src/screen/home/index.tsx
+++ b/packages/mobile/src/screen/home/index.tsx
@@ -10,7 +10,7 @@ import {observer} from 'mobx-react-lite';
 import {useStyle} from '../../styles';
 import {PageWithScrollView} from '../../components/page';
 import {useStore} from '../../stores';
-import {CoinPretty, PricePretty} from '@keplr-wallet/unit';
+import {CoinPretty, Dec, PricePretty} from '@keplr-wallet/unit';
 import {QueryError} from '@keplr-wallet/stores';
 import {Button} from '../../components/button';
 import {Gutter} from '../../components/gutter';
@@ -73,6 +73,14 @@ export const HomeScreen: FunctionComponent = observer(() => {
   const [isDepositModalOpen, setIsDepositModalOpen] = useState(false);
   const [isBuyModalOpen, setIsBuyModalOpen] = useState(false);
   const [selectModalIsOpen, setSelectModalIsOpen] = useState(false);
+
+  const hasBalance = (() => {
+    if (tabStatus === 'available') {
+      const balances = hugeQueriesStore.getAllBalances(true);
+      return balances.find(bal => bal.token.toDec().gt(new Dec(0))) != null;
+    }
+    return false;
+  })();
 
   const availableTotalPrice = useMemo(() => {
     let result: PricePretty | undefined;
@@ -362,6 +370,7 @@ export const HomeScreen: FunctionComponent = observer(() => {
                         ...StackActions.push('Send.SelectAsset'),
                       });
                     }}
+                    disabled={!hasBalance}
                   />
                 </Skeleton>
               </Column>

--- a/packages/mobile/src/screen/send/select-asset/index.tsx
+++ b/packages/mobile/src/screen/send/select-asset/index.tsx
@@ -19,6 +19,7 @@ import {
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {Box} from '../../../components/box';
 import {TouchableWithoutFeedback} from 'react-native-gesture-handler';
+import {EmptyView, EmptyViewText} from '../../../components/empty-view';
 
 export const SendSelectAssetScreen: FunctionComponent = observer(() => {
   const style = useStyle();
@@ -105,31 +106,46 @@ export const SendSelectAssetScreen: FunctionComponent = observer(() => {
         <Gutter size={12} />
       </Box>
 
-      <BoundaryScrollView
-        contentContainerStyle={{
-          ...style.flatten(['flex-grow-1', 'padding-x-12']),
-          paddingBottom: safeAreaInsets.bottom,
-        }}>
-        <BoundaryScrollViewBoundary
-          itemHeight={71.3}
-          gap={8}
-          items={filteredTokens.map(token => {
-            return (
-              <TokenItem
-                viewToken={token}
-                onClick={() => {
-                  navigation.dispatch({
-                    ...StackActions.replace('Send', {
-                      chainId: token.chainInfo.chainId,
-                      coinMinimalDenom: token.token.currency.coinMinimalDenom,
-                    }),
-                  });
-                }}
+      {filteredTokens.length ? (
+        <BoundaryScrollView
+          contentContainerStyle={{
+            ...style.flatten(['flex-grow-1', 'padding-x-12']),
+            paddingBottom: safeAreaInsets.bottom,
+          }}>
+          <BoundaryScrollViewBoundary
+            itemHeight={71.3}
+            gap={8}
+            items={filteredTokens.map(token => {
+              return (
+                <TokenItem
+                  viewToken={token}
+                  onClick={() => {
+                    navigation.dispatch({
+                      ...StackActions.replace('Send', {
+                        chainId: token.chainInfo.chainId,
+                        coinMinimalDenom: token.token.currency.coinMinimalDenom,
+                      }),
+                    });
+                  }}
+                />
+              );
+            })}
+          />
+        </BoundaryScrollView>
+      ) : (
+        <React.Fragment>
+          <Gutter size={150} />
+          <EmptyView>
+            <Box alignX="center">
+              <EmptyViewText
+                text={intl.formatMessage({
+                  id: 'page.send.select-asset.hide-ibc-token',
+                })}
               />
-            );
-          })}
-        />
-      </BoundaryScrollView>
+            </Box>
+          </EmptyView>
+        </React.Fragment>
+      )}
     </Box>
   );
 });


### PR DESCRIPTION
# 구현사항
자산이 없을시 send 버튼 비활성화 및 empty text 추가
![Screenshot 2024-01-15 at 7 44 49 PM](https://github.com/chainapsis/keplr-wallet/assets/10705018/4ef368a2-883c-41e7-b707-a122a5794a53)
<img width="381" alt="Screenshot 2024-01-15 at 7 45 40 PM" src="https://github.com/chainapsis/keplr-wallet/assets/10705018/60d3d71b-64cc-4fb1-b6a2-2d56905ac9a0">

https://chainapsis.slack.com/archives/C01RAHVLXFS/p1705310811263929 스레드에서 5번이슈
. https://www.notion.so/chainapsis/Claim-All-dYdX-USDC-dYdX-fb5b90801132440ebe0459d6a39730b5 이것도 USDC (dYdX)가 아니라 현재 USDC (Noble/channel-0)으로 뜨는 것 같습니당!
-> dydx로 보일수 있도록 수정 했습니다
<img width="403" alt="Screenshot 2024-01-16 at 12 37 41 PM" src="https://github.com/chainapsis/keplr-wallet/assets/10705018/9e734bd5-47d1-4025-b839-38d942fe9d62">



