### PR TITLE
docs: Corrected grammatical error Update README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-description: Keplr is a non-custodial blockchain wallets for webpages that allow users to interact with blockchain applications.
+description: Keplr is a non-custodial blockchain wallet for webpages that allow users to interact with blockchain applications.
 footer:
   newsletter: false
 aside: true


### PR DESCRIPTION
I noticed a grammatical error in the text describing Keplr. The word "wallets" was used in the plural form, but given the context, it should be singular.

I've updated it to "Keplr is a non-custodial blockchain **wallet**" to ensure accuracy and consistency.

