### PR TITLE
Typo fix 02-basic-api.md

### DIFF
--- a/docs/docs/02-basic-api.md
+++ b/docs/docs/02-basic-api.md
@@ -133,7 +133,7 @@ If the webpage has permission and Keplr is unlocked, this function will return t
 }
 ```
 
-It also returns the nickname for the key store currently selected, which should allow the webpage to display the current key store selected to the user in a more convenient mane.  
+It also returns the nickname for the key store currently selected, which should allow the webpage to display the current key store selected to the user in a more convenient main.  
 `isNanoLedger` field in the return type is used to indicate whether the selected account is from the Ledger Nano. Because current Cosmos app in the Ledger Nano doesn't support the direct (protobuf) format msgs, this field can be used to select the amino or direct signer. [Ref](./03-cosmjs.md#types-of-offline-signers)
 
 ### Sign Amino


### PR DESCRIPTION
# Typo Fix in `02-basic-api.md`

## Description

This pull request addresses a typographical error in the **`02-basic-api.md`** documentation file:
- Corrected **"mane"** to **"manner"** in the sentence:
  > It also returns the nickname for the key store currently selected, which should allow the webpage to display the current key store selected to the user in a more convenient manner.

### Changes
- **File:** `docs/docs/02-basic-api.md`
- **Details:**
  - Original text: "...in a more convenient **mane**."
  - Updated text: "...in a more convenient **manner**."
