### PR TITLE
Fix sign message icon space

### DIFF
--- a/apps/extension/src/pages/sign/components/message-item/index.tsx
+++ b/apps/extension/src/pages/sign/components/message-item/index.tsx
@@ -17,16 +17,16 @@ export const MessageItem: FunctionComponent<{
     <Box padding="1rem">
       <Columns sum={1}>
         <Box
-          width="3rem"
-          minWidth="3rem"
-          height="3rem"
+          width="2.5rem"
+          minWidth="2.5rem"
+          height="2.5rem"
           alignX="center"
           alignY="center"
         >
           {icon}
         </Box>
 
-        <Gutter size="0.75rem" />
+        <Gutter size="0.5rem" />
 
         <Column weight={1}>
           <Box minHeight="3rem" alignY="center">


### PR DESCRIPTION
<img width="359" alt="스크린샷 2024-08-07 오후 2 37 00" src="https://github.com/user-attachments/assets/4a65c2d2-b80b-42d4-8842-dd73c98ae6fc">
