### PR TITLE
Fixed Typos Across Multiple Files

### DIFF
--- a/apps/extension/src/pages/main/token-detail/msg-items/index.tsx
+++ b/apps/extension/src/pages/main/token-detail/msg-items/index.tsx
@@ -315,7 +315,7 @@ class ErrorBoundary extends React.Component<
 
   override render() {
     if (this.state.hasError) {
-      return <UnknownMsgItem title="Unknown error occured" />;
+      return <UnknownMsgItem title="Unknown error occurred" />;
     }
 
     return this.props.children;

--- a/apps/extension/src/pages/register/enable-chains/index.tsx
+++ b/apps/extension/src/pages/register/enable-chains/index.tsx
@@ -48,7 +48,7 @@ import { VerticalCollapseTransition } from "../../../components/transition/verti
 /**
  * EnableChainsScene은 finalize-key scene에서 선택한 chains를 활성화하는 scene이다.
  * 근데 문제는 extension 자체의 메인 페이지에서 manage chains 버튼을 눌러서도 올 수 있다는 점이다...
- * registeration이 하는 역할이 많아지면서 복잡해졌는데... 알아서 잘 처리하자
+ * registration이 하는 역할이 많아지면서 복잡해졌는데... 알아서 잘 처리하자
  */
 export const EnableChainsScene: FunctionComponent<{
   vaultId: string;

--- a/apps/extension/src/pages/sign/components/eth-tx/render/send-token.tsx
+++ b/apps/extension/src/pages/sign/components/eth-tx/render/send-token.tsx
@@ -75,7 +75,7 @@ export const EthSendTokenTx: IEthTxRenderer = {
           ),
         };
       } catch (e) {
-        // Fallback to other renderers if unsingedTx.data can't be decoded with ERC20 transfer method.
+        // Fallback to other renderers if unsignedTx.data can't be decoded with ERC20 transfer method.
         return undefined;
       }
     } else {

--- a/apps/mobile/src/languages/en.json
+++ b/apps/mobile/src/languages/en.json
@@ -649,7 +649,7 @@
   "page.stake.delegate.guide-box.paragraph": "You will need to unstake in order for your staked assets to be liquid again.This process will take {unbondingPeriodDay} days to complete.",
   "page.stake.undelegate.title": "Unstake",
   "page.stake.undelegate.guide-box.title": "Once the unstaking period begins you will:",
-  "page.stake.undelegate.guide-box.paragraph-1": "NOT recieve staking rewards",
+  "page.stake.undelegate.guide-box.paragraph-1": "NOT receive staking rewards",
   "page.stake.undelegate.guide-box.paragraph-2": "need to wait {unbondingPeriodDay} days for the amount to be liquid",
   "page.stake.undelegate.guide-box.paragraph-3": "But you will be able to cancel the unstaking process anytime, as this chain currently supports the function",
   "page.stake.redelegate.title": "Switch Validator",

--- a/apps/mobile/src/screen/activities/msg-items/index.tsx
+++ b/apps/mobile/src/screen/activities/msg-items/index.tsx
@@ -250,7 +250,7 @@ class ErrorBoundary extends React.Component<
 
   override render() {
     if (this.state.hasError) {
-      return <UnknownMsgItem title="Unknown error occured" />;
+      return <UnknownMsgItem title="Unknown error occurred" />;
     }
 
     return this.props.children;

--- a/apps/mobile/src/screen/sign/components/eth-tx/renders/send-token.tsx
+++ b/apps/mobile/src/screen/sign/components/eth-tx/renders/send-token.tsx
@@ -43,7 +43,7 @@ export const EthSendTokenTx: IEthTxRenderer = {
           ),
         };
       } catch (e) {
-        // Fallback to other renderers if unsingedTx.data can't be decoded with ERC20 transfer method.
+        // Fallback to other renderers if unsignedTx.data can't be decoded with ERC20 transfer method.
         return undefined;
       }
     } else {

--- a/packages/background/src/keyring/legacy/crypto.ts
+++ b/packages/background/src/keyring/legacy/crypto.ts
@@ -11,7 +11,7 @@ import { Buffer } from "buffer/";
 
 /**
  * This is similar to ethereum's key store.
- * But, the encryped data is not the private key, but the mnemonic words.
+ * But, the encrypted data is not the private key, but the mnemonic words.
  */
 export interface KeyStore {
   version: "1.2";


### PR DESCRIPTION
- Fixed typos in `send-token.tsx`, `index.tsx`, and other files.
- Ensured consistency in language usage and formatting.
- Corrected spelling errors in the `en.json` language file related to text descriptions.
