### PR TITLE
Fix typos in API method names Update README.md

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -198,7 +198,7 @@ This is an experimental implementation of [ADR-36](https://github.com/cosmos/cos
   
 Its main usage is to prove ownership of an account off-chain, requesting ADR-36 signature using the `signArbitrary` API.  
   
-If requested sign doc with the `signAnimo` API with the ADR-36 that Keplr requires instead of using the `signArbitary` API, it would function as `signArbitary`  
+If requested sign doc with the `signAmino` API with the ADR-36 that Keplr requires instead of using the `signArbitrary` API, it would function as `signArbitrary`  
 - Only supports sign doc in the format of Amino. (in the case of protobuf, [ADR-36](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-036-arbitrary-signature.md) requirements aren't fully specified for implementation)
 - sign doc message should be single and the message type should be "sign/MsgSignData"
 - sign doc "sign/MsgSignData" message should have "signer" and "data" as its value. "data" should be base64 encoded


### PR DESCRIPTION
### Description:

This update addresses some small but important typos in the method names that affect the clarity and functionality of the API. 

- The method `signAnimo` was mistakenly written with an "o" instead of an "a". The correct name is `signAmino`, which aligns with the standard for signing messages in the Amino format.
- Similarly, `signArbitary` was incorrectly spelled, missing the "r" in "Arbitrary". The corrected method name is now `signArbitrary`.

These changes ensure the method names are correctly aligned with the API documentation and improve consistency across the codebase.