### PR TITLE
Docs redirection config & contents update

### DIFF
--- a/docs/docs/intro/index.md
+++ b/docs/docs/intro/index.md
@@ -25,14 +25,14 @@ Keplr supports a wide range of blockchains, including Cosmos SDK-based chains, E
 Available as both a browser extension and mobile app, Keplr ensures users can securely access their wallets and interact with dApps on their preferred platform. This comprehensive accessibility empowers developers to build scalable and user-friendly dApps that meet modern multi-platform demands.
 
 ## Sections
-[Connect to Keplr](../getting-started/connect-to-keplr) describes how to integrate with Keplr in the webpage.  
+[Connect to Keplr](/api/getting-started/connect-to-keplr) describes how to integrate with Keplr in the webpage.  
 
-[Use with cosmjs](../use-with/cosmjs) describes how to use cosmjs with Keplr.
+[Use with cosmjs](/api/use-with/cosmjs) describes how to use cosmjs with Keplr.
 
-[Use with secretjs](../use-with/secretjs) describes how to use secretjs with Keplr if you need to use secret-wasm feature.
+[Use with secretjs](/api/use-with/secretjs) describes how to use secretjs with Keplr if you need to use secret-wasm feature.
   
-[Suggest chain](../guide/suggest-chain) describes how to suggest the chain to Keplr if the chain is not supported natively in Keplr.
+[Suggest chain](/api/guide/suggest-chain) describes how to suggest the chain to Keplr if the chain is not supported natively in Keplr.
 
-[EVM-based chains support](../multi-ecosystem-support/evm) describes how to support EVM-based chains with Keplr.
+[EVM-based chains support](/api/multi-ecosystem-support/evm) describes how to support EVM-based chains with Keplr.
 
-[Starknet Support](../multi-ecosystem-support/starknet) describes how to support Starknet chains with Keplr.
+[Starknet Support](/api/multi-ecosystem-support/starknet) describes how to support Starknet chains with Keplr.

--- a/docs/docs/use-with/cosmjs.md
+++ b/docs/docs/use-with/cosmjs.md
@@ -1,5 +1,5 @@
 ---
-title: CosmJs
+title: Use with CosmJs
 order: 2
 ---
 

--- a/docs/docs/use-with/cosmjs.md
+++ b/docs/docs/use-with/cosmjs.md
@@ -1,35 +1,57 @@
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
+
+# Use with CosmJS
+
+## Prerequisites
+
+### Detecting Keplr
+Keplr API may be undefined immediately after the webpage loads. Ensure you follow the guidelines in the [How to detect Keplr](../getting-started/connect-to-keplr#how-to-detect-keplr) section before proceeding.
+
+### Installing CosmJS Packages
+Select the appropriate CosmJS package based on the Cosmos SDK version:
+
+<Tabs>
+  <TabItem value="npm" label="npm" default>
+
+  | Package | Cosmos SDK Version |
+  |---------|--------------------|
+  | [@cosmjs/launchpad](https://www.npmjs.com/package/@cosmjs/launchpad) | 0.37 (cosmoshub-3), 0.38, 0.39 (Launchpad) |
+  | [@cosmjs/stargate](https://www.npmjs.com/package/@cosmjs/stargate) | 0.40+ (Stargate) |
+
+  </TabItem>
+
+  <TabItem value="yarn" label="Yarn">
+
+  | Package | Cosmos SDK Version |
+  |---------|--------------------|
+  | [@cosmjs/launchpad](https://classic.yarnpkg.com/en/package/@cosmjs/launchpad) | 0.37 (cosmoshub-3), 0.38, 0.39 (Launchpad) |
+  | [@cosmjs/stargate](https://classic.yarnpkg.com/en/package/@cosmjs/cosmwasm-stargate) | 0.40+ (Stargate) |
+
+  </TabItem>
+</Tabs>
+
 ---
-title: Use with CosmJs
-order: 2
----
 
-# Use with CosmJs
+## Connecting Keplr with CosmJS
 
-## How to detect Keplr
-Keplr API may be undefined right after the webpage is shown.
-Please check the [How to detect Keplr](../getting-started/connect-to-keplr#how-to-detect-keplr) first before reading this section.
-
-## Connecting with CosmJS
-
-CosmJS link: [https://www.npmjs.com/package/@cosmjs/launchpad](https://www.npmjs.com/package/@cosmjs/launchpad), [https://www.npmjs.com/package/@cosmjs/stargate](https://www.npmjs.com/package/@cosmjs/stargate)
-
-You can connect Keplr to CosmJS using the `OfflineSigner`.
+Keplr can be integrated with CosmJS using the `OfflineSigner`.
 
 ```javascript
-// Enabling before using the Keplr is recommended.
-// This method will ask the user whether or not to allow access if they haven't visited this website.
-// Also, it will request user to unlock the wallet if the wallet is locked.
-await window.keplr.enable(chainId);
+// It is recommended to enable Keplr before using OfflineSigner.
+// If the user hasn't visited this website before, this method will prompt the user to allow access.
+// Additionally, it will request the user to unlock the wallet if it is locked.
+await keplr.enable(chainId);
 
-const offlineSigner = window.getOfflineSigner(chainId);
+const offlineSigner = window.getOfflineSigner(chainId, signOptions);
 
-// You can get the address/public keys by `getAccounts` method.
-// It can return the array of address/public key.
-// But, currently, Keplr extension manages only one address/public key pair.
-// XXX: This line is needed to set the sender address for SigningCosmosClient.
+// You can obtain the address/public keys using the `getAccounts` method.
+// It returns an array of address/public key pairs.
+// However, currently, the Keplr extension manages only one address/public key pair.
+// Note: This line is necessary to set the sender address for the SigningCosmosClient.
 const accounts = await offlineSigner.getAccounts();
 
-// Initialize the gaia api with the offline signer that is injected by Keplr extension.
+// Initialize the Gaia API with the offline signer provided by the Keplr extension.
 const cosmJS = new SigningCosmosClient(
     "https://lcd-cosmoshub.keplr.app/rest",
     accounts[0].address,
@@ -37,37 +59,97 @@ const cosmJS = new SigningCosmosClient(
 );
 ```
 
-To get the `OfflineSigner`, you may use `keplr.getOfflineSigner(chainId)` or `window.getOfflineSigner(chainId)`. (`window.getOfflineSigner` is an alias that runs `keplr.getOfflineSigner` and returns the value)
+### Key Considerations
+- `keplr.enable(chainId)`: Requests the user to unlock Keplr and grant website access.
+- If the user rejects or cancels, an error is thrown.
+- If Keplr is already unlocked and authorized, the method resolves without prompting the user.
+- Even without calling `keplr.enable(chainId)`, any Keplr API request will trigger the same flow automatically. However, it's recommended to call it explicitly.
 
-The `window.keplr.enable(chainId)` method will request the user to unlock their Keplr extension if it's locked. If the user has not given permission to connect their extension to the website, it will first ask to connect the website.
+---
 
-If the user cancels the unlock or rejects the permission to connect, an error will be thrown.
+## Types of Offline Signers in CosmJS
 
-If the extension is already unlocked and the website has permission to connect, no action will happen and resolve.
+Keplr supports both types of offline signers described below. If you're leveraging Keplr in `window` directly, either `keplr.getOfflineSigner(chainId)` or `window.getOfflineSigner(chainId)` is available.
 
-`window.keplr.enable(chainId)` is not mandatory. Even if the method wasn't called, if an API that requests access to Keplr is called the flow above will automatically run. However, it is recommended that `window.keplr.enable(chainId)` is first run.
+1. **OfflineAminoSigner**: Used for signing `SignDoc` serialized with Amino
+    ```typescript
+    interface OfflineAminoSigner {
+      /**
+       * Get AccountData array from wallet. Rejects if not enabled.
+       */
+      readonly getAccounts: () => Promise<readonly AccountData[]>;
+      /**
+       * Request signature from whichever key corresponds to provided bech32-encoded address. Rejects if not enabled.
+       *
+       * The signer implementation may offer the user the ability to override parts of the signDoc. It must
+       * return the doc that was signed in the response.
+       *
+       * @param signerAddress The address of the account that should sign the transaction
+       * @param signDoc The content that should be signed
+       */
+      readonly signAmino: (
+        signerAddress: string,
+        signDoc: StdSignDoc
+      ) => Promise<AminoSignResponse>;
+    }
+    ```
+2. **OfflineDirectSigner**: Used for signing Protobuf-encoded `SignDoc`
+    ```typescript
+    interface OfflineDirectSigner {
+      readonly getAccounts: () => Promise<readonly AccountData[]>;
+      readonly signDirect: (
+        signerAddress: string,
+        signDoc: SignDoc
+      ) => Promise<DirectSignResponse>;
+    }
+    ```
+## Using signers
 
-## Types of Offline Signers
+### Choosing the Right Signer
+To get the basic information about the signing modes, refer to the [Signing Modes](../guide/sign-a-message#signing-modes-in-the-cosmos-sdk) section.
 
-In CosmJS, there are two types of Signers: OfflineSigner and OfflineDirectSigner. OfflineSigner is used to sign SignDoc serialized with Amino in Cosmos SDK Launchpad (Cosmos SDK v0.39.x or below). OfflineDirectSigner is used to sign Protobuf encoded SignDoc.
+### Getting Both Signers
 
-Keplr supports both types of Signers. Keplr’s `keplr.getOfflineSigner(chainId)` or `window.getOfflineSigner(chainId)` returns a Signer that satisfies both the OfflineSigner and OfflineDirectSigner. Therefore, when using CosmJS with this Signer, Amino is used for Launchpad chains and Protobuf is used for Stargate chains.
+It returns `signAmino` and `signDirect` methods for both Stargate and Launchpad.
 
-However, if the msg to be sent is able to be serialized/deserialized using Amino codec you can use a signer for Amino. Also, as there are some limitations to protobuf type sign doc, there may be cases when Amino is necessary. For example, Protobuf formatted sign doc is currently not supported by Ledger Nano’s Cosmos app. Also, because protobuf sign doc is binary formatted, msgs not natively supported by Keplr may not be human-readable.
+```typescript
+getOfflineSigner(
+  chainId: string,
+  signOptions?: KeplrSignOptions
+): OfflineAminoSigner & OfflineDirectSigner;
+```
 
-If you’d like to enforce the use of Amino, you can use the following APIs: `keplr.getOfflineSignerOnlyAmino(chainId)` or `window.getOfflineSignerOnlyAmino(chainId: string)`. Because this will always return an Amino compatible signer, any CosmJS requested msg that is Amino compatible will request an Amino SignDoc to Keplr.
+### Forcing Amino Signers
+To enforce Amino signing, use:
+```typescript
+getOfflineSignerOnlyAmino(
+  chainId: string,
+  signOptions?: KeplrSignOptions
+): OfflineAminoSigner;
+```
+This ensures that all CosmJS requests compatible with Amino will be signed in Amino format.
 
-Also, `keplr.getOfflineSignerAuto(chainId: string): Promise<OfflineSigner | OfflineDirectSigner>` or `window.getOfflineSignerAuto(chainId: string): Promise<OfflineSigner | OfflineDirectSigner>` API is supported. Please note that the value returned is async. This API automatically returns a signer that only supports Amino if the account is a Ledger-based account, and returns a signer that is compatible for both Amino and Protobuf if the account is a mnemonic/private key-based account. Because this API is affected by the type of the connected Keplr account, if [keplr_keystorechange](../guide/custom-event#key-store-change) event is used to detect account changes the signer must be changed using the API when this event has been triggered.
+### Auto-selecting a Signer
+To automatically choose the appropriate signer based on the account type:
+```typescript
+getOfflineSignerAuto(
+  chainId: string,
+  signOptions?: KeplrSignOptions
+): Promise<OfflineAminoSigner | OfflineDirectSigner>;
+```
 
-## Use with Stargate
+- Returns an **Amino signer** if the account is Ledger-based.
+- Returns a **Protobuf-compatible signer** if the account is mnemonic/private key-based.
+- If account type changes (e.g., a user switches wallets), update the signer using this API when the [`keplr_keystorechange`](../guide/custom-event#key-store-change) event is triggered.
 
-Keplr's `OfflineSigner` implements the `OfflineDirectSigner` interface. Use `SigningStargateClient` with Keplr's `OfflineSigner`, and Keplr will sign the transaction in Proto sign doc format.
+---
 
-### Example
-Refer to the [keplr-example](https://github.com/chainapsis/keplr-example/blob/master/src/main.js) repository for example code on how to integrate Keplr with CosmJS.
+## Using Keplr with Stargate
 
-### Interaction Options
-You can use Keplr native API’s to set interaction options even when using CosmJS. Please refer to [signOptions](../guide/sign-a-message#sign-options).
+Keplr's `OfflineSigner` implements the `OfflineDirectSigner` interface, allowing transactions to be signed in Protobuf format using `SigningStargateClient`.
 
-### Adding a custom blockchain to Keplr
-If Keplr doesn't natively support your blockchain within the extension, please refer to the [Suggest chain](../guide/suggest-chain) section.
+#### Interaction Options
+Even when using CosmJS, you can configure Keplr's interaction options. See [signOptions](../guide/sign-a-message#sign-options) for details.
+
+#### Adding a Custom Blockchain
+If your blockchain is not natively supported in Keplr, follow the instructions in the [Suggest Chain](../guide/suggest-chain) section to add it manually.

--- a/docs/docs/use-with/secretjs.md
+++ b/docs/docs/use-with/secretjs.md
@@ -1,63 +1,96 @@
----
-title: Use with SecretJs
-order: 3
----
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Use with SecretJS
-## How to detect Keplr
-Keplr API may be undefined right after the webpage shown.
-Please check the [How to detect Keplr](../getting-started/connect-to-keplr.mdx#how-to-detect-keplr) first before reading this section.
+
+## Prerequisites
+
+### Detecting Keplr
+Keplr API may be undefined immediately after the webpage loads. Ensure you follow the guidelines in the [How to detect Keplr](../getting-started/connect-to-keplr#how-to-detect-keplr) section before proceeding.
+
+### Installing SecretJS Package
+To install the `secretjs` package, use either npm or Yarn:
+
+<Tabs>
+  <TabItem value="npm" label="npm" default>
+  
+  ```bash
+  npm install secretjs
+  ```
+  <a href="https://www.npmjs.com/package/secretjs" target="_blank">View on npm</a>
+  </TabItem>
+
+  <TabItem value="yarn" label="Yarn">
+  
+  ```bash
+  yarn add secretjs
+  ```
+  <a href="https://classic.yarnpkg.com/en/package/secretjs" target="_blank">View on Yarn</a>
+  </TabItem>
+</Tabs>
+
+---
 
 ## Connecting with SecretJS
+The core usage of SecretJS is basically similar to using CosmJS. Refer to the [Use with CosmJS](./cosmjs) section if you need more details.
 
-SecretJS link: [https://www.npmjs.com/package/secretjs](https://www.npmjs.com/package/secretjs)
-The basics of using SecretJS are similar to CosmJS. Refer to the [Use with CosmJs](../use-with/cosmjs) section for more information.  
-  
-One difference between CosmJS and SecretJS is that we recommend using Keplr's `EnigmaUtils`.
-By using Keplr's `EnigmaUtils`, you can use Keplr to encrypt/decrypt, and the decrypted transaction messages are shown to the user in a human-readable format.
+One key difference is that SecretJS utilizes Keplr's `EnigmaUtils` for encryption and decryption. This ensures that decrypted transaction messages are displayed to users in a human-readable format.
+
+### Basic Setup
+Before interacting with SecretJS, it is recommended to enable the Keplr:
 
 ```javascript
-// Enabling before using the Keplr is recommended.
-// This method will ask the user whether or not to allow access if they haven't visited this website.
-// Also, it will request the user to unlock the wallet if the wallet is locked.
-await window.keplr.enable(chainId);
+const CHAIN_ID = "secret-1";
+await keplr.enable(CHAIN_ID);
+```
 
-const offlineSigner = window.getOfflineSigner(chainId);
-**const enigmaUtils = window.getEnigmaUtils(chainId);**
-
-// You can get the address/public keys by `getAccounts` method.
-// It can return the array of address/public key.
-// But, currently, Keplr extension manages only one address/public key pair.
-// XXX: This line is needed to set the sender address for SigningCosmosClient.
+### Initialize SecretJS
+```javascript
+const offlineSigner = keplr.getOfflineSigner(CHAIN_ID, signOptions);
 const accounts = await offlineSigner.getAccounts();
 
-// Initialize the gaia api with the offline signer that is injected by Keplr extension.
-const cosmJS = new SigningCosmWasmClient(
-    "https://lcd-secret.keplr.app/rest",
-    accounts[0].address,
-    offlineSigner,
-    **enigmaUtils**
-);
+// Retrieve EnigmaUtils for encryption/decryption.
+const enigmaUtils = keplr.getEnigmaUtils(CHAIN_ID);
+
+// Initialize the SecretJS client with Keplr's offline signer and EnigmaUtils.
+const secretjs = new SecretNetworkClient({
+  url,
+  chainId: CHAIN_ID,
+  wallet: offlineSigner,
+  walletAddress: accounts[0].address,
+  encryptionUtils: enigmaUtils,
+});
 ```
 
-### Suggest Adding SNIP-20 Tokens to Keplr
+:::note
+Even when using SecretJS, you can leverage Keplr’s native API to customize signing options. For more details, refer to the [Sign Options](../guide/sign-a-message#sign-options) section.
+:::
+
+---
+
+## Managing SNIP-20 Tokens in Keplr
+
+### Adding a SNIP-20 Token
+To request user permission to add a SNIP-20 token to Keplr's token list, use the following method:
 
 ```javascript
-async suggestToken(chainId: string, contractAddress: string): Promise<void>
+function suggestToken(
+  chainId: string, 
+  contractAddress: string
+): Promise<void>
 ```
+- If the user accepts, the token will be added to their Keplr wallet.
+- If the user rejects, an error will be thrown.
+- If the token is already registered, no action will be taken.
 
-The webpage can request the user permission to add a SNIP-20 token to Keplr's token list. Will throw an error if the user rejects the request.  
-If a SNIP-20 with the same contract address already exists, nothing will happen.
+### Retrieving a SNIP-20 Viewing Key
+To obtain the viewing key of a SNIP-20 token registered in Keplr, use:
 
-### Get SNIP-20 Viewing Key
 ```javascript
 getSecret20ViewingKey(
-    chainId: string,
-    contractAddress: string
+  chainId: string,
+  contractAddress: string
 ): Promise<string>;
 ```
-Returns the viewing key of a SNIP-20 token registered in Keplr.  
-If the SNIP-20 of the contract address doesn't exist, it will throw an error.
-
-### Interaction Options
-You can use Keplr native API’s to set interaction options even when using SecretJS. Please refer to [this section](../guide/sign-a-message#sign-options).
+- Returns the viewing key of the specified SNIP-20 token.
+- Throws an error if the token is not registered in Keplr.

--- a/docs/docs/use-with/secretjs.md
+++ b/docs/docs/use-with/secretjs.md
@@ -1,5 +1,5 @@
 ---
-title: SecretJs
+title: Use with SecretJs
 order: 3
 ---
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -25,6 +25,20 @@ const config: Config = {
 
   staticDirectories: ["public", "static"],
 
+  plugins: [
+    [
+      "@docusaurus/plugin-client-redirects",
+      {
+        redirects: [
+          {
+            from: "/api",
+            to: "/api/intro",
+          },
+        ],
+      },
+    ],
+  ],
+
   presets: [
     [
       "classic",

--- a/docs/package.json
+++ b/docs/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@docusaurus/eslint-plugin": "^3.6.3",
     "@docusaurus/module-type-aliases": "3.6.3",
+    "@docusaurus/plugin-client-redirects": "3.6.3",
     "@docusaurus/tsconfig": "3.6.3",
     "@docusaurus/types": "3.6.3",
     "typescript": "~5.6.2"

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -24,6 +24,14 @@ const sidebars: SidebarsConfig = {
         "getting-started/typescript-support",
       ],
     },
+    // {
+    //   type: "category",
+    //   label: "Use with",
+    //   collapsed: false,
+    //   items: ["use-with/cosmjs", "use-with/secretjs"],
+    // },
+    "use-with/cosmjs",
+    "use-with/secretjs",
     {
       type: "category",
       label: "Guide",
@@ -41,17 +49,11 @@ const sidebars: SidebarsConfig = {
     {
       type: "category",
       label: "Multi-Ecosystem Support",
-      collapsed: true,
+      collapsed: false,
       items: [
         "multi-ecosystem-support/evm",
         "multi-ecosystem-support/starknet",
       ],
-    },
-    {
-      type: "category",
-      label: "Use with",
-      collapsed: true,
-      items: ["use-with/cosmjs", "use-with/secretjs"],
     },
   ],
 };

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -2350,6 +2350,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@docusaurus/plugin-client-redirects@npm:3.6.3":
+  version: 3.6.3
+  resolution: "@docusaurus/plugin-client-redirects@npm:3.6.3"
+  dependencies:
+    "@docusaurus/core": 3.6.3
+    "@docusaurus/logger": 3.6.3
+    "@docusaurus/utils": 3.6.3
+    "@docusaurus/utils-common": 3.6.3
+    "@docusaurus/utils-validation": 3.6.3
+    eta: ^2.2.0
+    fs-extra: ^11.1.1
+    lodash: ^4.17.21
+    tslib: ^2.6.0
+  peerDependencies:
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  checksum: 8c254d976253b55d18ae6f3202f0254e00d0e720ac43a2093993f6004c16a9002000528119dfa707304fb337e3db1f4aaf3ce86225931bfce44cea1d85f044de
+  languageName: node
+  linkType: hard
+
 "@docusaurus/plugin-content-blog@npm:3.6.3":
   version: 3.6.3
   resolution: "@docusaurus/plugin-content-blog@npm:3.6.3"
@@ -5524,6 +5544,7 @@ __metadata:
     "@docusaurus/core": 3.6.3
     "@docusaurus/eslint-plugin": ^3.6.3
     "@docusaurus/module-type-aliases": 3.6.3
+    "@docusaurus/plugin-client-redirects": 3.6.3
     "@docusaurus/preset-classic": ^3.6.3
     "@docusaurus/tsconfig": 3.6.3
     "@docusaurus/types": 3.6.3


### PR DESCRIPTION
### Changes
- Some other docs, referring Keplr docs, still links to old page directory. Redirection config was set in this PR.
- Sidebar orders (Removed `Use with` category)
- Updated contents for CosmJS, SecretJS (polished expressions and improved structures)

needing to do the further updates such as Deeplink page, but I submitted changes for some parts of my lists firstly.

---

### Preview Test

- [CosmJS page update](https://keplr-wallet-extension-git-fork-editaahn-edit-726f8a-chainapsis.vercel.app/api/use-with/cosmjs)
- [SecretJS page update](https://keplr-wallet-extension-git-fork-editaahn-edit-726f8a-chainapsis.vercel.app/api/use-with/secretjs)
- [Redirection test](https://keplr-wallet-extension-git-fork-editaahn-edit-726f8a-chainapsis.vercel.app/api): /api -> /api/intro
  - If I find more to redirect, I'll update this then