### PR TITLE
docs: Fix typo "CosmJS link" should be "CosmJS links Update cosmjs.md

### DIFF
--- a/docs/api/cosmjs.md
+++ b/docs/api/cosmjs.md
@@ -9,7 +9,7 @@ Please check the [How to detect Keplr](./README.md#how-to-detect-keplr) first be
 
 ## Connecting with CosmJS
 
-CosmJS link: [https://www.npmjs.com/package/@cosmjs/launchpad](https://www.npmjs.com/package/@cosmjs/launchpad), [https://www.npmjs.com/package/@cosmjs/stargate](https://www.npmjs.com/package/@cosmjs/stargate)
+CosmJS links: [https://www.npmjs.com/package/@cosmjs/launchpad](https://www.npmjs.com/package/@cosmjs/launchpad), [https://www.npmjs.com/package/@cosmjs/stargate](https://www.npmjs.com/package/@cosmjs/stargate)
 
 You can connect Keplr to CosmJS using the `OfflineSigner`.
 


### PR DESCRIPTION
I noticed a small inconsistency in the text where "CosmJS link" was used, even though two links are provided.

The correct phrasing should be "CosmJS links" to reflect the plural form.

I’ve updated it accordingly to ensure the wording is accurate. 
