### PR TITLE
feat: added dymension-network chain feature

### DIFF
--- a/packages/background/src/keyring-cosmos/service.ts
+++ b/packages/background/src/keyring-cosmos/service.ts
@@ -102,13 +102,15 @@ export class KeyRingCosmosService {
 
     const isEthermintLike = KeyRingService.isEthermintLike(chainInfo);
     const evmInfo = ChainsService.getEVMInfo(chainInfo);
+    const isDymensionNetwork =
+      chainInfo.features?.includes("dymension-network");
 
     const keyInfo = this.keyRingService.getKeyInfo(vaultId);
     if (!keyInfo) {
       throw new Error("Null key info");
     }
 
-    if (isEthermintLike && keyInfo.type === "ledger") {
+    if (isEthermintLike && keyInfo.type === "ledger" && !isDymensionNetwork) {
       KeyRingCosmosService.throwErrorIfEthermintWithLedgerButNotSupported(
         chainId
       );
@@ -228,13 +230,15 @@ export class KeyRingCosmosService {
       throw new Error("Can't sign for hidden chain");
     }
     const isEthermintLike = KeyRingService.isEthermintLike(chainInfo);
+    const isDymensionNetwork =
+      chainInfo.features?.includes("dymension-network");
 
     const keyInfo = this.keyRingService.getKeyInfo(vaultId);
     if (!keyInfo) {
       throw new Error("Null key info");
     }
 
-    if (isEthermintLike && keyInfo.type === "ledger") {
+    if (isEthermintLike && keyInfo.type === "ledger" && !isDymensionNetwork) {
       KeyRingCosmosService.throwErrorIfEthermintWithLedgerButNotSupported(
         chainId
       );
@@ -371,13 +375,15 @@ export class KeyRingCosmosService {
     const vaultId = this.keyRingService.selectedVaultId;
 
     const isEthermintLike = KeyRingService.isEthermintLike(chainInfo);
+    const isDymensionNetwork =
+      chainInfo.features?.includes("dymension-network");
 
     const keyInfo = this.keyRingService.getKeyInfo(vaultId);
     if (!keyInfo) {
       throw new Error("Null key info");
     }
 
-    if (isEthermintLike && keyInfo.type === "ledger") {
+    if (isEthermintLike && keyInfo.type === "ledger" && !isDymensionNetwork) {
       KeyRingCosmosService.throwErrorIfEthermintWithLedgerButNotSupported(
         chainId
       );
@@ -471,13 +477,15 @@ export class KeyRingCosmosService {
     const vaultId = this.keyRingService.selectedVaultId;
 
     const isEthermintLike = KeyRingService.isEthermintLike(chainInfo);
+    const isDymensionNetwork =
+      chainInfo.features?.includes("dymension-network");
 
     const keyInfo = this.keyRingService.getKeyInfo(vaultId);
     if (!keyInfo) {
       throw new Error("Null key info");
     }
 
-    if (isEthermintLike && keyInfo.type === "ledger") {
+    if (isEthermintLike && keyInfo.type === "ledger" && !isDymensionNetwork) {
       KeyRingCosmosService.throwErrorIfEthermintWithLedgerButNotSupported(
         chainId
       );
@@ -589,13 +597,15 @@ export class KeyRingCosmosService {
       throw new Error("Can't sign for hidden chain");
     }
     const isEthermintLike = KeyRingService.isEthermintLike(chainInfo);
+    const isDymensionNetwork =
+      chainInfo.features?.includes("dymension-network");
 
     const keyInfo = this.keyRingService.getKeyInfo(vaultId);
     if (!keyInfo) {
       throw new Error("Null key info");
     }
 
-    if (isEthermintLike && keyInfo.type === "ledger") {
+    if (isEthermintLike && keyInfo.type === "ledger" && !isDymensionNetwork) {
       KeyRingCosmosService.throwErrorIfEthermintWithLedgerButNotSupported(
         chainId
       );
@@ -685,13 +695,15 @@ export class KeyRingCosmosService {
       throw new Error("Can't sign for hidden chain");
     }
     const isEthermintLike = KeyRingService.isEthermintLike(chainInfo);
+    const isDymensionNetwork =
+      chainInfo.features?.includes("dymension-network");
 
     const keyInfo = this.keyRingService.getKeyInfo(vaultId);
     if (!keyInfo) {
       throw new Error("Null key info");
     }
 
-    if (isEthermintLike && keyInfo.type === "ledger") {
+    if (isEthermintLike && keyInfo.type === "ledger" && !isDymensionNetwork) {
       KeyRingCosmosService.throwErrorIfEthermintWithLedgerButNotSupported(
         chainId
       );
@@ -822,13 +834,15 @@ export class KeyRingCosmosService {
       throw new Error("Can't sign for hidden chain");
     }
     const isEthermintLike = KeyRingService.isEthermintLike(chainInfo);
+    const isDymensionNetwork =
+      chainInfo.features?.includes("dymension-network");
 
     const keyInfo = this.keyRingService.getKeyInfo(vaultId);
     if (!keyInfo) {
       throw new Error("Null key info");
     }
 
-    if (isEthermintLike && keyInfo.type === "ledger") {
+    if (isEthermintLike && keyInfo.type === "ledger" && !isDymensionNetwork) {
       KeyRingCosmosService.throwErrorIfEthermintWithLedgerButNotSupported(
         chainId
       );
@@ -1028,6 +1042,8 @@ export class KeyRingCosmosService {
       throw new Error("Can't sign for hidden chain");
     }
     const isEthermintLike = KeyRingService.isEthermintLike(chainInfo);
+    const isDymensionNetwork =
+      chainInfo.features?.includes("dymension-network");
 
     if (!isEthermintLike) {
       throw new Error("This feature is only usable on cosmos-sdk evm chain");
@@ -1042,7 +1058,7 @@ export class KeyRingCosmosService {
       throw new Error("This feature is only usable on ledger ethereum app");
     }
 
-    if (isEthermintLike && keyInfo.type === "ledger") {
+    if (isEthermintLike && keyInfo.type === "ledger" && !isDymensionNetwork) {
       KeyRingCosmosService.throwErrorIfEthermintWithLedgerButNotSupported(
         chainId
       );
@@ -1489,7 +1505,6 @@ Salt: ${salt}`;
       !chainId.startsWith("injective") &&
       !chainId.startsWith("dymension_") &&
       !chainId.startsWith("nim_") &&
-      !chainId.startsWith("dimension_") &&
       !chainId.startsWith("zetachain_") &&
       !chainId.startsWith("eip155:")
     ) {

--- a/packages/background/src/keyring-cosmos/service.ts
+++ b/packages/background/src/keyring-cosmos/service.ts
@@ -102,15 +102,16 @@ export class KeyRingCosmosService {
 
     const isEthermintLike = KeyRingService.isEthermintLike(chainInfo);
     const evmInfo = ChainsService.getEVMInfo(chainInfo);
-    const isDymensionNetwork =
-      chainInfo.features?.includes("dymension-network");
+    const forceEVMLedger = chainInfo.features?.includes(
+      "force-enable-evm-ledger"
+    );
 
     const keyInfo = this.keyRingService.getKeyInfo(vaultId);
     if (!keyInfo) {
       throw new Error("Null key info");
     }
 
-    if (isEthermintLike && keyInfo.type === "ledger" && !isDymensionNetwork) {
+    if (isEthermintLike && keyInfo.type === "ledger" && !forceEVMLedger) {
       KeyRingCosmosService.throwErrorIfEthermintWithLedgerButNotSupported(
         chainId
       );
@@ -230,15 +231,16 @@ export class KeyRingCosmosService {
       throw new Error("Can't sign for hidden chain");
     }
     const isEthermintLike = KeyRingService.isEthermintLike(chainInfo);
-    const isDymensionNetwork =
-      chainInfo.features?.includes("dymension-network");
+    const forceEVMLedger = chainInfo.features?.includes(
+      "force-enable-evm-ledger"
+    );
 
     const keyInfo = this.keyRingService.getKeyInfo(vaultId);
     if (!keyInfo) {
       throw new Error("Null key info");
     }
 
-    if (isEthermintLike && keyInfo.type === "ledger" && !isDymensionNetwork) {
+    if (isEthermintLike && keyInfo.type === "ledger" && !forceEVMLedger) {
       KeyRingCosmosService.throwErrorIfEthermintWithLedgerButNotSupported(
         chainId
       );
@@ -375,15 +377,16 @@ export class KeyRingCosmosService {
     const vaultId = this.keyRingService.selectedVaultId;
 
     const isEthermintLike = KeyRingService.isEthermintLike(chainInfo);
-    const isDymensionNetwork =
-      chainInfo.features?.includes("dymension-network");
+    const forceEVMLedger = chainInfo.features?.includes(
+      "force-enable-evm-ledger"
+    );
 
     const keyInfo = this.keyRingService.getKeyInfo(vaultId);
     if (!keyInfo) {
       throw new Error("Null key info");
     }
 
-    if (isEthermintLike && keyInfo.type === "ledger" && !isDymensionNetwork) {
+    if (isEthermintLike && keyInfo.type === "ledger" && !forceEVMLedger) {
       KeyRingCosmosService.throwErrorIfEthermintWithLedgerButNotSupported(
         chainId
       );
@@ -477,15 +480,16 @@ export class KeyRingCosmosService {
     const vaultId = this.keyRingService.selectedVaultId;
 
     const isEthermintLike = KeyRingService.isEthermintLike(chainInfo);
-    const isDymensionNetwork =
-      chainInfo.features?.includes("dymension-network");
+    const forceEVMLedger = chainInfo.features?.includes(
+      "force-enable-evm-ledger"
+    );
 
     const keyInfo = this.keyRingService.getKeyInfo(vaultId);
     if (!keyInfo) {
       throw new Error("Null key info");
     }
 
-    if (isEthermintLike && keyInfo.type === "ledger" && !isDymensionNetwork) {
+    if (isEthermintLike && keyInfo.type === "ledger" && !forceEVMLedger) {
       KeyRingCosmosService.throwErrorIfEthermintWithLedgerButNotSupported(
         chainId
       );
@@ -597,15 +601,16 @@ export class KeyRingCosmosService {
       throw new Error("Can't sign for hidden chain");
     }
     const isEthermintLike = KeyRingService.isEthermintLike(chainInfo);
-    const isDymensionNetwork =
-      chainInfo.features?.includes("dymension-network");
+    const forceEVMLedger = chainInfo.features?.includes(
+      "force-enable-evm-ledger"
+    );
 
     const keyInfo = this.keyRingService.getKeyInfo(vaultId);
     if (!keyInfo) {
       throw new Error("Null key info");
     }
 
-    if (isEthermintLike && keyInfo.type === "ledger" && !isDymensionNetwork) {
+    if (isEthermintLike && keyInfo.type === "ledger" && !forceEVMLedger) {
       KeyRingCosmosService.throwErrorIfEthermintWithLedgerButNotSupported(
         chainId
       );
@@ -695,15 +700,16 @@ export class KeyRingCosmosService {
       throw new Error("Can't sign for hidden chain");
     }
     const isEthermintLike = KeyRingService.isEthermintLike(chainInfo);
-    const isDymensionNetwork =
-      chainInfo.features?.includes("dymension-network");
+    const forceEVMLedger = chainInfo.features?.includes(
+      "force-enable-evm-ledger"
+    );
 
     const keyInfo = this.keyRingService.getKeyInfo(vaultId);
     if (!keyInfo) {
       throw new Error("Null key info");
     }
 
-    if (isEthermintLike && keyInfo.type === "ledger" && !isDymensionNetwork) {
+    if (isEthermintLike && keyInfo.type === "ledger" && !forceEVMLedger) {
       KeyRingCosmosService.throwErrorIfEthermintWithLedgerButNotSupported(
         chainId
       );
@@ -834,15 +840,16 @@ export class KeyRingCosmosService {
       throw new Error("Can't sign for hidden chain");
     }
     const isEthermintLike = KeyRingService.isEthermintLike(chainInfo);
-    const isDymensionNetwork =
-      chainInfo.features?.includes("dymension-network");
+    const forceEVMLedger = chainInfo.features?.includes(
+      "force-enable-evm-ledger"
+    );
 
     const keyInfo = this.keyRingService.getKeyInfo(vaultId);
     if (!keyInfo) {
       throw new Error("Null key info");
     }
 
-    if (isEthermintLike && keyInfo.type === "ledger" && !isDymensionNetwork) {
+    if (isEthermintLike && keyInfo.type === "ledger" && !forceEVMLedger) {
       KeyRingCosmosService.throwErrorIfEthermintWithLedgerButNotSupported(
         chainId
       );
@@ -1042,8 +1049,9 @@ export class KeyRingCosmosService {
       throw new Error("Can't sign for hidden chain");
     }
     const isEthermintLike = KeyRingService.isEthermintLike(chainInfo);
-    const isDymensionNetwork =
-      chainInfo.features?.includes("dymension-network");
+    const forceEVMLedger = chainInfo.features?.includes(
+      "force-enable-evm-ledger"
+    );
 
     if (!isEthermintLike) {
       throw new Error("This feature is only usable on cosmos-sdk evm chain");
@@ -1058,7 +1066,7 @@ export class KeyRingCosmosService {
       throw new Error("This feature is only usable on ledger ethereum app");
     }
 
-    if (isEthermintLike && keyInfo.type === "ledger" && !isDymensionNetwork) {
+    if (isEthermintLike && keyInfo.type === "ledger" && !forceEVMLedger) {
       KeyRingCosmosService.throwErrorIfEthermintWithLedgerButNotSupported(
         chainId
       );

--- a/packages/background/src/keyring-ethereum/service.ts
+++ b/packages/background/src/keyring-ethereum/service.ts
@@ -88,6 +88,8 @@ export class KeyRingEthereumService {
     }
     const isEthermintLike = KeyRingService.isEthermintLike(chainInfo);
     const evmInfo = ChainsService.getEVMInfo(chainInfo);
+    const isDymensionNetwork =
+      chainInfo.features?.includes("dymension-network");
 
     if (!isEthermintLike && !evmInfo) {
       throw new Error("Not ethermint like and EVM chain");
@@ -98,7 +100,7 @@ export class KeyRingEthereumService {
       throw new Error("Null key info");
     }
 
-    if (keyInfo.type === "ledger") {
+    if (keyInfo.type === "ledger" && !isDymensionNetwork) {
       KeyRingCosmosService.throwErrorIfEthermintWithLedgerButNotSupported(
         chainId
       );

--- a/packages/background/src/keyring-ethereum/service.ts
+++ b/packages/background/src/keyring-ethereum/service.ts
@@ -88,8 +88,9 @@ export class KeyRingEthereumService {
     }
     const isEthermintLike = KeyRingService.isEthermintLike(chainInfo);
     const evmInfo = ChainsService.getEVMInfo(chainInfo);
-    const isDymensionNetwork =
-      chainInfo.features?.includes("dymension-network");
+    const forceEVMLedger = chainInfo.features?.includes(
+      "force-enable-evm-ledger"
+    );
 
     if (!isEthermintLike && !evmInfo) {
       throw new Error("Not ethermint like and EVM chain");
@@ -100,7 +101,7 @@ export class KeyRingEthereumService {
       throw new Error("Null key info");
     }
 
-    if (keyInfo.type === "ledger" && !isDymensionNetwork) {
+    if (keyInfo.type === "ledger" && !forceEVMLedger) {
       KeyRingCosmosService.throwErrorIfEthermintWithLedgerButNotSupported(
         chainId
       );

--- a/packages/chain-validator/src/feature.ts
+++ b/packages/chain-validator/src/feature.ts
@@ -24,7 +24,7 @@ export const SupportedChainFeatures = [
   "osmosis-base-fee-beta",
   "feemarket",
   "op-stack-l1-data-fee",
-  "dymension-network",
+  "force-enable-evm-ledger",
 ];
 
 /**

--- a/packages/chain-validator/src/feature.ts
+++ b/packages/chain-validator/src/feature.ts
@@ -24,6 +24,7 @@ export const SupportedChainFeatures = [
   "osmosis-base-fee-beta",
   "feemarket",
   "op-stack-l1-data-fee",
+  "dymension-network",
 ];
 
 /**


### PR DESCRIPTION
Currently, for EVM chains, only explicit chainIDs are allowed.

we want to have Keplr+Ledger support for all dymension eco-system rollapps.

This PR add the `dymension-network` chain feature, to allow dymension chains to have Keplr+Ledger support
