### PR TITLE
Speedup Int-Pretty constructor and Clone()

### DIFF
--- a/packages/unit/src/int-pretty.spec.ts
+++ b/packages/unit/src/int-pretty.spec.ts
@@ -24,7 +24,6 @@ describe("Test IntPretty", () => {
     expect(new IntPretty(0.003).maxDecimals(2).toString()).toBe("0.00");
     expect(new IntPretty(0.00003456).toString()).toBe("0.00003456");
 
-
     expect(new IntPretty(new Int(1)).toDec().equals(new Dec("1.0"))).toBe(true);
     expect(new IntPretty(new Int(1)).maxDecimals(2).toString()).toBe("1.00");
   });

--- a/packages/unit/src/int-pretty.spec.ts
+++ b/packages/unit/src/int-pretty.spec.ts
@@ -11,11 +11,19 @@ describe("Test IntPretty", () => {
       "1.10"
     );
 
+    expect(new IntPretty(new Dec("5")).toString()).toBe("5");
+    expect(new IntPretty(new Dec("5.0")).toString()).toBe("5");
+
     expect(new IntPretty("1.1").toDec().equals(new Dec("1.1"))).toBe(true);
     expect(new IntPretty("1.1").maxDecimals(2).toString()).toBe("1.10");
 
     expect(new IntPretty(1.1).toDec().equals(new Dec("1.1"))).toBe(true);
     expect(new IntPretty(1.1).maxDecimals(2).toString()).toBe("1.10");
+    expect(new IntPretty(1.1234).maxDecimals(2).toString()).toBe("1.12");
+    expect(new IntPretty(0.1234).maxDecimals(2).toString()).toBe("0.12");
+    expect(new IntPretty(0.003).maxDecimals(2).toString()).toBe("0.00");
+    expect(new IntPretty(0.00003456).toString()).toBe("0.00003456");
+
 
     expect(new IntPretty(new Int(1)).toDec().equals(new Dec("1.0"))).toBe(true);
     expect(new IntPretty(new Int(1)).maxDecimals(2).toString()).toBe("1.00");

--- a/packages/unit/src/int-pretty.ts
+++ b/packages/unit/src/int-pretty.ts
@@ -1,4 +1,3 @@
-import { Int } from "./int";
 import { Dec } from "./decimal";
 import { DecUtils } from "./dec-utils";
 import { CoinUtils } from "./coin-utils";
@@ -46,18 +45,24 @@ export class IntPretty {
       return;
     }
 
-    let dec = num;
-    let decPrecision = 0;
-    for (let i = 0; i < 18; i++) {
-      if (
-        !dec.truncate().equals(new Int(0)) &&
-        dec.equals(new Dec(dec.truncate()))
-      ) {
-        break;
-      }
-      dec = dec.mul(new Dec(10));
-      decPrecision++;
+    // Get string representation and find decimal position
+    const decStr = num.toString();
+    const decimalIndex = decStr.indexOf('.');
+    
+    // If no decimal point no precision needed
+    if (decimalIndex === -1) {
+      this.dec = num;
+      this._options.maxDecimals = 0;
+      return;
     }
+  
+    // Count significant digits by walking backwards until non-zero digit
+    const decimalPart = decStr.slice(decimalIndex + 1);
+    let trailingZeros = 0;
+    for (let i = decimalPart.length - 1; i >= 0 && decimalPart[i] === '0'; i--) {
+      trailingZeros++;
+    }
+    const decPrecision = decimalPart.length - trailingZeros;
 
     this.dec = num;
     this._options.maxDecimals = decPrecision;
@@ -291,12 +296,11 @@ export class IntPretty {
   }
 
   clone(): IntPretty {
-    const pretty = new IntPretty(this.dec);
-    pretty.dec = this.dec;
-    pretty.floatingDecimalPointRight = this.floatingDecimalPointRight;
-    pretty._options = {
-      ...this._options,
-    };
-    return pretty;
+    // Clone is often in hot-paths for int-pretty, and the function constructor has overhead.
+    // Thus we do a direct clone.
+    return Object.setPrototypeOf(
+      { dec: this.dec, floatingDecimalPointRight: this.floatingDecimalPointRight, _options: { ...this._options } },
+      IntPretty.prototype
+    );
   }
 }

--- a/packages/unit/src/int-pretty.ts
+++ b/packages/unit/src/int-pretty.ts
@@ -47,19 +47,23 @@ export class IntPretty {
 
     // Get string representation and find decimal position
     const decStr = num.toString();
-    const decimalIndex = decStr.indexOf('.');
-    
+    const decimalIndex = decStr.indexOf(".");
+
     // If no decimal point no precision needed
     if (decimalIndex === -1) {
       this.dec = num;
       this._options.maxDecimals = 0;
       return;
     }
-  
+
     // Count significant digits by walking backwards until non-zero digit
     const decimalPart = decStr.slice(decimalIndex + 1);
     let trailingZeros = 0;
-    for (let i = decimalPart.length - 1; i >= 0 && decimalPart[i] === '0'; i--) {
+    for (
+      let i = decimalPart.length - 1;
+      i >= 0 && decimalPart[i] === "0";
+      i--
+    ) {
       trailingZeros++;
     }
     const decPrecision = decimalPart.length - trailingZeros;
@@ -299,7 +303,11 @@ export class IntPretty {
     // Clone is often in hot-paths for int-pretty, and the function constructor has overhead.
     // Thus we do a direct clone.
     return Object.setPrototypeOf(
-      { dec: this.dec, floatingDecimalPointRight: this.floatingDecimalPointRight, _options: { ...this._options } },
+      {
+        dec: this.dec,
+        floatingDecimalPointRight: this.floatingDecimalPointRight,
+        _options: { ...this._options },
+      },
       IntPretty.prototype
     );
   }


### PR DESCRIPTION
I found that the int pretty constructor ended up being a performance bottleneck in the Osmosis FE

This was due to our usage of Price pretty's, and every operation doing IntPretty clones.

This PR removes the Clone overhead, and removes many additional string operations + allocs from the constructor.

This was found to be a big speedup for Osmosis FE.

PR'd in case it helps you!