### PR TITLE
Fix unable to validate bech32 address when the chain is evm compatible

### DIFF
--- a/packages/hooks/src/tx/recipient.ts
+++ b/packages/hooks/src/tx/recipient.ts
@@ -419,7 +419,8 @@ export class RecipientConfig
       !!chainInfo.features?.includes("eth-key-sign") ||
       isEvmChain;
     const isHexAddressAllowed =
-      this._allowHexAddressOnly || this._allowHexAddressToBech32Address;
+      this._allowHexAddressOnly ||
+      (rawRecipient.startsWith("0x") && this._allowHexAddressToBech32Address);
 
     if (hasEthereumAddress && isHexAddressAllowed) {
       if (EthereumAccountBase.isEthereumHexAddressWithChecksum(rawRecipient)) {


### PR DESCRIPTION
evm compatible인 경우 주소 형식에 따라 hex address와 bech32 address 모두 검증이 가능해야 하는데 이 부분을 제가 간과했습니다. rawRecipient가 0x로 시작하고 hex to bech32 변환이 가능한 경우에만 hex address 검증을 실행하도록 수정했습니다.