### PR TITLE
[KEPLR-301] Add search bar to contacts tab on address book modal

### DIFF
--- a/apps/extension/src/components/address-book-modal/index.tsx
+++ b/apps/extension/src/components/address-book-modal/index.tsx
@@ -86,9 +86,8 @@ export const AddressBookModal: FunctionComponent<{
     }, [historyType, recipientConfig.chainId, uiConfigStore.addressBookConfig]);
 
     useEffect(() => {
-      if (type !== "accounts") return;
       (() => {
-        if (!debounceTrimmedSearchText) {
+        if (type !== "accounts" || !debounceTrimmedSearchText) {
           return uiConfigStore.addressBookConfig.getVaultCosmosKeysSettled(
             recipientConfig.chainId,
             permitSelfKeyInfo ? undefined : keyRingStore.selectedKeyInfo?.id

--- a/apps/extension/src/components/address-book-modal/index.tsx
+++ b/apps/extension/src/components/address-book-modal/index.tsx
@@ -57,18 +57,18 @@ export const AddressBookModal: FunctionComponent<{
 
     const [type, setType] = useState<Type>("recent");
 
-    const [accountsSearchText, setAccountsSearchText] = useState("");
-    const [debounceAccountsSearchText, setDebounceAccountsSearchText] =
+    const [searchText, setSearchText] = useState("");
+    const [debounceTrimmedSearchText, setDebounceTrimmedSearchText] =
       useState<string>("");
     useEffect(() => {
       const timer = setTimeout(() => {
-        setDebounceAccountsSearchText(accountsSearchText);
+        setDebounceTrimmedSearchText(searchText.trim());
       }, 300);
 
       return () => {
         clearTimeout(timer);
       };
-    }, [accountsSearchText]);
+    }, [searchText]);
 
     const [recents, setRecents] = useState<RecentSendHistory[]>([]);
     const [accounts, setAccounts] = useState<
@@ -86,15 +86,16 @@ export const AddressBookModal: FunctionComponent<{
     }, [historyType, recipientConfig.chainId, uiConfigStore.addressBookConfig]);
 
     useEffect(() => {
+      if (type !== "accounts") return;
       (() => {
-        if (!debounceAccountsSearchText.trim()) {
+        if (!debounceTrimmedSearchText) {
           return uiConfigStore.addressBookConfig.getVaultCosmosKeysSettled(
             recipientConfig.chainId,
             permitSelfKeyInfo ? undefined : keyRingStore.selectedKeyInfo?.id
           );
         } else {
           return uiConfigStore.addressBookConfig.getVaultCosmosKeysWithSearchSettled(
-            debounceAccountsSearchText,
+            debounceTrimmedSearchText,
             recipientConfig.chainId,
             permitSelfKeyInfo ? undefined : keyRingStore.selectedKeyInfo?.id
           );
@@ -114,11 +115,12 @@ export const AddressBookModal: FunctionComponent<{
         );
       });
     }, [
+      type,
       keyRingStore.selectedKeyInfo?.id,
       permitSelfKeyInfo,
       recipientConfig.chainId,
       uiConfigStore.addressBookConfig,
-      debounceAccountsSearchText,
+      debounceTrimmedSearchText,
     ]);
 
     const chainInfo = chainStore.getChain(recipientConfig.chainId);
@@ -153,6 +155,10 @@ export const AddressBookModal: FunctionComponent<{
             });
         }
         case "contacts": {
+          const searchRegex = debounceTrimmedSearchText
+            ? new RegExp(debounceTrimmedSearchText, "i")
+            : null;
+
           return uiConfigStore.addressBookConfig
             .getAddressBook(recipientConfig.chainId)
             .map((addressData) => {
@@ -167,7 +173,14 @@ export const AddressBookModal: FunctionComponent<{
                 return false;
               }
 
-              return true;
+              if (!searchRegex) {
+                return true;
+              }
+
+              return (
+                searchRegex.test(contact.name) ||
+                searchRegex.test(contact.address)
+              );
             });
         }
         case "accounts": {
@@ -254,12 +267,12 @@ export const AddressBookModal: FunctionComponent<{
 
           <Gutter size="0.75rem" />
 
-          {type === "accounts" ? (
+          {type !== "recent" ? (
             <React.Fragment>
               <SearchTextInput
-                value={accountsSearchText}
+                value={searchText}
                 onChange={(e) => {
-                  setAccountsSearchText(e.target.value);
+                  setSearchText(e.target.value);
                 }}
                 placeholder={intl.formatMessage({
                   id: "components.address-book-modal.my-account-tab.input.search.placeholder",


### PR DESCRIPTION
Changes:

1. Renamed `accountsSearchText` and `debounceAccountsSearchText` to `searchText` and `debounceTrimmedSearchText` respectively, in order to use them commonly in both the Contacts tab and My Account tab without declaring additional state variables.
2. Modified `searchText` to apply trimming when debounce is applied, eliminating the need to call a separate trim method.
3. In the Contacts tab, added logic so that when a search term is entered, the datas value is calculated to return wallet names or addresses that include the search term regardless of case (since EVM addresses may contain uppercase letters).