### PR TITLE
docs: typo fix Update 01-intro.md

### DIFF
--- a/docs/docs/01-intro.md
+++ b/docs/docs/01-intro.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-description: Keplr is a non-custodial blockchain wallets for webpages that allow users to interact with blockchain applications.
+description: Keplr is a non-custodial blockchain wallet for webpages that allow users to interact with blockchain applications.
 aside: true
 ---
 
@@ -8,7 +8,7 @@ aside: true
 
 ## Introduction
 
-Keplr is a non-custodial blockchain wallets for webpages that allow users to interact with blockchain applications.
+Keplr is a non-custodial blockchain wallet for webpages that allow users to interact with blockchain applications.
 
 ## Why Keplr?
 


### PR DESCRIPTION
The typo is in the following sentence from the **Introduction** section:

> Keplr is a non-custodial blockchain wallets for webpages that allow users to interact with blockchain applications.

**Error**: "wallets" is plural, while the context implies a singular form.

**Correction**: 

> Keplr is a non-custodial blockchain wallet for webpages that allows users to interact with blockchain applications. 

**Explanation**: 
- "wallet" should be singular since it refers to a single product, Keplr.
- "allows" is adjusted to agree with the singular subject "wallet".