### PR TITLE
evm 브릿지 1차 pr

### DIFF
--- a/apps/extension/src/pages/send/amount/ibc-transfer/destination-chain-view.tsx
+++ b/apps/extension/src/pages/send/amount/ibc-transfer/destination-chain-view.tsx
@@ -1,8 +1,6 @@
 import React, { FunctionComponent } from "react";
 import { Box } from "../../../../components/box";
-import { IIBCChannelConfig } from "@keplr-wallet/hooks";
 import { observer } from "mobx-react-lite";
-import { useStore } from "../../../../stores";
 import { Subtitle2 } from "../../../../components/typography";
 import { useTheme } from "styled-components";
 import { ColorPalette } from "../../../../styles";
@@ -12,13 +10,12 @@ import { ChainImageFallback } from "../../../../components/image";
 import { Gutter } from "../../../../components/gutter";
 import { ArrowRightIcon } from "../../../../components/icon";
 import { useIntl } from "react-intl";
+import { ChainInfo, ModularChainInfo } from "@keplr-wallet/types";
 
 export const DestinationChainView: FunctionComponent<{
-  ibcChannelConfig: IIBCChannelConfig;
+  chainInfo?: ModularChainInfo | ChainInfo;
   onClick: () => void;
-}> = observer(({ ibcChannelConfig, onClick }) => {
-  const { chainStore } = useStore();
-
+}> = observer(({ chainInfo, onClick }) => {
   const theme = useTheme();
   const intl = useIntl();
 
@@ -48,16 +45,9 @@ export const DestinationChainView: FunctionComponent<{
         }}
       >
         <XAxis alignY="center">
-          {ibcChannelConfig.channels.length === 0 ? null : (
+          {!chainInfo ? null : (
             <React.Fragment>
-              <ChainImageFallback
-                chainInfo={chainStore.getChain(
-                  ibcChannelConfig.channels[
-                    ibcChannelConfig.channels.length - 1
-                  ].counterpartyChainId
-                )}
-                size="2rem"
-              />
+              <ChainImageFallback chainInfo={chainInfo} size="2rem" />
               <Gutter size="0.75rem" />
             </React.Fragment>
           )}
@@ -69,14 +59,9 @@ export const DestinationChainView: FunctionComponent<{
             }
           >
             {(() => {
-              if (ibcChannelConfig.channels.length === 0) {
+              if (!chainInfo) {
                 return "";
               }
-
-              const chainInfo = chainStore.getChain(
-                ibcChannelConfig.channels[ibcChannelConfig.channels.length - 1]
-                  .counterpartyChainId
-              );
 
               return chainInfo.chainName;
             })()}

--- a/apps/extension/src/pages/send/amount/ibc-transfer/modal.tsx
+++ b/apps/extension/src/pages/send/amount/ibc-transfer/modal.tsx
@@ -257,7 +257,6 @@ export const IBCTransferSelectDestinationModal: FunctionComponent<{
                         await account.init();
                       }
 
-                      //이걸 합쳐서 bridge 타입으로 변경해서 분리 시키는게 났지 않을까?
                       setSendType("ibc-transfer");
                       ibcChannelConfig.setChannels(bridgeOrChannel.channels);
                       setIBCChannelsInfoFluent(bridgeOrChannel);

--- a/apps/extension/src/pages/send/amount/ibc-transfer/modal.tsx
+++ b/apps/extension/src/pages/send/amount/ibc-transfer/modal.tsx
@@ -16,6 +16,8 @@ import { FormattedMessage, useIntl } from "react-intl";
 import { EmptyView } from "../../../../components/empty-view";
 import { HomeIcon } from "../../../../components/icon";
 import { WalletStatus } from "@keplr-wallet/stores";
+import { IBCChannel, NoneIBCBridgeInfo } from "@keplr-wallet/stores-internal";
+import { AppCurrency } from "@keplr-wallet/types";
 
 export const IBCTransferSelectDestinationModal: FunctionComponent<{
   chainId: string;
@@ -24,6 +26,10 @@ export const IBCTransferSelectDestinationModal: FunctionComponent<{
   ibcChannelConfig: IIBCChannelConfig;
   setIsIBCTransfer: (value: boolean) => void;
   close: () => void;
+  setDestinationChainInfoOfBridge: (value: {
+    chainId: string;
+    currency: AppCurrency;
+  }) => void;
 
   // 이 컴포넌트는 사실 send page에서만 쓰이기 때문에 사용하는 쪽에서 필요한 로직을 위해서 몇몇 이상한(?) prop을 넘겨준다.
   // setAutomaticRecipient는 send page에서 recipient가 자동으로 설정되었을때 유저에게 UI를 보여주기 위해서 필요하다.
@@ -51,11 +57,18 @@ export const IBCTransferSelectDestinationModal: FunctionComponent<{
     close,
     setAutomaticRecipient,
     setIBCChannelsInfoFluent,
+    setDestinationChainInfoOfBridge,
   }) => {
     const { accountStore, chainStore, skipQueriesStore } = useStore();
 
     const theme = useTheme();
     const intl = useIntl();
+
+    const bridgeInfos: (NoneIBCBridgeInfo | IBCChannel)[] =
+      skipQueriesStore.queryIBCPacketForwardingTransfer.getBridges(
+        chainId,
+        denom
+      );
 
     const channels =
       skipQueriesStore.queryIBCPacketForwardingTransfer.getIBCChannels(
@@ -63,11 +76,21 @@ export const IBCTransferSelectDestinationModal: FunctionComponent<{
         denom
       );
 
+    const bridgeOrIBCList = bridgeInfos.concat(channels).sort((a, b) => {
+      // Sort by chain name.
+      return chainStore
+        .getChain(a.destinationChainId)
+        .chainName.trim()
+        .localeCompare(
+          chainStore.getChain(b.destinationChainId).chainName.trim()
+        );
+    });
+
     const [search, setSearch] = useState("");
 
     const searchRef = useFocusOnMount<HTMLInputElement>();
 
-    const filteredChannels = channels.filter((c) => {
+    const filteredChannels = bridgeOrIBCList.filter((c) => {
       const chainInfo = chainStore.getChain(c.destinationChainId);
       return chainInfo.chainName
         .trim()
@@ -124,8 +147,15 @@ export const IBCTransferSelectDestinationModal: FunctionComponent<{
           ) : null}
           {filteredChannels
             .sort((a, b) => {
-              const aIsToOrigin = a.destinationChainId === a.originChainId;
-              const bIsToOrigin = b.destinationChainId === b.originChainId;
+              const isIBCChainOfA = "originChainId" in a;
+              const isIBCChainOfB = "originChainId" in b;
+
+              const aIsToOrigin = isIBCChainOfA
+                ? a.destinationChainId === a.originChainId
+                : false;
+              const bIsToOrigin = isIBCChainOfB
+                ? b.destinationChainId === b.originChainId
+                : false;
 
               if (aIsToOrigin && !bIsToOrigin) {
                 return -1;
@@ -137,11 +167,17 @@ export const IBCTransferSelectDestinationModal: FunctionComponent<{
 
               return 0;
             })
-            .map((channel) => {
-              const isToOrigin =
-                channel.destinationChainId === channel.originChainId;
+            .map((bridgeOrChannel) => {
+              const isIBCChain = "originChainId" in bridgeOrChannel;
 
-              const chainInfo = chainStore.getChain(channel.destinationChainId);
+              const isToOrigin = isIBCChain
+                ? bridgeOrChannel.destinationChainId ===
+                  bridgeOrChannel.originChainId
+                : false;
+
+              const chainInfo = chainStore.getChain(
+                bridgeOrChannel.destinationChainId
+              );
 
               return (
                 <Box
@@ -160,10 +196,24 @@ export const IBCTransferSelectDestinationModal: FunctionComponent<{
                   onClick={async (e) => {
                     e.preventDefault();
 
-                    if (channel.channels.length > 0) {
+                    const isIBCChain = "channels" in bridgeOrChannel;
+
+                    if (!isIBCChain) {
+                      setDestinationChainInfoOfBridge({
+                        chainId: bridgeOrChannel.destinationChainId,
+                        currency: chainInfo.forceFindCurrency(
+                          bridgeOrChannel.denom
+                        ),
+                      });
+                      close();
+                      return;
+                    }
+
+                    if (bridgeOrChannel.channels.length > 0) {
                       const lastChainId =
-                        channel.channels[channel.channels.length - 1]
-                          .counterpartyChainId;
+                        bridgeOrChannel.channels[
+                          bridgeOrChannel.channels.length - 1
+                        ].counterpartyChainId;
 
                       const account = accountStore.getAccount(lastChainId);
 
@@ -171,9 +221,10 @@ export const IBCTransferSelectDestinationModal: FunctionComponent<{
                         await account.init();
                       }
 
+                      //이걸 합쳐서 bridge 타입으로 변경해서 분리 시키는게 났지 않을까?
                       setIsIBCTransfer(true);
-                      ibcChannelConfig.setChannels(channel.channels);
-                      setIBCChannelsInfoFluent(channel);
+                      ibcChannelConfig.setChannels(bridgeOrChannel.channels);
+                      setIBCChannelsInfoFluent(bridgeOrChannel);
                       // ledger에서 evmos, injective같은 경우는 유저가 먼저 ethereum app을 init 해놓지 않으면 주소를 가져올 수 없음.
                       // 이런 경우 때문에 채널은 무조건 설정해주고 account는 loaded됐을때만 주소를 설정한다.
                       if (account.walletStatus === WalletStatus.Loaded) {

--- a/apps/extension/src/pages/send/amount/ibc-transfer/modal.tsx
+++ b/apps/extension/src/pages/send/amount/ibc-transfer/modal.tsx
@@ -18,19 +18,19 @@ import { HomeIcon } from "../../../../components/icon";
 import { WalletStatus } from "@keplr-wallet/stores";
 import { IBCChannel, NoneIBCBridgeInfo } from "@keplr-wallet/stores-internal";
 import { AppCurrency } from "@keplr-wallet/types";
+import { SendType } from "..";
 
 export const IBCTransferSelectDestinationModal: FunctionComponent<{
   chainId: string;
   denom: string;
   recipientConfig: IRecipientConfig;
   ibcChannelConfig: IIBCChannelConfig;
-  setIsIBCTransfer: (value: boolean) => void;
+  setSendType: (value: SendType) => void;
   close: () => void;
   setDestinationChainInfoOfBridge: (value: {
     chainId: string;
     currency: AppCurrency;
   }) => void;
-
   // 이 컴포넌트는 사실 send page에서만 쓰이기 때문에 사용하는 쪽에서 필요한 로직을 위해서 몇몇 이상한(?) prop을 넘겨준다.
   // setAutomaticRecipient는 send page에서 recipient가 자동으로 설정되었을때 유저에게 UI를 보여주기 위해서 필요하다.
   setAutomaticRecipient: (address: string) => void;
@@ -53,7 +53,7 @@ export const IBCTransferSelectDestinationModal: FunctionComponent<{
     denom,
     recipientConfig,
     ibcChannelConfig,
-    setIsIBCTransfer,
+    setSendType,
     close,
     setAutomaticRecipient,
     setIBCChannelsInfoFluent,
@@ -169,7 +169,6 @@ export const IBCTransferSelectDestinationModal: FunctionComponent<{
             })
             .map((bridgeOrChannel) => {
               const isIBCChain = "originChainId" in bridgeOrChannel;
-
               const isToOrigin = isIBCChain
                 ? bridgeOrChannel.destinationChainId ===
                   bridgeOrChannel.originChainId
@@ -205,6 +204,7 @@ export const IBCTransferSelectDestinationModal: FunctionComponent<{
                           bridgeOrChannel.denom
                         ),
                       });
+                      setSendType("bridge");
                       close();
                       return;
                     }
@@ -222,7 +222,7 @@ export const IBCTransferSelectDestinationModal: FunctionComponent<{
                       }
 
                       //이걸 합쳐서 bridge 타입으로 변경해서 분리 시키는게 났지 않을까?
-                      setIsIBCTransfer(true);
+                      setSendType("ibc-transfer");
                       ibcChannelConfig.setChannels(bridgeOrChannel.channels);
                       setIBCChannelsInfoFluent(bridgeOrChannel);
                       // ledger에서 evmos, injective같은 경우는 유저가 먼저 ethereum app을 init 해놓지 않으면 주소를 가져올 수 없음.

--- a/apps/extension/src/pages/send/amount/ibc-transfer/modal.tsx
+++ b/apps/extension/src/pages/send/amount/ibc-transfer/modal.tsx
@@ -19,6 +19,7 @@ import { WalletStatus } from "@keplr-wallet/stores";
 import { IBCChannel, NoneIBCBridgeInfo } from "@keplr-wallet/stores-internal";
 import { AppCurrency } from "@keplr-wallet/types";
 import { SendType } from "..";
+import { DenomHelper } from "@keplr-wallet/common";
 
 export const IBCTransferSelectDestinationModal: FunctionComponent<{
   chainId: string;
@@ -203,6 +204,15 @@ export const IBCTransferSelectDestinationModal: FunctionComponent<{
                       const isEVMOnlyChain = chainStore.isEvmOnlyChain(
                         bridgeOrChannel.destinationChainId
                       );
+                      const isEvmChain = chainStore.isEvmChain(chainId);
+
+                      const sendingDenomHelper = new DenomHelper(
+                        bridgeOrChannel.denom
+                      );
+                      const isERC20 = sendingDenomHelper.type === "erc20";
+
+                      const isDestinationEvmAddress =
+                        isEVMOnlyChain || (isERC20 && isEvmChain);
 
                       const account = accountStore.getAccount(
                         bridgeOrChannel.destinationChainId
@@ -220,7 +230,7 @@ export const IBCTransferSelectDestinationModal: FunctionComponent<{
                       });
                       setSendType("bridge");
 
-                      if (isEVMOnlyChain) {
+                      if (isDestinationEvmAddress) {
                         recipientConfigForBridge.setValue(
                           account.ethereumHexAddress
                         );

--- a/apps/extension/src/pages/send/amount/ibc-transfer/modal.tsx
+++ b/apps/extension/src/pages/send/amount/ibc-transfer/modal.tsx
@@ -24,6 +24,7 @@ export const IBCTransferSelectDestinationModal: FunctionComponent<{
   chainId: string;
   denom: string;
   recipientConfig: IRecipientConfig;
+  recipientConfigForBridge: IRecipientConfig;
   ibcChannelConfig: IIBCChannelConfig;
   setSendType: (value: SendType) => void;
   close: () => void;
@@ -52,6 +53,7 @@ export const IBCTransferSelectDestinationModal: FunctionComponent<{
     chainId,
     denom,
     recipientConfig,
+    recipientConfigForBridge,
     ibcChannelConfig,
     setSendType,
     close,
@@ -198,6 +200,18 @@ export const IBCTransferSelectDestinationModal: FunctionComponent<{
                     const isIBCChain = "channels" in bridgeOrChannel;
 
                     if (!isIBCChain) {
+                      const isEVMOnlyChain = chainStore.isEvmOnlyChain(
+                        bridgeOrChannel.destinationChainId
+                      );
+
+                      const account = accountStore.getAccount(
+                        bridgeOrChannel.destinationChainId
+                      );
+
+                      if (account.walletStatus === WalletStatus.NotInit) {
+                        await account.init();
+                      }
+
                       setDestinationChainInfoOfBridge({
                         chainId: bridgeOrChannel.destinationChainId,
                         currency: chainInfo.forceFindCurrency(
@@ -205,6 +219,18 @@ export const IBCTransferSelectDestinationModal: FunctionComponent<{
                         ),
                       });
                       setSendType("bridge");
+
+                      if (isEVMOnlyChain) {
+                        recipientConfigForBridge.setValue(
+                          account.ethereumHexAddress
+                        );
+                        setAutomaticRecipient(account.ethereumHexAddress);
+                      } else {
+                        recipientConfigForBridge.setValue(
+                          account.bech32Address
+                        );
+                        setAutomaticRecipient(account.bech32Address);
+                      }
                       close();
                       return;
                     }

--- a/apps/extension/src/pages/send/amount/index.tsx
+++ b/apps/extension/src/pages/send/amount/index.tsx
@@ -490,8 +490,30 @@ export const SendAmountPage: FunctionComponent = observer(() => {
     console.log(e);
   }
 
-  const isSendByBridge =
-    isEVMOnlyChain && ibcSwapConfigs.amountConfig.outChainId !== chainId;
+  const destinationChainInfo = useMemo(() => {
+    if (sendType === "ibc-transfer") {
+      if (sendConfigs.channelConfig.channels.length === 0) {
+        return undefined;
+      }
+
+      return chainStore.getChain(
+        sendConfigs.channelConfig.channels[
+          sendConfigs.channelConfig.channels.length - 1
+        ].counterpartyChainId
+      );
+    }
+
+    if (sendType === "bridge") {
+      return chainStore.getChain(
+        ibcSwapConfigsForBridge.amountConfig.outChainId
+      );
+    }
+  }, [
+    sendType,
+    chainStore,
+    sendConfigs.channelConfig.channels,
+    ibcSwapConfigsForBridge,
+  ]);
 
   return (
     <HeaderLayout
@@ -909,7 +931,7 @@ export const SendAmountPage: FunctionComponent = observer(() => {
 
           <VerticalCollapseTransition collapsed={sendType === "send"}>
             <DestinationChainView
-              ibcChannelConfig={sendConfigs.channelConfig}
+              chainInfo={destinationChainInfo}
               onClick={() => {
                 setIsIBCTransferDestinationModalOpen(true);
               }}
@@ -943,8 +965,8 @@ export const SendAmountPage: FunctionComponent = observer(() => {
 
           <AmountInput
             amountConfig={
-              isSendByBridge
-                ? ibcSwapConfigs.amountConfig
+              sendType === "bridge"
+                ? ibcSwapConfigsForBridge.amountConfig
                 : sendConfigs.amountConfig
             }
           />

--- a/apps/extension/src/pages/send/amount/index.tsx
+++ b/apps/extension/src/pages/send/amount/index.tsx
@@ -227,7 +227,7 @@ function useGetGasSimulatorOfNotBridge(
   return gasSimulator;
 }
 
-function useSetupEvmSenderAddressAndSetupEvmTx(
+function useChangeSenderAddressWhenEtherMintChainSendToHexAddress(
   isEvmChain: boolean,
   sendConfigs: {
     amountConfig: IBCAmountConfig;
@@ -377,7 +377,7 @@ const useIBCSwapConfigWithRecipientConfig = (
 
   const recipientConfig = useIBCRecipientConfig(
     chainGetter,
-    chainId,
+    outChainId,
     channelConfig,
     options,
     false
@@ -473,7 +473,7 @@ export const SendAmountPage: FunctionComponent = observer(() => {
     destinationChainInfoOfBridge.chainId,
     destinationChainInfoOfBridge.currency,
     //NOTE - when swap is used on send page, it use bridge so swap fee is 0
-    0.75,
+    0,
     {
       allowHexAddressToBech32Address:
         !isEvmChain &&
@@ -545,7 +545,7 @@ export const SendAmountPage: FunctionComponent = observer(() => {
     currentFeeCurrencyCoinMinimalDenom,
   ]);
 
-  useSetupEvmSenderAddressAndSetupEvmTx(
+  useChangeSenderAddressWhenEtherMintChainSendToHexAddress(
     isEvmChain,
     sendConfigs,
     chainInfo,
@@ -740,6 +740,35 @@ export const SendAmountPage: FunctionComponent = observer(() => {
     sendConfigs.channelConfig.channels,
     ibcSwapConfigsForBridge,
   ]);
+
+  const {
+    feeConfig,
+    gasConfig,
+    senderConfig,
+    recipientConfig,
+    memoConfig,
+    amountConfig,
+  } = useMemo(() => {
+    if (sendType === "bridge") {
+      return {
+        feeConfig: ibcSwapConfigsForBridge.feeConfig,
+        gasConfig: ibcSwapConfigsForBridge.gasConfig,
+        senderConfig: ibcSwapConfigsForBridge.senderConfig,
+        recipientConfig: ibcSwapConfigsForBridge.recipientConfig,
+        memoConfig: ibcSwapConfigsForBridge.memoConfig,
+        amountConfig: ibcSwapConfigsForBridge.amountConfig,
+      };
+    }
+
+    return {
+      feeConfig: sendConfigs.feeConfig,
+      gasConfig: sendConfigs.gasConfig,
+      senderConfig: sendConfigs.senderConfig,
+      recipientConfig: sendConfigs.recipientConfig,
+      memoConfig: sendConfigs.memoConfig,
+      amountConfig: sendConfigs.amountConfig,
+    };
+  }, [sendType, sendConfigs, ibcSwapConfigsForBridge]);
 
   return (
     <HeaderLayout
@@ -1201,21 +1230,9 @@ export const SendAmountPage: FunctionComponent = observer(() => {
           <RecipientInput
             ref={addressRef}
             historyType={historyType}
-            recipientConfig={
-              sendType === "bridge"
-                ? ibcSwapConfigsForBridge.recipientConfig
-                : sendConfigs.recipientConfig
-            }
-            memoConfig={
-              sendType === "bridge"
-                ? ibcSwapConfigsForBridge.memoConfig
-                : sendConfigs.memoConfig
-            }
-            currency={
-              sendType === "bridge"
-                ? ibcSwapConfigsForBridge.amountConfig.currency
-                : sendConfigs.amountConfig.currency
-            }
+            recipientConfig={recipientConfig}
+            memoConfig={memoConfig}
+            currency={currency}
             permitAddressBookSelfKeyInfo={sendType !== "send"}
             bottom={
               <VerticalCollapseTransition
@@ -1233,13 +1250,7 @@ export const SendAmountPage: FunctionComponent = observer(() => {
             }
           />
 
-          <AmountInput
-            amountConfig={
-              sendType === "bridge"
-                ? ibcSwapConfigsForBridge.amountConfig
-                : sendConfigs.amountConfig
-            }
-          />
+          <AmountInput amountConfig={amountConfig} />
 
           {!isEvmTx && (
             <MemoInput
@@ -1283,21 +1294,9 @@ export const SendAmountPage: FunctionComponent = observer(() => {
           <Gutter size="0" />
 
           <FeeControl
-            senderConfig={
-              sendType === "bridge"
-                ? ibcSwapConfigsForBridge.senderConfig
-                : sendConfigs.senderConfig
-            }
-            feeConfig={
-              sendType === "bridge"
-                ? ibcSwapConfigsForBridge.feeConfig
-                : sendConfigs.feeConfig
-            }
-            gasConfig={
-              sendType === "bridge"
-                ? ibcSwapConfigsForBridge.gasConfig
-                : sendConfigs.gasConfig
-            }
+            senderConfig={senderConfig}
+            feeConfig={feeConfig}
+            gasConfig={gasConfig}
             gasSimulator={gasSimulatorForNotBridgeSend}
             isForEVMTx={isEvmTx}
           />

--- a/apps/extension/src/pages/send/amount/index.tsx
+++ b/apps/extension/src/pages/send/amount/index.tsx
@@ -254,6 +254,7 @@ function useSetupEvmSenderAddressAndSetupEvmTx(
         (chainInfo.stakeCurrency?.coinMinimalDenom ??
           chainInfo.currencies[0].coinMinimalDenom) ===
           sendingDenomHelper.denom;
+
       const isSendToHexAddressAndNotIBCToken =
         sendConfigs.recipientConfig.isRecipientEthereumHexAddress &&
         (isERC20 || isSendingNativeToken);
@@ -420,7 +421,6 @@ export const SendAmountPage: FunctionComponent = observer(() => {
 
   const [sendType, setSendType] = useState<SendType>("send");
 
-  //NOTE 일단 이건 브릿지용이긴 함 분리가 필요해 보이긴 한데 일단 패스
   const [destinationChainInfoOfBridge, setDestinationChainInfoOfBridge] =
     useState({
       chainId: "",
@@ -466,10 +466,8 @@ export const SendAmountPage: FunctionComponent = observer(() => {
     accountStore,
     ethereumAccountStore,
     skipQueriesStore,
-    destinationChainInfoOfBridge.chainId.length
-      ? destinationChainInfoOfBridge.chainId
-      : chainId,
-    account.ethereumHexAddress,
+    chainId,
+    isEVMOnlyChain ? account.ethereumHexAddress : account.bech32Address,
     200000,
     destinationChainInfoOfBridge.chainId,
     destinationChainInfoOfBridge.currency,
@@ -1252,9 +1250,21 @@ export const SendAmountPage: FunctionComponent = observer(() => {
           <Gutter size="0" />
 
           <FeeControl
-            senderConfig={sendConfigs.senderConfig}
-            feeConfig={sendConfigs.feeConfig}
-            gasConfig={sendConfigs.gasConfig}
+            senderConfig={
+              sendType === "bridge"
+                ? ibcSwapConfigsForBridge.senderConfig
+                : sendConfigs.senderConfig
+            }
+            feeConfig={
+              sendType === "bridge"
+                ? ibcSwapConfigsForBridge.feeConfig
+                : sendConfigs.feeConfig
+            }
+            gasConfig={
+              sendType === "bridge"
+                ? ibcSwapConfigsForBridge.gasConfig
+                : sendConfigs.gasConfig
+            }
             gasSimulator={gasSimulatorForNotBridgeSend}
             isForEVMTx={isEvmTx}
           />

--- a/apps/extension/src/pages/send/amount/index.tsx
+++ b/apps/extension/src/pages/send/amount/index.tsx
@@ -26,6 +26,8 @@ import {
   useIBCChannelConfig,
   useSendMixedIBCTransferConfig,
   useTxConfigsValidate,
+  IBCRecipientConfig,
+  useIBCRecipientConfig,
 } from "@keplr-wallet/hooks";
 import { useNavigate } from "react-router";
 import { AmountInput, RecipientInput } from "../../../components/input";
@@ -48,6 +50,7 @@ import {
   ChainInfoWithCoreTypes,
   LogAnalyticsEventMsg,
   SendTxAndRecordMsg,
+  SendTxEthereumMsgAndRecordMsg,
 } from "@keplr-wallet/background";
 import { FormattedMessage, useIntl } from "react-intl";
 import { useTxConfigsQueryString } from "../../../hooks/use-tx-config-query-string";
@@ -69,10 +72,6 @@ import {
   SkipQueries,
 } from "@keplr-wallet/stores-internal";
 import {
-  IBCRecipientConfig,
-  useIBCRecipientConfig,
-} from "@keplr-wallet/hooks/build/ibc/reciepient";
-import {
   AccountSetBase,
   AccountStore,
   ChainGetter,
@@ -87,7 +86,6 @@ import {
   EthereumAccountBase,
   EthereumAccountStore,
 } from "@keplr-wallet/stores-eth";
-import { SendTxEthereumMsgAndRecordMsg } from "@keplr-wallet/background/build/tx-ethereum";
 
 const Styles = {
   Flex1: styled.div`

--- a/apps/hooks-internal/src/ibc-swap/amount.ts
+++ b/apps/hooks-internal/src/ibc-swap/amount.ts
@@ -596,20 +596,6 @@ export class IBCSwapAmountConfig extends AmountConfig {
       };
     }
 
-    if (
-      !this.skipQueries.queryIBCSwap.isSwapDestinationOrAlternatives(
-        this.outChainId,
-        this.outAmount.currency
-      )
-    ) {
-      return {
-        ...prev,
-        error: new Error(
-          "The currency you are swapping to is currently not supported"
-        ),
-      };
-    }
-
     if (queryIBCSwap.getQueryRoute().isFetching) {
       return {
         ...prev,
@@ -652,6 +638,20 @@ export class IBCSwapAmountConfig extends AmountConfig {
           ),
         };
       }
+    }
+
+    if (
+      !this.skipQueries.queryIBCSwap.isSwapDestinationOrAlternatives(
+        this.outChainId,
+        this.outAmount.currency
+      )
+    ) {
+      return {
+        ...prev,
+        error: new Error(
+          "The currency you are swapping to is currently not supported"
+        ),
+      };
     }
 
     if (queryIBCSwap.getQueryRoute().response?.data.txs_required !== 1) {

--- a/apps/hooks-internal/src/ibc-swap/amount.ts
+++ b/apps/hooks-internal/src/ibc-swap/amount.ts
@@ -596,6 +596,20 @@ export class IBCSwapAmountConfig extends AmountConfig {
       };
     }
 
+    if (
+      !this.skipQueries.queryIBCSwap.isSwapDestinationOrAlternatives(
+        this.outChainId,
+        this.outAmount.currency
+      )
+    ) {
+      return {
+        ...prev,
+        error: new Error(
+          "The currency you are swapping to is currently not supported"
+        ),
+      };
+    }
+
     if (queryIBCSwap.getQueryRoute().isFetching) {
       return {
         ...prev,
@@ -638,20 +652,6 @@ export class IBCSwapAmountConfig extends AmountConfig {
           ),
         };
       }
-    }
-
-    if (
-      !this.skipQueries.queryIBCSwap.isSwapDestinationOrAlternatives(
-        this.outChainId,
-        this.outAmount.currency
-      )
-    ) {
-      return {
-        ...prev,
-        error: new Error(
-          "The currency you are swapping to is currently not supported"
-        ),
-      };
     }
 
     if (queryIBCSwap.getQueryRoute().response?.data.txs_required !== 1) {

--- a/apps/mobile/src/screen/activities/msg-items/ibc-swap-refunded.tsx
+++ b/apps/mobile/src/screen/activities/msg-items/ibc-swap-refunded.tsx
@@ -15,7 +15,6 @@ export const MsgRelationIBCSwapRefunded: FunctionComponent<{
   isInAllActivitiesPage: boolean | undefined;
 }> = observer(({msg, prices, targetDenom, isInAllActivitiesPage}) => {
   const {chainStore} = useStore();
-
   const style = useStyle();
 
   const chainInfo = chainStore.getChain(msg.chainId);

--- a/apps/stores-internal/src/skip/ibc-pfm-transfer.ts
+++ b/apps/stores-internal/src/skip/ibc-pfm-transfer.ts
@@ -3,32 +3,68 @@ import { ObservableQueryChains } from "./chains";
 import { computedFn } from "mobx-utils";
 import { ChainIdHelper } from "@keplr-wallet/cosmos";
 import { InternalChainStore } from "../internal";
+import { ObservableQueryRoute } from "./route";
+import { ObservableQueryMsgsDirect } from "./msgs-direct";
+import { ObservableQueryAssets } from "./assets";
+import { IBCChannel, NoneIBCBridgeInfo } from "./types";
 
 export class ObservableQueryIbcPfmTransfer {
   constructor(
     protected readonly chainStore: InternalChainStore,
     protected readonly queryChains: ObservableQueryChains,
-    protected readonly queryAssetsFromSource: ObservableQueryAssetsFromSource
+    protected readonly queryAssets: ObservableQueryAssets,
+    protected readonly queryAssetsFromSource: ObservableQueryAssetsFromSource,
+    protected readonly queryRoute: ObservableQueryRoute,
+    protected readonly queryMsgsDirect: ObservableQueryMsgsDirect
   ) {}
 
+  getBridges = computedFn(
+    (chainId: string, coinMinimalDenom: string): NoneIBCBridgeInfo[] => {
+      const res: NoneIBCBridgeInfo[] = [];
+
+      const chainInfo = this.chainStore.getChain(chainId);
+
+      const isEVMOnlyChain = chainInfo.chainId.startsWith("eip155:");
+      const asset = this.queryAssets
+        .getAssets(chainInfo.chainId)
+        .assets.find((asset) => asset.denom === coinMinimalDenom);
+
+      for (const candidateChain of this.queryChains.chains) {
+        const isCandidateChainEVMOnlyChain =
+          candidateChain.chainInfo.chainId.startsWith("eip155:");
+        const isCandidateChain =
+          candidateChain.chainInfo.chainId !== chainInfo.chainId &&
+          (isEVMOnlyChain || isCandidateChainEVMOnlyChain);
+
+        if (isCandidateChain) {
+          const candidateAsset = this.queryAssets
+            .getAssets(candidateChain.chainInfo.chainId)
+            .assetsRaw.find(
+              (a) =>
+                a.recommendedSymbol &&
+                a.recommendedSymbol === asset?.recommendedSymbol
+            );
+
+          if (candidateAsset) {
+            const currencyFound = this.chainStore
+              .getChain(candidateChain.chainInfo.chainId)
+              .findCurrencyWithoutReaction(candidateAsset.denom);
+
+            if (currencyFound) {
+              res.push({
+                destinationChainId: candidateChain.chainInfo.chainId,
+                denom: candidateAsset.denom,
+              });
+            }
+          }
+        }
+      }
+      return res;
+    }
+  );
+
   getIBCChannels = computedFn(
-    (
-      chainId: string,
-      denom: string
-    ): {
-      destinationChainId: string;
-      originDenom: string;
-      originChainId: string;
-
-      channels: {
-        portId: string;
-        channelId: string;
-
-        counterpartyChainId: string;
-      }[];
-
-      denom: string;
-    }[] => {
+    (chainId: string, denom: string): IBCChannel[] => {
       if (!this.chainStore.hasChain(chainId)) {
         return [];
       }

--- a/apps/stores-internal/src/skip/ibc-pfm-transfer.ts
+++ b/apps/stores-internal/src/skip/ibc-pfm-transfer.ts
@@ -21,9 +21,10 @@ export class ObservableQueryIbcPfmTransfer {
       const chainInfo = this.chainStore.getChain(chainId);
 
       const isEVMOnlyChain = chainInfo.chainId.startsWith("eip155:");
-      const asset = this.queryAssets
+
+      const assetForBridge = this.queryAssets
         .getAssets(chainInfo.chainId)
-        .assets.find((asset) => asset.denom === coinMinimalDenom);
+        .assetsRaw.find((asset) => asset.denom === coinMinimalDenom);
 
       for (const candidateChain of this.queryChains.chains) {
         const isCandidateChainEVMOnlyChain =
@@ -38,7 +39,7 @@ export class ObservableQueryIbcPfmTransfer {
             .assetsRaw.find(
               (a) =>
                 a.recommendedSymbol &&
-                a.recommendedSymbol === asset?.recommendedSymbol
+                a.recommendedSymbol === assetForBridge?.recommendedSymbol
             );
 
           if (candidateAsset) {

--- a/apps/stores-internal/src/skip/ibc-pfm-transfer.ts
+++ b/apps/stores-internal/src/skip/ibc-pfm-transfer.ts
@@ -3,8 +3,6 @@ import { ObservableQueryChains } from "./chains";
 import { computedFn } from "mobx-utils";
 import { ChainIdHelper } from "@keplr-wallet/cosmos";
 import { InternalChainStore } from "../internal";
-import { ObservableQueryRoute } from "./route";
-import { ObservableQueryMsgsDirect } from "./msgs-direct";
 import { ObservableQueryAssets } from "./assets";
 import { IBCChannel, NoneIBCBridgeInfo } from "./types";
 
@@ -13,9 +11,7 @@ export class ObservableQueryIbcPfmTransfer {
     protected readonly chainStore: InternalChainStore,
     protected readonly queryChains: ObservableQueryChains,
     protected readonly queryAssets: ObservableQueryAssets,
-    protected readonly queryAssetsFromSource: ObservableQueryAssetsFromSource,
-    protected readonly queryRoute: ObservableQueryRoute,
-    protected readonly queryMsgsDirect: ObservableQueryMsgsDirect
+    protected readonly queryAssetsFromSource: ObservableQueryAssetsFromSource
   ) {}
 
   getBridges = computedFn(

--- a/apps/stores-internal/src/skip/queries.ts
+++ b/apps/stores-internal/src/skip/queries.ts
@@ -62,9 +62,7 @@ export class SkipQueries {
       chainStore,
       this.queryChains,
       this.queryAssets,
-      this.queryAssetsFromSource,
-      this.queryRoute,
-      this.queryMsgsDirect
+      this.queryAssetsFromSource
     );
     this.queryIBCSwap = new ObservableQueryIbcSwap(
       chainStore,

--- a/apps/stores-internal/src/skip/queries.ts
+++ b/apps/stores-internal/src/skip/queries.ts
@@ -61,7 +61,10 @@ export class SkipQueries {
     this.queryIBCPacketForwardingTransfer = new ObservableQueryIbcPfmTransfer(
       chainStore,
       this.queryChains,
-      this.queryAssetsFromSource
+      this.queryAssets,
+      this.queryAssetsFromSource,
+      this.queryRoute,
+      this.queryMsgsDirect
     );
     this.queryIBCSwap = new ObservableQueryIbcSwap(
       chainStore,

--- a/apps/stores-internal/src/skip/types.ts
+++ b/apps/stores-internal/src/skip/types.ts
@@ -267,3 +267,22 @@ export interface ChainsResponse {
     chain_type: string;
   }[];
 }
+
+export type NoneIBCBridgeInfo = {
+  destinationChainId: string;
+  denom: string;
+};
+
+export type IBCChannel = {
+  destinationChainId: string;
+  originDenom: string;
+  originChainId: string;
+
+  channels: {
+    portId: string;
+    channelId: string;
+    counterpartyChainId: string;
+  }[];
+
+  denom: string;
+};

--- a/packages/background/src/index.ts
+++ b/packages/background/src/index.ts
@@ -53,6 +53,7 @@ export * from "./token-scan";
 export * from "./recent-send-history";
 export * from "./side-panel";
 export * from "./settings";
+export * from "./tx-ethereum";
 
 import { KVStore } from "@keplr-wallet/common";
 import { ChainInfo, ModularChainInfo } from "@keplr-wallet/types";

--- a/packages/background/src/index.ts
+++ b/packages/background/src/index.ts
@@ -292,7 +292,8 @@ export function init(
   BackgroundTxEthereum.init(
     router,
     backgroundTxEthereumService,
-    permissionInteractiveService
+    permissionInteractiveService,
+    recentSendHistoryService
   );
   PhishingList.init(router, phishingListService);
   AutoLocker.init(router, autoLockAccountService);

--- a/packages/background/src/tx-ethereum/init.ts
+++ b/packages/background/src/tx-ethereum/init.ts
@@ -1,16 +1,22 @@
 import { Router } from "@keplr-wallet/router";
-import { SendTxEthereumMsg } from "./messages";
+import { SendTxEthereumMsg, SendTxEthereumMsgAndRecordMsg } from "./messages";
 import { ROUTE } from "./constants";
 import { getHandler } from "./handler";
 import { BackgroundTxEthereumService } from "./service";
 import { PermissionInteractiveService } from "../permission-interactive";
+import { RecentSendHistoryService } from "../recent-send-history";
 
 export function init(
   router: Router,
   service: BackgroundTxEthereumService,
-  permissionInteractionService: PermissionInteractiveService
+  permissionInteractionService: PermissionInteractiveService,
+  recentSendHistoryService: RecentSendHistoryService
 ): void {
   router.registerMessage(SendTxEthereumMsg);
+  router.registerMessage(SendTxEthereumMsgAndRecordMsg);
 
-  router.addHandler(ROUTE, getHandler(service, permissionInteractionService));
+  router.addHandler(
+    ROUTE,
+    getHandler(service, permissionInteractionService, recentSendHistoryService)
+  );
 }

--- a/packages/background/src/tx-ethereum/messages.ts
+++ b/packages/background/src/tx-ethereum/messages.ts
@@ -38,3 +38,73 @@ export class SendTxEthereumMsg extends Message<string> {
     return SendTxEthereumMsg.type();
   }
 }
+
+export class SendTxEthereumMsgAndRecordMsg extends Message<string> {
+  public static type() {
+    return "send-ethereum-tx-to-background-and-record-msg";
+  }
+
+  constructor(
+    public readonly historyType: string,
+    public readonly chainId: string,
+    public readonly destinationChainId: string,
+    public readonly tx: Uint8Array,
+    public readonly sender: string,
+    public readonly recipient: string,
+    public readonly amount: {
+      readonly amount: string;
+      readonly denom: string;
+    }[],
+    public readonly memo: string,
+    public readonly silent?: boolean
+  ) {
+    super();
+  }
+
+  validateBasic(): void {
+    if (!this.chainId) {
+      throw new KeplrError("tx", 100, "chain id is empty");
+    }
+
+    if (!this.tx) {
+      throw new KeplrError("tx", 101, "tx is empty");
+    }
+
+    if (!this.historyType) {
+      throw new Error("type is empty");
+    }
+
+    if (!this.destinationChainId) {
+      throw new Error("chain id is empty");
+    }
+
+    if (!this.sender) {
+      throw new Error("sender is empty");
+    }
+
+    if (!this.recipient) {
+      throw new Error("recipient is empty");
+    }
+
+    if (!this.amount) {
+      throw new Error("amount is empty");
+    }
+
+    if (!this.memo) {
+      throw new Error("memo is empty");
+    }
+  }
+
+  override approveExternal(): boolean {
+    // Silent mode is only allowed for the internal txs.
+    return !this.silent;
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return SendTxEthereumMsgAndRecordMsg.type();
+  }
+}

--- a/packages/hooks/src/ibc/index.ts
+++ b/packages/hooks/src/ibc/index.ts
@@ -3,3 +3,4 @@ export * from "./channel";
 export * from "./errors";
 export * from "./send-ibc-transfer";
 export * from "./types";
+export * from "./reciepient";

--- a/packages/stores-eth/src/account/base.ts
+++ b/packages/stores-eth/src/account/base.ts
@@ -280,6 +280,9 @@ export class EthereumAccountBase {
       onBroadcastFailed?: (e?: Error) => void;
       onBroadcasted?: (txHash: string) => void;
       onFulfill?: (txReceipt: EthTxReceipt) => void;
+    },
+    options?: {
+      sendTx?: (chainId: string, signedTx: Buffer) => Promise<string>;
     }
   ) {
     try {
@@ -323,7 +326,10 @@ export class EthereumAccountBase {
       );
 
       const sendEthereumTx = keplr.sendEthereumTx.bind(keplr);
-      const txHash = await sendEthereumTx(this.chainId, signedTx);
+      const txHash = options?.sendTx
+        ? await options.sendTx(this.chainId, signedTx)
+        : await sendEthereumTx(this.chainId, signedTx);
+
       if (!txHash) {
         throw new Error("No tx hash responded");
       }


### PR DESCRIPTION
# 구현사항
1. send/amount 페이지에서 ibc button 을 클릭시 브릿지 가능한 요소 보여주기
2. 이더리움 체인 클릭시 hex주소로 설정 및 swap route 쿼리
3. 일반 이더리움 send에서 전송후 address book에 최근항목에 저장이 안되는 문제 수정 -> 8f2e3fe2a7f5b67e4255d1836f1b58bddfdab35a

 현재 구현 안되어있는 사항
1. 실제 msg를 보내는 부분
2. ibc tranfer 이름 변경 필요
3. swap fee? 같은 실제 브릿지후 얼마가 되는지 가격 보여줘야함 

## 각 파일 수정 사항들
`destination-chain-view.tsx` 
- 외부에서 destination chain을 받고 그대로 보여주도록 수정 (bridge 목적 체인의 경우에는 channel이 없기때문에 상위 컴포넌트에서 해당 부분을 결정 할수 있게 수정)

`amount/ibc-transfer/modal.tsx`
- 목적 체인이 브릿지되거나 or ibc로 갈 수있고 특정 체인(noble)의 경우 2가지 종류의 체인을 한 모달에서 보여주기 위해서 NoneIBCBridgeInfo와 IBCChannel 타입을 받아서 사용 하도록 수정 
- queryIBCPacketForwardingTransfer으로 부터 브릿지 정보를 받아서 보여주도록 수정
- sendType이 bridge일 경우 ibcSwapConfg를 사용하도록 수정

`send/amount/index.tsx`
- 기존의 isIbcTrasfer을 send, ibc-transfer, bridge 3가지 경우를 대응 하기 위해서 sendType으로 수정 
 - bridge의 경우 기존 ibcSwap의 로직을 활용 하기 위해서 useIBCSwapConfigWithRecipientConfig를 추가
 - 현재 send의 페이지 경우 ibcSendConfig와 ibcSwapConfig 둘다 설정에 필요 하기 때문에 둘다 설정하고
 amountInput등의 인자로 넣어줄때는 할때마다 sendType으로 분기하면 지저분해 보여서 해당 경우에는 활용 하기 위해서 sendType에 따라서 미리 값을 받도록 수정
 ```ts
   const {
    feeConfig,
    gasConfig,
    senderConfig,
    recipientConfig,
    memoConfig,
    amountConfig,
  } = useMemo(() => {
    if (sendType === "bridge") {
      return {
        feeConfig: ibcSwapConfigsForBridge.feeConfig,
        gasConfig: ibcSwapConfigsForBridge.gasConfig,
        senderConfig: ibcSwapConfigsForBridge.senderConfig,
        recipientConfig: ibcSwapConfigsForBridge.recipientConfig,
        memoConfig: ibcSwapConfigsForBridge.memoConfig,
        amountConfig: ibcSwapConfigsForBridge.amountConfig,
      };
    }

    return {
      feeConfig: sendConfigs.feeConfig,
      gasConfig: sendConfigs.gasConfig,
      senderConfig: sendConfigs.senderConfig,
      recipientConfig: sendConfigs.recipientConfig,
      memoConfig: sendConfigs.memoConfig,
      amountConfig: sendConfigs.amountConfig,
    };
  }, [sendType, sendConfigs, ibcSwapConfigsForBridge]);
  ```
  해당 구조가 좀 복잡한것도 같아서 더 좋은 방안이 있다면 말씀해주세요 
  
  `apps/stores-internal/src/skip/ibc-pfm-transfer.ts`
  - getBridge 함수 추가 해당로직은 getAssets에서 가져옴 
  
  
 `apps/hooks-internal/src/ibc-swap/amount.ts`
 - send페이지에서 isSwapDestinationOrAlternatives를 호출하기 전에 `queryIBCSwap.getQueryRoute().isFetching` 이 먼저 true로 설정되면서 isSwapDestinationOrAlternatives부분의 옵저버가 풀리는 문제가 있어서 위치를 수정함 -> 다시 수정중 
 
