### PR TITLE
[KEPLR-485] Disallow hex addresses in Injective

### DIFF
--- a/packages/hooks/src/tx/recipient.ts
+++ b/packages/hooks/src/tx/recipient.ts
@@ -416,10 +416,11 @@ export class RecipientConfig
     const hasEthereumAddress =
       chainInfo.bip44.coinType === 60 ||
       !!chainInfo.features?.includes("eth-address-gen") ||
-      !!chainInfo.features?.includes("eth-key-sign") ||
-      isEvmChain;
+      !!chainInfo.features?.includes("eth-key-sign");
+
     if (
-      hasEthereumAddress &&
+      (isEvmChain ||
+        (hasEthereumAddress && this._allowHexAddressToBech32Address)) &&
       (rawRecipient.startsWith("0x") || this._allowHexAddressOnly)
     ) {
       if (EthereumAccountBase.isEthereumHexAddressWithChecksum(rawRecipient)) {
@@ -478,7 +479,7 @@ export const useRecipientConfig = (
   config.setAllowHexAddressToBech32Address(
     options.allowHexAddressToBech32Address
   );
-  config.setAllowHexAddressToBech32Address(options.allowHexAddressOnly);
+  config.setAllowHexAddressOnly(options.allowHexAddressOnly);
   config.setICNS(options.icns);
   config.setENS(options.ens);
 

--- a/packages/hooks/src/tx/recipient.ts
+++ b/packages/hooks/src/tx/recipient.ts
@@ -416,13 +416,12 @@ export class RecipientConfig
     const hasEthereumAddress =
       chainInfo.bip44.coinType === 60 ||
       !!chainInfo.features?.includes("eth-address-gen") ||
-      !!chainInfo.features?.includes("eth-key-sign");
+      !!chainInfo.features?.includes("eth-key-sign") ||
+      isEvmChain;
+    const isHexAddressAllowed =
+      this._allowHexAddressOnly || this._allowHexAddressToBech32Address;
 
-    if (
-      (isEvmChain ||
-        (hasEthereumAddress && this._allowHexAddressToBech32Address)) &&
-      (rawRecipient.startsWith("0x") || this._allowHexAddressOnly)
-    ) {
+    if (hasEthereumAddress && isHexAddressAllowed) {
       if (EthereumAccountBase.isEthereumHexAddressWithChecksum(rawRecipient)) {
         return {};
       } else {


### PR DESCRIPTION
Injective에서 recipient 값으로 hex 주소를 입력하면 hex 주소 검증대신 bech32 주소 검증이 실행되도록 수정했습니다.