### PR TITLE
Update ko.json

### DIFF
--- a/packages/extension/src/languages/ko.json
+++ b/packages/extension/src/languages/ko.json
@@ -19,7 +19,7 @@
   "error.can-not-find-balance-for-fee-currency": "수수료로 사용되는 토큰의 잔액을 확인할 수 없습니다.",
   "error.not-enough-balance-to-pay-fee": "수수료를 지불할 잔액이 부족합니다.",
   "error.claimable-reward-is-smaller-than-the-required-fee": "받을 리워드가 지불할 수수료보다 적습니다.",
-  "error.outdated-cosmos-sdk": "cosmos-sdk 버전이 오래되서 지원되지 않습니다.",
+  "error.outdated-cosmos-sdk": "cosmos-sdk 버전이 오래돼서 지원되지 않습니다.",
   "error.can-not-find-fee-for-claim-all": "수수료로 지불할 통화를 찾을 수 없습니다.",
 
   "pages.register.components.header.intro-title": "내 손 안의 인터체인",
@@ -111,7 +111,7 @@
   "pages.register.back-up-private-key.blur-text": "프라이빗키를 보려면, 여기를 클릭하세요.",
   "pages.register.back-up-private-key.warning-title": "프라이빗키를 안전하게 보관하세요.",
   "pages.register.back-up-private-key.warning-paragraph": "프라이빗키를 가진 누구나 당신의 자산에 접근하고, 탈취할 수 있습니다.{br}{br}사용하신 구글 계정을 잃어버린 경우, 프라이빗키를 통해서만 해당 지갑을 복구할 수 있습니다. 그러므로 프라이빗키를 반드시 안전한 곳에 보관해주세요.",
-  "pages.register.back-up-private-key.import-button": "불러오기",
+  "pages.register.back-up-private-key.import-button": "확인",
 
   "pages.register.connect-ledger.title": "하드웨어 지갑을 연결해주세요.",
   "pages.register.connect-ledger.paragraph": "EVM 체인(Injective, Evmos)을 케플러에서 사용하실 분들은 이후 단계에서 이더리움 앱을 연결하실 수 있습니다.",


### PR DESCRIPTION
minor fixes in Korean translation

- 오래되서 -> 오래돼서 문법 교정
- 불러오기 -> 확인 // 현재 구글 계정이 생성과 불러오기가 같은 플로우이다보니 생성할 때도 "불러오기" 버튼이 뜨고 있는데, 양 쪽 다 사용될 수 있도록 "확인" 이라는 버튼으로 바꾸는 것을 제안드립니다. 