### PR TITLE
docs: typo fix Update README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-description: Keplr is a non-custodial blockchain wallets for webpages that allow users to interact with blockchain applications.
+description: Keplr is a non-custodial blockchain wallet for webpages that allow users to interact with blockchain applications.
 footer:
   newsletter: false
 aside: true
@@ -11,7 +11,7 @@ order: 1
 
 ## Introduction
 
-Keplr is a non-custodial blockchain wallets for webpages that allow users to interact with blockchain applications.
+Keplr is a non-custodial blockchain wallet for webpages that allow users to interact with blockchain applications.
 
 ## Why Keplr?
 


### PR DESCRIPTION
There's a typo in the word **"wallets"**, which is incorrectly in plural form.
It should be singular to match the grammar of the sentence.

### Issue:  
"Keplr is a non-custodial blockchain **wallets** for webpages..."  

### Fix:  
"Keplr is a non-custodial blockchain **wallet** for webpages..."  

Thanks for review!