### PR TITLE
[KEPLR-691] Overflow on deposit modal

### DIFF
--- a/apps/extension/src/components/transition/scene/internal/base.tsx
+++ b/apps/extension/src/components/transition/scene/internal/base.tsx
@@ -491,7 +491,7 @@ const SceneComponent: FunctionComponent<
       <animated.div
         style={{
           display: "grid",
-          gridTemplateColumns: "1fr",
+          gridTemplateColumns: "100%",
           zIndex: index + 1,
           width: to([sceneWidth], (sceneWidth) => {
             return sceneWidth || "100%";


### PR DESCRIPTION
- 사이드 패널 너비가 늘어날 때, grid column의 너비가 같이 늘어나는데, 늘어난 너비가 자식 요소의 최소 너비로 간주되다 보니 1fr이 적용된 grid column의 너비가 늘어난 상태 그대로 유지되는 문제가 있습니다.
- 1fr이 결국 하나의 column만 사용하기 때문에, 자식 요소보다는 부모 요소의 너비에 따라 column의 너비가 변경되도록  `1fr`을 `100%`로 변경했습니다.
- `FixedWidthSceneTransition` 컴포넌트를 사용하는 다른 곳 (update node modal, register page)에서는 grid 열의 너비 자체가 변경될 일이 없기 때문에 문제가 되지 않습니다.