### PR TITLE
[KEPLR-720] Improve evm fee options

### DIFF
--- a/apps/extension/src/components/input/fee-control/index.tsx
+++ b/apps/extension/src/components/input/fee-control/index.tsx
@@ -215,7 +215,15 @@ export const FeeControl: FunctionComponent<{
 
     const [isModalOpen, setIsModalOpen] = useState(false);
 
-    const isShowingEstimatedFee = isForEVMTx && !!gasSimulator?.gasEstimated;
+    // EVM 트랜잭션의 경우, 외부에서 fee를 설정한 경우를 구분하기 위해서 사용
+    const isFeeSetByUser = isForEVMTx && feeConfig.type !== "manual";
+
+    // gasAdjustment와 gasEstimated를 사용해 계산된 값을 보여주는 경우
+    const isShowingFeeWithGasAdjustment =
+      isForEVMTx &&
+      gasSimulator?.enabled &&
+      !!gasSimulator?.gasEstimated &&
+      isFeeSetByUser;
 
     return (
       <Box>
@@ -274,17 +282,39 @@ export const FeeControl: FunctionComponent<{
                       })()
                         .map((fee) =>
                           fee
+                            .sub(
+                              new Dec(feeConfig.l1DataFee?.toString() || "0")
+                            )
                             .quo(
                               new Dec(
-                                isShowingEstimatedFee ? gasConfig?.gas || 1 : 1
+                                isShowingFeeWithGasAdjustment
+                                  ? gasConfig?.gas || 1
+                                  : 1
                               )
                             )
                             .mul(
                               new Dec(
-                                isShowingEstimatedFee
+                                isShowingFeeWithGasAdjustment
                                   ? gasSimulator?.gasEstimated || 1
                                   : 1
                               )
+                            )
+                            .mul(
+                              new Dec(
+                                isShowingFeeWithGasAdjustment
+                                  ? gasSimulator?.gasAdjustment || 1
+                                  : 1
+                              )
+                            )
+                            .add(
+                              new Dec(feeConfig.l1DataFee?.toString() || "0")
+                            )
+                            .add(
+                              isFeeSetByUser
+                                ? new Dec(0)
+                                : new Dec(
+                                    feeConfig.l1DataFee?.toString() || "0"
+                                  ) // evm fee가 외부에서 설정된 경우, fee = gasLimit * gasPrice이므로 l1DataFee를 더해줘야 함
                             )
                             .maxDecimals(6)
                             .inequalitySymbol(true)
@@ -320,17 +350,33 @@ export const FeeControl: FunctionComponent<{
                     } else {
                       const price = priceStore.calculatePrice(
                         fee
+                          .sub(new Dec(feeConfig.l1DataFee?.toString() || "0"))
                           .quo(
                             new Dec(
-                              isShowingEstimatedFee ? gasConfig?.gas || 1 : 1
+                              isShowingFeeWithGasAdjustment
+                                ? gasConfig?.gas || 1
+                                : 1
                             )
                           )
                           .mul(
                             new Dec(
-                              isShowingEstimatedFee
+                              isShowingFeeWithGasAdjustment
                                 ? gasSimulator?.gasEstimated || 1
                                 : 1
                             )
+                          )
+                          .mul(
+                            new Dec(
+                              isShowingFeeWithGasAdjustment
+                                ? gasSimulator?.gasAdjustment || 1
+                                : 1
+                            )
+                          )
+                          .add(new Dec(feeConfig.l1DataFee?.toString() || "0"))
+                          .add(
+                            isFeeSetByUser
+                              ? new Dec(0)
+                              : new Dec(feeConfig.l1DataFee?.toString() || "0")
                           )
                       );
                       if (price) {

--- a/apps/extension/src/components/input/fee-control/index.tsx
+++ b/apps/extension/src/components/input/fee-control/index.tsx
@@ -219,11 +219,8 @@ export const FeeControl: FunctionComponent<{
     const isFeeSetByUser = isForEVMTx && feeConfig.type !== "manual";
 
     // gasAdjustment와 gasEstimated를 사용해 계산된 값을 보여주는 경우
-    const isShowingFeeWithGasAdjustment =
-      isForEVMTx &&
-      gasSimulator?.enabled &&
-      !!gasSimulator?.gasEstimated &&
-      isFeeSetByUser;
+    const isShowingFeeWithGasEstimated =
+      !!gasSimulator?.enabled && !!gasSimulator?.gasEstimated && isFeeSetByUser;
 
     return (
       <Box>
@@ -287,21 +284,21 @@ export const FeeControl: FunctionComponent<{
                             )
                             .quo(
                               new Dec(
-                                isShowingFeeWithGasAdjustment
+                                isShowingFeeWithGasEstimated
                                   ? gasConfig?.gas || 1
                                   : 1
                               )
                             )
                             .mul(
                               new Dec(
-                                isShowingFeeWithGasAdjustment
+                                isShowingFeeWithGasEstimated
                                   ? gasSimulator?.gasEstimated || 1
                                   : 1
                               )
                             )
                             .mul(
                               new Dec(
-                                isShowingFeeWithGasAdjustment
+                                isShowingFeeWithGasEstimated
                                   ? gasSimulator?.gasAdjustment || 1
                                   : 1
                               )
@@ -353,21 +350,21 @@ export const FeeControl: FunctionComponent<{
                           .sub(new Dec(feeConfig.l1DataFee?.toString() || "0"))
                           .quo(
                             new Dec(
-                              isShowingFeeWithGasAdjustment
+                              isShowingFeeWithGasEstimated
                                 ? gasConfig?.gas || 1
                                 : 1
                             )
                           )
                           .mul(
                             new Dec(
-                              isShowingFeeWithGasAdjustment
+                              isShowingFeeWithGasEstimated
                                 ? gasSimulator?.gasEstimated || 1
                                 : 1
                             )
                           )
                           .mul(
                             new Dec(
-                              isShowingFeeWithGasAdjustment
+                              isShowingFeeWithGasEstimated
                                 ? gasSimulator?.gasAdjustment || 1
                                 : 1
                             )

--- a/apps/extension/src/components/input/fee-control/modal.tsx
+++ b/apps/extension/src/components/input/fee-control/modal.tsx
@@ -145,8 +145,8 @@ export const TransactionFeeModal: FunctionComponent<{
 
     const isShowingMaxFee = isForEVMTx;
     const isFeeSetByUser = isForEVMTx && feeConfig.type !== "manual";
-    const isShowingGasEstimated =
-      isForEVMTx && !!isGasSimulatorEnabled && !!gasSimulator?.gasEstimated;
+    const isShowingFeeWithGasEstimated =
+      !!isGasSimulatorEnabled && !!gasSimulator?.gasEstimated && isFeeSetByUser;
 
     return (
       <Styles.Container>
@@ -210,7 +210,7 @@ export const TransactionFeeModal: FunctionComponent<{
               feeConfig={feeConfig}
               gasConfig={gasConfig}
               gasSimulator={gasSimulator}
-              isShowingGasEstimated={isShowingGasEstimated}
+              isShowingFeeWithGasEstimated={isShowingFeeWithGasEstimated}
             />
           </Stack>
 
@@ -512,9 +512,9 @@ const FeeSelector: FunctionComponent<{
   feeConfig: IFeeConfig;
   gasConfig?: IGasConfig;
   gasSimulator?: IGasSimulator;
-  isShowingGasEstimated?: boolean;
+  isShowingFeeWithGasEstimated?: boolean;
 }> = observer(
-  ({ feeConfig, gasConfig, gasSimulator, isShowingGasEstimated }) => {
+  ({ feeConfig, gasConfig, gasSimulator, isShowingFeeWithGasEstimated }) => {
     const { priceStore } = useStore();
     const theme = useTheme();
 
@@ -561,19 +561,21 @@ const FeeSelector: FunctionComponent<{
                         .sub(new Dec(feeConfig.l1DataFee?.toString() || "0"))
                         .quo(
                           new Dec(
-                            isShowingGasEstimated ? gasConfig?.gas || 1 : 1
+                            isShowingFeeWithGasEstimated
+                              ? gasConfig?.gas || 1
+                              : 1
                           )
                         )
                         .mul(
                           new Dec(
-                            isShowingGasEstimated
+                            isShowingFeeWithGasEstimated
                               ? gasSimulator?.gasAdjustment || 1
                               : 1
                           )
                         )
                         .mul(
                           new Dec(
-                            isShowingGasEstimated
+                            isShowingFeeWithGasEstimated
                               ? gasSimulator?.gasEstimated || 1
                               : 1
                           )
@@ -587,17 +589,21 @@ const FeeSelector: FunctionComponent<{
                 {feeConfig
                   .getFeeTypePrettyForFeeCurrency(feeCurrency, "low")
                   .sub(new Dec(feeConfig.l1DataFee?.toString() || "0"))
-                  .quo(new Dec(isShowingGasEstimated ? gasConfig?.gas || 1 : 1))
+                  .quo(
+                    new Dec(
+                      isShowingFeeWithGasEstimated ? gasConfig?.gas || 1 : 1
+                    )
+                  )
                   .mul(
                     new Dec(
-                      isShowingGasEstimated
+                      isShowingFeeWithGasEstimated
                         ? gasSimulator?.gasAdjustment || 1
                         : 1
                     )
                   )
                   .mul(
                     new Dec(
-                      isShowingGasEstimated
+                      isShowingFeeWithGasEstimated
                         ? gasSimulator?.gasEstimated || 1
                         : 1
                     )
@@ -638,19 +644,21 @@ const FeeSelector: FunctionComponent<{
                         .sub(new Dec(feeConfig.l1DataFee?.toString() || "0"))
                         .quo(
                           new Dec(
-                            isShowingGasEstimated ? gasConfig?.gas || 1 : 1
+                            isShowingFeeWithGasEstimated
+                              ? gasConfig?.gas || 1
+                              : 1
                           )
                         )
                         .mul(
                           new Dec(
-                            isShowingGasEstimated
+                            isShowingFeeWithGasEstimated
                               ? gasSimulator?.gasAdjustment || 1
                               : 1
                           )
                         )
                         .mul(
                           new Dec(
-                            isShowingGasEstimated
+                            isShowingFeeWithGasEstimated
                               ? gasSimulator?.gasEstimated || 1
                               : 1
                           )
@@ -664,17 +672,21 @@ const FeeSelector: FunctionComponent<{
                 {feeConfig
                   .getFeeTypePrettyForFeeCurrency(feeCurrency, "average")
                   .sub(new Dec(feeConfig.l1DataFee?.toString() || "0"))
-                  .quo(new Dec(isShowingGasEstimated ? gasConfig?.gas || 1 : 1))
+                  .quo(
+                    new Dec(
+                      isShowingFeeWithGasEstimated ? gasConfig?.gas || 1 : 1
+                    )
+                  )
                   .mul(
                     new Dec(
-                      isShowingGasEstimated
+                      isShowingFeeWithGasEstimated
                         ? gasSimulator?.gasAdjustment || 1
                         : 1
                     )
                   )
                   .mul(
                     new Dec(
-                      isShowingGasEstimated
+                      isShowingFeeWithGasEstimated
                         ? gasSimulator?.gasEstimated || 1
                         : 1
                     )
@@ -723,19 +735,21 @@ const FeeSelector: FunctionComponent<{
                         .sub(new Dec(feeConfig.l1DataFee?.toString() || "0"))
                         .quo(
                           new Dec(
-                            isShowingGasEstimated ? gasConfig?.gas || 1 : 1
+                            isShowingFeeWithGasEstimated
+                              ? gasConfig?.gas || 1
+                              : 1
                           )
                         )
                         .mul(
                           new Dec(
-                            isShowingGasEstimated
+                            isShowingFeeWithGasEstimated
                               ? gasSimulator?.gasAdjustment || 1
                               : 1
                           )
                         )
                         .mul(
                           new Dec(
-                            isShowingGasEstimated
+                            isShowingFeeWithGasEstimated
                               ? gasSimulator?.gasEstimated || 1
                               : 1
                           )
@@ -749,17 +763,21 @@ const FeeSelector: FunctionComponent<{
                 {feeConfig
                   .getFeeTypePrettyForFeeCurrency(feeCurrency, "high")
                   .sub(new Dec(feeConfig.l1DataFee?.toString() || "0"))
-                  .quo(new Dec(isShowingGasEstimated ? gasConfig?.gas || 1 : 1))
+                  .quo(
+                    new Dec(
+                      isShowingFeeWithGasEstimated ? gasConfig?.gas || 1 : 1
+                    )
+                  )
                   .mul(
                     new Dec(
-                      isShowingGasEstimated
+                      isShowingFeeWithGasEstimated
                         ? gasSimulator?.gasAdjustment || 1
                         : 1
                     )
                   )
                   .mul(
                     new Dec(
-                      isShowingGasEstimated
+                      isShowingFeeWithGasEstimated
                         ? gasSimulator?.gasEstimated || 1
                         : 1
                     )

--- a/apps/extension/src/components/input/fee-control/modal.tsx
+++ b/apps/extension/src/components/input/fee-control/modal.tsx
@@ -143,7 +143,10 @@ export const TransactionFeeModal: FunctionComponent<{
       isGasSimulatorEnabled,
     ]);
 
-    const isShowingMaxFee = isForEVMTx && !!gasSimulator?.gasEstimated;
+    const isShowingMaxFee = isForEVMTx;
+    const isFeeSetByUser = isForEVMTx && feeConfig.type !== "manual";
+    const isShowingGasEstimated =
+      isForEVMTx && !!isGasSimulatorEnabled && !!gasSimulator?.gasEstimated;
 
     return (
       <Styles.Container>
@@ -207,7 +210,7 @@ export const TransactionFeeModal: FunctionComponent<{
               feeConfig={feeConfig}
               gasConfig={gasConfig}
               gasSimulator={gasSimulator}
-              isForEVMTx={isForEVMTx}
+              isShowingGasEstimated={isShowingGasEstimated}
             />
           </Stack>
 
@@ -226,6 +229,11 @@ export const TransactionFeeModal: FunctionComponent<{
                     <FormattedMessage id="components.input.fee-control.modal.max-fee" />
                   </b>
                   {`: ${feeConfig.fees[0]
+                    .sub(
+                      isFeeSetByUser
+                        ? new Dec(feeConfig.l1DataFee?.toString() || "0")
+                        : new Dec(0)
+                    )
                     .maxDecimals(6)
                     .inequalitySymbol(true)
                     .trim(true)
@@ -246,7 +254,11 @@ export const TransactionFeeModal: FunctionComponent<{
                   {` ${(() => {
                     let total: PricePretty | undefined;
                     let hasUnknown = false;
-                    const maxFee = feeConfig.fees[0];
+                    const maxFee = feeConfig.fees[0].sub(
+                      isFeeSetByUser
+                        ? new Dec(feeConfig.l1DataFee?.toString() || "0")
+                        : new Dec(0)
+                    );
                     if (!maxFee.currency.coinGeckoId) {
                       hasUnknown = true;
                     } else {
@@ -500,222 +512,270 @@ const FeeSelector: FunctionComponent<{
   feeConfig: IFeeConfig;
   gasConfig?: IGasConfig;
   gasSimulator?: IGasSimulator;
-  isForEVMTx?: boolean;
-}> = observer(({ feeConfig, gasConfig, gasSimulator, isForEVMTx }) => {
-  const { priceStore } = useStore();
-  const theme = useTheme();
+  isShowingGasEstimated?: boolean;
+}> = observer(
+  ({ feeConfig, gasConfig, gasSimulator, isShowingGasEstimated }) => {
+    const { priceStore } = useStore();
+    const theme = useTheme();
 
-  const feeCurrency =
-    feeConfig.fees.length > 0
-      ? feeConfig.fees[0].currency
-      : feeConfig.selectableFeeCurrencies[0];
+    const feeCurrency =
+      feeConfig.fees.length > 0
+        ? feeConfig.fees[0].currency
+        : feeConfig.selectableFeeCurrencies[0];
 
-  if (!feeCurrency) {
-    return null;
+    if (!feeCurrency) {
+      return null;
+    }
+
+    return (
+      <Columns sum={3}>
+        <Column weight={1}>
+          <FeeSelectorStyle.Item
+            style={{
+              borderRadius: "0.5rem 0 0 0.5rem",
+              borderRight: `1px solid ${
+                theme.mode === "light"
+                  ? ColorPalette["gray-100"]
+                  : ColorPalette["gray-400"]
+              }`,
+            }}
+            onClick={() => {
+              feeConfig.setFee({
+                type: "low",
+                currency: feeCurrency,
+              });
+            }}
+            selected={feeConfig.type === "low"}
+          >
+            {/* 텍스트의 길이 등에 의해서 레이아웃이 변하는걸 막기 위해서 가라로 1px의 너비르 가지는 Box로 감싸준다. */}
+            <Box width="1px" alignX="center">
+              <FeeSelectorStyle.Title selected={feeConfig.type === "low"}>
+                <FormattedMessage id="components.input.fee-control.modal.fee-selector.low" />
+              </FeeSelectorStyle.Title>
+              {feeCurrency.coinGeckoId ? (
+                <FeeSelectorStyle.Price selected={feeConfig.type === "low"}>
+                  {priceStore
+                    .calculatePrice(
+                      feeConfig
+                        .getFeeTypePrettyForFeeCurrency(feeCurrency, "low")
+                        .sub(new Dec(feeConfig.l1DataFee?.toString() || "0"))
+                        .quo(
+                          new Dec(
+                            isShowingGasEstimated ? gasConfig?.gas || 1 : 1
+                          )
+                        )
+                        .mul(
+                          new Dec(
+                            isShowingGasEstimated
+                              ? gasSimulator?.gasAdjustment || 1
+                              : 1
+                          )
+                        )
+                        .mul(
+                          new Dec(
+                            isShowingGasEstimated
+                              ? gasSimulator?.gasEstimated || 1
+                              : 1
+                          )
+                        )
+                        .add(new Dec(feeConfig.l1DataFee?.toString() || "0"))
+                    )
+                    ?.toString() || "-"}
+                </FeeSelectorStyle.Price>
+              ) : null}
+              <FeeSelectorStyle.Amount selected={feeConfig.type === "low"}>
+                {feeConfig
+                  .getFeeTypePrettyForFeeCurrency(feeCurrency, "low")
+                  .sub(new Dec(feeConfig.l1DataFee?.toString() || "0"))
+                  .quo(new Dec(isShowingGasEstimated ? gasConfig?.gas || 1 : 1))
+                  .mul(
+                    new Dec(
+                      isShowingGasEstimated
+                        ? gasSimulator?.gasAdjustment || 1
+                        : 1
+                    )
+                  )
+                  .mul(
+                    new Dec(
+                      isShowingGasEstimated
+                        ? gasSimulator?.gasEstimated || 1
+                        : 1
+                    )
+                  )
+                  .add(new Dec(feeConfig.l1DataFee?.toString() || "0"))
+                  .maxDecimals(6)
+                  .inequalitySymbol(true)
+                  .trim(true)
+                  .shrink(true)
+                  .hideIBCMetadata(true)
+                  .toString()}
+              </FeeSelectorStyle.Amount>
+            </Box>
+          </FeeSelectorStyle.Item>
+        </Column>
+
+        <Column weight={1}>
+          <FeeSelectorStyle.Item
+            onClick={() => {
+              feeConfig.setFee({
+                type: "average",
+                currency: feeCurrency,
+              });
+            }}
+            selected={feeConfig.type === "average"}
+          >
+            {/* 텍스트의 길이 등에 의해서 레이아웃이 변하는걸 막기 위해서 가라로 1px의 너비르 가지는 Box로 감싸준다. */}
+            <Box width="1px" alignX="center">
+              <FeeSelectorStyle.Title selected={feeConfig.type === "average"}>
+                <FormattedMessage id="components.input.fee-control.modal.fee-selector.average" />
+              </FeeSelectorStyle.Title>
+              {feeCurrency.coinGeckoId ? (
+                <FeeSelectorStyle.Price selected={feeConfig.type === "average"}>
+                  {priceStore
+                    .calculatePrice(
+                      feeConfig
+                        .getFeeTypePrettyForFeeCurrency(feeCurrency, "average")
+                        .sub(new Dec(feeConfig.l1DataFee?.toString() || "0"))
+                        .quo(
+                          new Dec(
+                            isShowingGasEstimated ? gasConfig?.gas || 1 : 1
+                          )
+                        )
+                        .mul(
+                          new Dec(
+                            isShowingGasEstimated
+                              ? gasSimulator?.gasAdjustment || 1
+                              : 1
+                          )
+                        )
+                        .mul(
+                          new Dec(
+                            isShowingGasEstimated
+                              ? gasSimulator?.gasEstimated || 1
+                              : 1
+                          )
+                        )
+                        .add(new Dec(feeConfig.l1DataFee?.toString() || "0"))
+                    )
+                    ?.toString() || "-"}
+                </FeeSelectorStyle.Price>
+              ) : null}
+              <FeeSelectorStyle.Amount selected={feeConfig.type === "average"}>
+                {feeConfig
+                  .getFeeTypePrettyForFeeCurrency(feeCurrency, "average")
+                  .sub(new Dec(feeConfig.l1DataFee?.toString() || "0"))
+                  .quo(new Dec(isShowingGasEstimated ? gasConfig?.gas || 1 : 1))
+                  .mul(
+                    new Dec(
+                      isShowingGasEstimated
+                        ? gasSimulator?.gasAdjustment || 1
+                        : 1
+                    )
+                  )
+                  .mul(
+                    new Dec(
+                      isShowingGasEstimated
+                        ? gasSimulator?.gasEstimated || 1
+                        : 1
+                    )
+                  )
+                  .add(new Dec(feeConfig.l1DataFee?.toString() || "0"))
+                  .maxDecimals(6)
+                  .inequalitySymbol(true)
+                  .trim(true)
+                  .shrink(true)
+                  .hideIBCMetadata(true)
+                  .toString()}
+              </FeeSelectorStyle.Amount>
+            </Box>
+          </FeeSelectorStyle.Item>
+        </Column>
+
+        <Column weight={1}>
+          <FeeSelectorStyle.Item
+            style={{
+              borderRadius: "0 0.5rem 0.5rem 0",
+              borderLeft: `1px solid ${
+                theme.mode === "light"
+                  ? ColorPalette["gray-100"]
+                  : ColorPalette["gray-400"]
+              }`,
+            }}
+            onClick={() => {
+              feeConfig.setFee({
+                type: "high",
+                currency: feeCurrency,
+              });
+            }}
+            selected={feeConfig.type === "high"}
+          >
+            {/* 텍스트의 길이 등에 의해서 레이아웃이 변하는걸 막기 위해서 가라로 1px의 너비르 가지는 Box로 감싸준다. */}
+            <Box width="1px" alignX="center">
+              <FeeSelectorStyle.Title selected={feeConfig.type === "high"}>
+                <FormattedMessage id="components.input.fee-control.modal.fee-selector.high" />
+              </FeeSelectorStyle.Title>
+              {feeCurrency.coinGeckoId ? (
+                <FeeSelectorStyle.Price selected={feeConfig.type === "high"}>
+                  {priceStore
+                    .calculatePrice(
+                      feeConfig
+                        .getFeeTypePrettyForFeeCurrency(feeCurrency, "high")
+                        .sub(new Dec(feeConfig.l1DataFee?.toString() || "0"))
+                        .quo(
+                          new Dec(
+                            isShowingGasEstimated ? gasConfig?.gas || 1 : 1
+                          )
+                        )
+                        .mul(
+                          new Dec(
+                            isShowingGasEstimated
+                              ? gasSimulator?.gasAdjustment || 1
+                              : 1
+                          )
+                        )
+                        .mul(
+                          new Dec(
+                            isShowingGasEstimated
+                              ? gasSimulator?.gasEstimated || 1
+                              : 1
+                          )
+                        )
+                        .add(new Dec(feeConfig.l1DataFee?.toString() || "0"))
+                    )
+                    ?.toString() || "-"}
+                </FeeSelectorStyle.Price>
+              ) : null}
+              <FeeSelectorStyle.Amount selected={feeConfig.type === "high"}>
+                {feeConfig
+                  .getFeeTypePrettyForFeeCurrency(feeCurrency, "high")
+                  .sub(new Dec(feeConfig.l1DataFee?.toString() || "0"))
+                  .quo(new Dec(isShowingGasEstimated ? gasConfig?.gas || 1 : 1))
+                  .mul(
+                    new Dec(
+                      isShowingGasEstimated
+                        ? gasSimulator?.gasAdjustment || 1
+                        : 1
+                    )
+                  )
+                  .mul(
+                    new Dec(
+                      isShowingGasEstimated
+                        ? gasSimulator?.gasEstimated || 1
+                        : 1
+                    )
+                  )
+                  .add(new Dec(feeConfig.l1DataFee?.toString() || "0"))
+                  .maxDecimals(6)
+                  .inequalitySymbol(true)
+                  .trim(true)
+                  .shrink(true)
+                  .hideIBCMetadata(true)
+                  .toString()}
+              </FeeSelectorStyle.Amount>
+            </Box>
+          </FeeSelectorStyle.Item>
+        </Column>
+      </Columns>
+    );
   }
-
-  const isShowingGasEstimatedOnly = isForEVMTx && !!gasSimulator?.gasEstimated;
-
-  return (
-    <Columns sum={3}>
-      <Column weight={1}>
-        <FeeSelectorStyle.Item
-          style={{
-            borderRadius: "0.5rem 0 0 0.5rem",
-            borderRight: `1px solid ${
-              theme.mode === "light"
-                ? ColorPalette["gray-100"]
-                : ColorPalette["gray-400"]
-            }`,
-          }}
-          onClick={() => {
-            feeConfig.setFee({
-              type: "low",
-              currency: feeCurrency,
-            });
-          }}
-          selected={feeConfig.type === "low"}
-        >
-          {/* 텍스트의 길이 등에 의해서 레이아웃이 변하는걸 막기 위해서 가라로 1px의 너비르 가지는 Box로 감싸준다. */}
-          <Box width="1px" alignX="center">
-            <FeeSelectorStyle.Title selected={feeConfig.type === "low"}>
-              <FormattedMessage id="components.input.fee-control.modal.fee-selector.low" />
-            </FeeSelectorStyle.Title>
-            {feeCurrency.coinGeckoId ? (
-              <FeeSelectorStyle.Price selected={feeConfig.type === "low"}>
-                {priceStore
-                  .calculatePrice(
-                    feeConfig
-                      .getFeeTypePrettyForFeeCurrency(feeCurrency, "low")
-                      .quo(
-                        new Dec(
-                          isShowingGasEstimatedOnly ? gasConfig?.gas || 1 : 1
-                        )
-                      )
-                      .mul(
-                        new Dec(
-                          isShowingGasEstimatedOnly
-                            ? gasSimulator?.gasEstimated || 1
-                            : 1
-                        )
-                      )
-                  )
-                  ?.toString() || "-"}
-              </FeeSelectorStyle.Price>
-            ) : null}
-            <FeeSelectorStyle.Amount selected={feeConfig.type === "low"}>
-              {feeConfig
-                .getFeeTypePrettyForFeeCurrency(feeCurrency, "low")
-                .quo(
-                  new Dec(isShowingGasEstimatedOnly ? gasConfig?.gas || 1 : 1)
-                )
-                .mul(
-                  new Dec(
-                    isShowingGasEstimatedOnly
-                      ? gasSimulator?.gasEstimated || 1
-                      : 1
-                  )
-                )
-                .maxDecimals(6)
-                .inequalitySymbol(true)
-                .trim(true)
-                .shrink(true)
-                .hideIBCMetadata(true)
-                .toString()}
-            </FeeSelectorStyle.Amount>
-          </Box>
-        </FeeSelectorStyle.Item>
-      </Column>
-
-      <Column weight={1}>
-        <FeeSelectorStyle.Item
-          onClick={() => {
-            feeConfig.setFee({
-              type: "average",
-              currency: feeCurrency,
-            });
-          }}
-          selected={feeConfig.type === "average"}
-        >
-          {/* 텍스트의 길이 등에 의해서 레이아웃이 변하는걸 막기 위해서 가라로 1px의 너비르 가지는 Box로 감싸준다. */}
-          <Box width="1px" alignX="center">
-            <FeeSelectorStyle.Title selected={feeConfig.type === "average"}>
-              <FormattedMessage id="components.input.fee-control.modal.fee-selector.average" />
-            </FeeSelectorStyle.Title>
-            {feeCurrency.coinGeckoId ? (
-              <FeeSelectorStyle.Price selected={feeConfig.type === "average"}>
-                {priceStore
-                  .calculatePrice(
-                    feeConfig
-                      .getFeeTypePrettyForFeeCurrency(feeCurrency, "average")
-                      .quo(
-                        new Dec(
-                          isShowingGasEstimatedOnly ? gasConfig?.gas || 1 : 1
-                        )
-                      )
-                      .mul(
-                        new Dec(
-                          isShowingGasEstimatedOnly
-                            ? gasSimulator?.gasEstimated || 1
-                            : 1
-                        )
-                      )
-                  )
-                  ?.toString() || "-"}
-              </FeeSelectorStyle.Price>
-            ) : null}
-            <FeeSelectorStyle.Amount selected={feeConfig.type === "average"}>
-              {feeConfig
-                .getFeeTypePrettyForFeeCurrency(feeCurrency, "average")
-                .quo(
-                  new Dec(isShowingGasEstimatedOnly ? gasConfig?.gas || 1 : 1)
-                )
-                .mul(
-                  new Dec(
-                    isShowingGasEstimatedOnly
-                      ? gasSimulator?.gasEstimated || 1
-                      : 1
-                  )
-                )
-                .maxDecimals(6)
-                .inequalitySymbol(true)
-                .trim(true)
-                .shrink(true)
-                .hideIBCMetadata(true)
-                .toString()}
-            </FeeSelectorStyle.Amount>
-          </Box>
-        </FeeSelectorStyle.Item>
-      </Column>
-
-      <Column weight={1}>
-        <FeeSelectorStyle.Item
-          style={{
-            borderRadius: "0 0.5rem 0.5rem 0",
-            borderLeft: `1px solid ${
-              theme.mode === "light"
-                ? ColorPalette["gray-100"]
-                : ColorPalette["gray-400"]
-            }`,
-          }}
-          onClick={() => {
-            feeConfig.setFee({
-              type: "high",
-              currency: feeCurrency,
-            });
-          }}
-          selected={feeConfig.type === "high"}
-        >
-          {/* 텍스트의 길이 등에 의해서 레이아웃이 변하는걸 막기 위해서 가라로 1px의 너비르 가지는 Box로 감싸준다. */}
-          <Box width="1px" alignX="center">
-            <FeeSelectorStyle.Title selected={feeConfig.type === "high"}>
-              <FormattedMessage id="components.input.fee-control.modal.fee-selector.high" />
-            </FeeSelectorStyle.Title>
-            {feeCurrency.coinGeckoId ? (
-              <FeeSelectorStyle.Price selected={feeConfig.type === "high"}>
-                {priceStore
-                  .calculatePrice(
-                    feeConfig
-                      .getFeeTypePrettyForFeeCurrency(feeCurrency, "high")
-                      .quo(
-                        new Dec(
-                          isShowingGasEstimatedOnly ? gasConfig?.gas || 1 : 1
-                        )
-                      )
-                      .mul(
-                        new Dec(
-                          isShowingGasEstimatedOnly
-                            ? gasSimulator?.gasEstimated || 1
-                            : 1
-                        )
-                      )
-                  )
-                  ?.toString() || "-"}
-              </FeeSelectorStyle.Price>
-            ) : null}
-            <FeeSelectorStyle.Amount selected={feeConfig.type === "high"}>
-              {feeConfig
-                .getFeeTypePrettyForFeeCurrency(feeCurrency, "high")
-                .quo(
-                  new Dec(isShowingGasEstimatedOnly ? gasConfig?.gas || 1 : 1)
-                )
-                .mul(
-                  new Dec(
-                    isShowingGasEstimatedOnly
-                      ? gasSimulator?.gasEstimated || 1
-                      : 1
-                  )
-                )
-                .maxDecimals(6)
-                .inequalitySymbol(true)
-                .trim(true)
-                .shrink(true)
-                .hideIBCMetadata(true)
-                .toString()}
-            </FeeSelectorStyle.Amount>
-          </Box>
-        </FeeSelectorStyle.Item>
-      </Column>
-    </Columns>
-  );
-});
+);

--- a/apps/extension/src/pages/sign/components/fee-summary/index.tsx
+++ b/apps/extension/src/pages/sign/components/fee-summary/index.tsx
@@ -29,8 +29,6 @@ export const FeeSummary: FunctionComponent<{
 
   const theme = useTheme();
 
-  const isShowingGasEstimatedOnly = isForEVMTx && !!gasSimulator?.gasEstimated;
-
   return (
     <Box>
       <Box
@@ -84,16 +82,7 @@ export const FeeSummary: FunctionComponent<{
             })()
               .map((fee) =>
                 fee
-                  .quo(
-                    new Dec(isShowingGasEstimatedOnly ? gasConfig?.gas || 1 : 1)
-                  )
-                  .mul(
-                    new Dec(
-                      isShowingGasEstimatedOnly
-                        ? gasSimulator?.gasEstimated || 1
-                        : 1
-                    )
-                  )
+                  .add(new Dec(feeConfig.l1DataFee?.toString() || "0"))
                   .maxDecimals(6)
                   .inequalitySymbol(true)
                   .trim(true)
@@ -134,19 +123,7 @@ export const FeeSummary: FunctionComponent<{
                   break;
                 } else {
                   const price = priceStore.calculatePrice(
-                    fee
-                      .quo(
-                        new Dec(
-                          isShowingGasEstimatedOnly ? gasConfig?.gas || 1 : 1
-                        )
-                      )
-                      .mul(
-                        new Dec(
-                          isShowingGasEstimatedOnly
-                            ? gasSimulator?.gasEstimated || 1
-                            : 1
-                        )
-                      )
+                    fee.add(new Dec(feeConfig.l1DataFee?.toString() || "0"))
                   );
                   if (price) {
                     if (!total) {

--- a/apps/extension/src/pages/sign/ethereum/view.tsx
+++ b/apps/extension/src/pages/sign/ethereum/view.tsx
@@ -190,17 +190,17 @@ export const EthereumSigningView: FunctionComponent<{
           unsignedTx.maxFeePerGas ?? unsignedTx.gasPrice ?? 0
         );
         if (gasPriceFromTx > 0) {
+          // 사이트에서 제공된 수수료를 사용하는 경우, fee type이 manual로 설정되며,
+          // 사용자가 수동으로 설정하는 것을 지양하기 위해 preferNoSetFee를 true로 설정
           feeConfig.setFee(
             new CoinPretty(
               chainInfo.currencies[0],
               new Dec(gasConfig.gas).mul(new Dec(gasPriceFromTx))
             )
           );
-        }
 
-        // 만약 사이트에서 제공된 gasLimit 또는 gasPrice가 있으면,
-        // 사용자가 수동으로 설정하는 것을 지양하기 위해 preferNoSetFee를 true로 설정
-        setPreferNoSetFee(gasLimitFromTx > 0 || gasPriceFromTx > 0);
+          setPreferNoSetFee(!interactionData.isInternal);
+        }
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/extension/src/pages/sign/ethereum/view.tsx
+++ b/apps/extension/src/pages/sign/ethereum/view.tsx
@@ -108,6 +108,7 @@ export const EthereumSigningView: FunctionComponent<{
   );
 
   const [signingDataBuff, setSigningDataBuff] = useState(Buffer.from(message));
+  const [preferNoSetFee, setPreferNoSetFee] = useState<boolean>(false);
   const isTxSigning = signType === EthSignType.TRANSACTION;
 
   const gasSimulator = useGasSimulator(
@@ -195,6 +196,10 @@ export const EthereumSigningView: FunctionComponent<{
             )
           );
         }
+
+        // 만약 사이트에서 제공된 gasLimit 또는 gasPrice가 있으면,
+        // 사용자가 수동으로 설정하는 것을 지양하기 위해 preferNoSetFee를 true로 설정
+        setPreferNoSetFee(gasLimitFromTx > 0 || gasPriceFromTx > 0);
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -742,6 +747,7 @@ export const EthereumSigningView: FunctionComponent<{
                 senderConfig={senderConfig}
                 gasConfig={gasConfig}
                 gasSimulator={gasSimulator}
+                disableAutomaticFeeSet={preferNoSetFee}
                 isForEVMTx
               />
             );

--- a/apps/extension/src/pages/sign/ethereum/view.tsx
+++ b/apps/extension/src/pages/sign/ethereum/view.tsx
@@ -43,6 +43,7 @@ import {
   useFeeConfig,
   useGasSimulator,
   useSenderConfig,
+  useTxConfigsValidate,
   useZeroAllowedGasConfig,
 } from "@keplr-wallet/hooks";
 import { handleExternalInteractionWithNoProceedNext } from "../../../utils";
@@ -355,12 +356,20 @@ export const EthereumSigningView: FunctionComponent<{
   const [isUnknownContractExecution, setIsUnknownContractExecution] =
     useState(false);
 
+  const txConfigsValidate = useTxConfigsValidate({
+    senderConfig,
+    gasConfig,
+    feeConfig,
+  });
+
   const isLoading =
     signEthereumInteractionStore.isObsoleteInteractionApproved(
       interactionData.id
     ) ||
     isLedgerInteracting ||
     isKeystoneInteracting;
+
+  const buttonDisabled = txConfigsValidate.interactionBlocked;
 
   return (
     <HeaderLayout
@@ -419,6 +428,7 @@ export const EthereumSigningView: FunctionComponent<{
           color: "primary",
           size: "large",
           left: !isLoading && <ApproveIcon />,
+          disabled: buttonDisabled,
           isLoading,
           onClick: async () => {
             try {

--- a/packages/stores-eth/src/account/base.ts
+++ b/packages/stores-eth/src/account/base.ts
@@ -21,22 +21,7 @@ import { Interface } from "@ethersproject/abi";
 
 const opStackGasPriceOracleProxyAddress =
   "0x420000000000000000000000000000000000000F";
-const opStackGasPriceOracleProxyABI = new Interface([
-  {
-    constant: true,
-    inputs: [],
-    name: "implementation",
-    outputs: [
-      {
-        name: "",
-        type: "address",
-      },
-    ],
-    payable: false,
-    stateMutability: "view",
-    type: "function",
-  },
-]);
+
 const opStackGasPriceOracleABI = new Interface([
   {
     inputs: [{ internalType: "bytes", name: "_data", type: "bytes" }],
@@ -153,30 +138,17 @@ export class EthereumAccountBase {
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const keplr = (await this.getKeplr())!;
-    const implementationAddress = await keplr.ethereum.request<string>({
-      method: "eth_call",
-      params: [
-        {
-          to: opStackGasPriceOracleProxyAddress,
-          data: opStackGasPriceOracleProxyABI.encodeFunctionData(
-            "implementation"
-          ),
-        },
-      ],
-      chainId: this.chainId,
-    });
-    const gasPriceOracleContractAddress =
-      "0x" + implementationAddress.slice(26);
 
     const l1Fee = await keplr.ethereum.request<string>({
       method: "eth_call",
       params: [
         {
-          to: gasPriceOracleContractAddress,
+          to: opStackGasPriceOracleProxyAddress,
           data: opStackGasPriceOracleABI.encodeFunctionData("getL1Fee", [
             serialize(unsignedTx),
           ]),
         },
+        "latest",
       ],
       chainId: this.chainId,
     });


### PR DESCRIPTION
### 변경사항

- 외부 요청을 통해 수수료 옵션이 설정된 경우, cosmos처럼 메시지를 보여주도록 추가
- fee selector를 통해 fee가 설정된 경우, 사용자가 변경한 수수료 옵션이 tx data에 반영되도록 수정
- 사용자에게 보여지는 evm fee 계산 방식 개선
   - 외부 사이트 및 내부 요청(FeeSummary)을 통해 설정된 수수료를 보여주는 부분에서 사용되는 `feeConfig.fees[0]`는 `gasLimit` * `gasPrice`이므로, `l1DataFee`를 더해줘야 total fee를 보여줘야 합니다.
   - `feeConfig.type`이 있는 경우: fee selector를 통해 fee tier를 선택하는 경우 및 `getFeeTypePrettyForFeeCurrency` 메서드를 사용해 수수료를 계산했을 때 fee는 `(gasLimit * gasPrice) + l1DataFee`이므로, 이를 고려한 total fee를 보여줘야 합니다.

- op stack l1DataFee를 가져올 때 proxy contract를 직접 호출하도록 변경
    - upgrdeable contract의 구조상 proxy가 storage layer, implementation이 logic layer로 분리되어 있어서
    - implementation contract를 호출하게 되면 storage 정보가 완전히 달라서 의도된 값을 가져올 수 없습니다.

### 추가 고려 사항

- block gas limit를 넘으면 tx가 revert 되므로 이를 ui에서 고려 필요


### evm 수수료 계산 경우의 수

- 외부 사이트에서 요청이 들어올 때 수수료를 설정해주는 경우 -`uniswap`,`1inch` (L1, op stack L2, etc L2) 
- 외부 사이트에서 요청이 들어올 때 수수료를 설정해주지 않는 경우 - `skip` (L1, op stack L2, etc L2) 
- send page에서 내부적으로 수수료를 설정하는 경우 (L1, op stack L2, etc L2) 