### PR TITLE
Update the msg type of Shentu chain

### DIFF
--- a/apps/extension/src/stores/root.tsx
+++ b/apps/extension/src/stores/root.tsx
@@ -348,17 +348,6 @@ export class RootStore {
       CosmosAccount.use({
         queriesStore: this.queriesStore,
         msgOptsCreator: (chainId) => {
-          // In certik, change the msg type of the MsgSend to "bank/MsgSend"
-          if (chainId.startsWith("shentu-")) {
-            return {
-              send: {
-                native: {
-                  type: "bank/MsgSend",
-                },
-              },
-            };
-          }
-
           // In akash or sifchain, increase the default gas for sending
           if (
             chainId.startsWith("akashnet-") ||

--- a/apps/mobile/src/stores/root.tsx
+++ b/apps/mobile/src/stores/root.tsx
@@ -231,17 +231,6 @@ export class RootStore {
       CosmosAccount.use({
         queriesStore: this.queriesStore,
         msgOptsCreator: chainId => {
-          // In certik, change the msg type of the MsgSend to "bank/MsgSend"
-          if (chainId.startsWith('shentu-')) {
-            return {
-              send: {
-                native: {
-                  type: 'bank/MsgSend',
-                },
-              },
-            };
-          }
-
           // In akash or sifchain, increase the default gas for sending
           if (
             chainId.startsWith('akashnet-') ||


### PR DESCRIPTION
In version v2.12.0, the Shentu chain upgraded to Cosmos-SDK v0.50.8:

During this upgrade, the message type for bank send transactions changed from `bank/MsgSend` to `cosmos-sdk/MsgSend`, which is no longer compatible with the previous format.

Currently, using bank/MsgSend to send transactions will fail.

Support from Keplr is required to accommodate this change.