### PR TITLE
bridge 전송 로직 추가 - 2 

### DIFF
--- a/apps/extension/src/languages/en.json
+++ b/apps/extension/src/languages/en.json
@@ -471,7 +471,7 @@
   "page.sign.components.messages.redelegate.paragraph": "Switch Validator from <b>{from}</b> to <b>{to}</b> for <b>{coin}</b>",
   "page.sign.components.messages.send.title": "Send",
   "page.sign.components.messages.send.paragraph": "<b>{address}</b> will receive <b>{amount}</b>",
-  "page.sign.components.messages.transfer.title": "IBC Transfer",
+  "page.sign.components.messages.transfer.title": "Cross-Chain Send",
   "page.sign.components.messages.transfer.paragraph": "Send <b>{coin}</b> to <b>{address}</b> via <b>{channelId}</b>",
   "page.sign.components.messages.transfer.forwarding.close-button": "Close",
   "page.sign.components.messages.transfer.forwarding.open-button": "See forwarding data",

--- a/apps/extension/src/languages/ko.json
+++ b/apps/extension/src/languages/ko.json
@@ -455,7 +455,7 @@
   "page.sign.components.messages.redelegate.paragraph": "현재 <b>{from}</b>에게 위임된 <b>{coin}</b>을 <b>{to}</b> 에게 재위임하기.",
   "page.sign.components.messages.send.title": "토큰 전송",
   "page.sign.components.messages.send.paragraph": "<b>{address}</b>가 <b>{amount}</b>를 받습니다.",
-  "page.sign.components.messages.transfer.title": "IBC 전송",
+  "page.sign.components.messages.transfer.title": "크로스 체인 전송",
   "page.sign.components.messages.transfer.paragraph": "채널 <b>{channelId}</b>를 통해 <b>{address}</b>에게 <b>{coin}</b>를 보냅니다.",
   "page.sign.components.messages.transfer.forwarding.close-button": "닫기",
   "page.sign.components.messages.transfer.forwarding.open-button": "포워딩 정보 보기",

--- a/apps/extension/src/languages/zh-cn.json
+++ b/apps/extension/src/languages/zh-cn.json
@@ -439,7 +439,7 @@
   "page.sign.components.messages.redelegate.paragraph": "将<b>{coin}</b>从<b>{from}</b>重新质押给<b>{to}</b>",
   "page.sign.components.messages.send.title": "发送",
   "page.sign.components.messages.send.paragraph": "<b>{address}</b> 将收到 <b>{amount}</b>",
-  "page.sign.components.messages.transfer.title": "IBC转账",
+  "page.sign.components.messages.transfer.title": "跨链发送",
   "page.sign.components.messages.transfer.paragraph": "通过{channelId}将 {coin} 发送到{address}",
   "page.sign.components.messages.transfer.forwarding.close-button": "关闭",
   "page.sign.components.messages.transfer.forwarding.open-button": "查看转发数据",

--- a/apps/extension/src/pages/send/amount/index.tsx
+++ b/apps/extension/src/pages/send/amount/index.tsx
@@ -520,7 +520,11 @@ export const SendAmountPage: FunctionComponent = observer(() => {
     chainId,
     ibcSwapConfigsForBridge,
     ethereumAccountStore,
-    currency
+    currency,
+    {
+      chainId: ibcSwapConfigsForBridge.recipientConfig.chainId,
+      recipient: ibcSwapConfigsForBridge.recipientConfig.value,
+    }
   );
   const txConfigsValidateForBridge = useTxConfigsValidate({
     ...ibcSwapConfigsForBridge,
@@ -980,7 +984,11 @@ export const SendAmountPage: FunctionComponent = observer(() => {
                     uiConfigStore.ibcSwapConfig.slippageNum,
                     // 코스모스 스왑은 스왑베뉴가 무조건 하나라고 해서 일단 처음걸 쓰기로 한다.
                     swapFeeBpsReceiver[0],
-                    priorOutAmount
+                    priorOutAmount,
+                    {
+                      chainId: ibcSwapConfigsForBridge.recipientConfig.chainId,
+                      recipient: ibcSwapConfigsForBridge.recipientConfig.value,
+                    }
                   ),
                 ]);
                 tx = _tx;
@@ -2175,7 +2183,11 @@ function useGetGasSimulationForBridge(
     senderConfig: SenderConfig;
   },
   ethereumAccountStore: EthereumAccountStore,
-  currency: AppCurrency
+  currency: AppCurrency,
+  recipient?: {
+    chainId: string;
+    recipient: string;
+  }
 ) {
   const gasSimulator = useGasSimulator(
     new ExtensionKVStore("gas-simulator.ibc-swap.swap"),
@@ -2320,7 +2332,8 @@ function useGetGasSimulationForBridge(
         // simulation 자체는 쉽게 통과시키기 위해서 슬리피지를 50으로 설정한다.
         50,
         // 코스모스 스왑은 스왑베뉴가 무조건 하나라고 해서 일단 처음걸 쓰기로 한다.
-        swapFeeBpsReceiver[0]
+        swapFeeBpsReceiver[0],
+        recipient
       );
 
       if (!tx) {

--- a/apps/extension/src/pages/send/amount/index.tsx
+++ b/apps/extension/src/pages/send/amount/index.tsx
@@ -467,6 +467,13 @@ export const SendAmountPage: FunctionComponent = observer(() => {
     ? queryBalances.getQueryEthereumHexAddress(sender).getBalance(currency)
     : queryBalances.getQueryBech32Address(sender).getBalance(currency);
 
+  const isDestinationEvmChain = chainStore.isEvmChain(
+    destinationChainInfoOfBridge.chainId
+  );
+  const isDestinationEvmOnlyChain = chainStore.isEvmOnlyChain(
+    destinationChainInfoOfBridge.chainId
+  );
+
   const ibcSwapConfigsForBridge = useIBCSwapConfigWithRecipientConfig(
     chainStore,
     queriesStore,
@@ -482,10 +489,10 @@ export const SendAmountPage: FunctionComponent = observer(() => {
     0,
     {
       allowHexAddressToBech32Address:
-        !isEvmChain &&
-        !isEvmTx &&
+        isDestinationEvmChain &&
+        !isDestinationEvmOnlyChain &&
         !chainStore.getChain(chainId).chainId.startsWith("injective"),
-      allowHexAddressOnly: sendType === "bridge",
+      allowHexAddressOnly: isDestinationEvmOnlyChain,
       icns: ICNSInfo,
       ens: ENSInfo,
       computeTerraClassicTax: true,

--- a/apps/extension/src/pages/send/amount/index.tsx
+++ b/apps/extension/src/pages/send/amount/index.tsx
@@ -388,7 +388,10 @@ const useIBCSwapConfigWithRecipientConfig = (
     outChainId,
     outCurrency,
     swapFeeBps,
-    isAllowSwaps
+    isAllowSwaps,
+    {
+      evmSwaps: false,
+    }
   );
   const channelConfig = useIBCChannelConfig(false);
 

--- a/apps/extension/src/pages/send/amount/index.tsx
+++ b/apps/extension/src/pages/send/amount/index.tsx
@@ -97,8 +97,8 @@ import {
 import {
   EthereumAccountBase,
   EthereumAccountStore,
+  UnsignedEVMTransaction,
   UnsignedEVMTransactionWithErc20Approvals,
-  // UnsignedEVMTransactionWithErc20Approvals,
 } from "@keplr-wallet/stores-eth";
 import { autorun } from "mobx";
 import { usePreviousDistinct } from "../../../hooks/use-previous";
@@ -881,6 +881,8 @@ export const SendAmountPage: FunctionComponent = observer(() => {
         e.preventDefault();
 
         if (!interactionBlocked) {
+          let hasApprovalTxWhenBridge = false;
+
           try {
             if (sendType === "bridge") {
               let tx: MakeTxResponse | UnsignedEVMTransactionWithErc20Approvals;
@@ -1238,10 +1240,6 @@ export const SendAmountPage: FunctionComponent = observer(() => {
                             outCurrency.coinMinimalDenom,
                           out_currency_denom: outCurrency.coinDenom,
                         });
-
-                        navigate("/", {
-                          replace: true,
-                        });
                       },
                       onFulfill: (tx: any) => {
                         if (tx.code != null && tx.code !== 0) {
@@ -1268,325 +1266,356 @@ export const SendAmountPage: FunctionComponent = observer(() => {
                     }
                   );
                 } else {
-                  // const ethereumAccount = ethereumAccountStore.getAccount(
-                  //   ibcSwapConfigs.amountConfig.chainId
-                  // );
-                  // const sender = ibcSwapConfigs.senderConfig.sender;
-                  // const isErc20InCurrency =
-                  //   ("type" in inCurrency && inCurrency.type === "erc20") ||
-                  //   inCurrency.coinMinimalDenom.startsWith("erc20:");
-                  // const erc20Approval = tx.requiredErc20Approvals?.[0];
-                  // const erc20ApprovalTx =
-                  //   erc20Approval && isErc20InCurrency
-                  //     ? ethereumAccount.makeErc20ApprovalTx(
-                  //         {
-                  //           ...inCurrency,
-                  //           type: "erc20",
-                  //           contractAddress:
-                  //             inCurrency.coinMinimalDenom.replace("erc20:", ""),
-                  //         },
-                  //         erc20Approval.spender,
-                  //         erc20Approval.amount
-                  //       )
-                  //     : undefined;
-                  // const { maxFeePerGas, maxPriorityFeePerGas, gasPrice } =
-                  //   ibcSwapConfigs.feeConfig.getEIP1559TxFees(
-                  //     ibcSwapConfigs.feeConfig.type
-                  //   );
-                  // const feeObject =
-                  //   maxFeePerGas && maxPriorityFeePerGas
-                  //     ? {
-                  //         type: 2,
-                  //         maxFeePerGas: `0x${BigInt(
-                  //           maxFeePerGas.truncate().toString()
-                  //         ).toString(16)}`,
-                  //         maxPriorityFeePerGas: `0x${BigInt(
-                  //           maxPriorityFeePerGas.truncate().toString()
-                  //         ).toString(16)}`,
-                  //         gasLimit: `0x${ibcSwapConfigs.gasConfig.gas.toString(
-                  //           16
-                  //         )}`,
-                  //       }
-                  //     : {
-                  //         gasPrice: `0x${BigInt(
-                  //           gasPrice.truncate().toString()
-                  //         ).toString(16)}`,
-                  //         gasLimit: `0x${ibcSwapConfigs.gasConfig.gas.toString(
-                  //           16
-                  //         )}`,
-                  //       };
-                  // ethereumAccount.setIsSendingTx(true);
-                  // await ethereumAccount.sendEthereumTx(
-                  //   sender,
-                  //   {
-                  //     ...(erc20ApprovalTx ?? tx),
-                  //     ...feeObject,
-                  //   },
-                  //   {
-                  //     onBroadcasted: (txHash) => {
-                  //       if (!erc20ApprovalTx) {
-                  //         ethereumAccount.setIsSendingTx(false);
-                  //         const msg = new RecordTxWithSkipSwapMsg(
-                  //           inChainId,
-                  //           outChainId,
-                  //           {
-                  //             chainId: outChainId,
-                  //             denom: outCurrency.coinMinimalDenom,
-                  //             expectedAmount:
-                  //               ibcSwapConfigs.amountConfig.outAmount
-                  //                 .toDec()
-                  //                 .toString(),
-                  //           },
-                  //           simpleRoute,
-                  //           sender,
-                  //           chainStore.isEvmOnlyChain(outChainId)
-                  //             ? accountStore.getAccount(outChainId)
-                  //                 .ethereumHexAddress
-                  //             : accountStore.getAccount(outChainId)
-                  //                 .bech32Address,
-                  //           [
-                  //             ...ibcSwapConfigs.amountConfig.amount.map(
-                  //               (amount) => {
-                  //                 return {
-                  //                   amount: DecUtils.getTenExponentN(
-                  //                     amount.currency.coinDecimals
-                  //                   )
-                  //                     .mul(amount.toDec())
-                  //                     .toString(),
-                  //                   denom: amount.currency.coinMinimalDenom,
-                  //                 };
-                  //               }
-                  //             ),
-                  //             {
-                  //               amount: DecUtils.getTenExponentN(
-                  //                 ibcSwapConfigs.amountConfig.outAmount.currency
-                  //                   .coinDecimals
-                  //               )
-                  //                 .mul(
-                  //                   ibcSwapConfigs.amountConfig.outAmount.toDec()
-                  //                 )
-                  //                 .toString(),
-                  //               denom:
-                  //                 ibcSwapConfigs.amountConfig.outAmount.currency
-                  //                   .coinMinimalDenom,
-                  //             },
-                  //           ],
-                  //           {
-                  //             currencies:
-                  //               chainStore.getChain(outChainId).currencies,
-                  //           },
-                  //           routeDurationSeconds ?? 0,
-                  //           txHash
-                  //         );
-                  //         new InExtensionMessageRequester().sendMessage(
-                  //           BACKGROUND_PORT,
-                  //           msg
-                  //         );
-                  //         navigate("/", {
-                  //           replace: true,
-                  //         });
-                  //       }
-                  //     },
-                  //     onFulfill: (txReceipt) => {
-                  //       const queryBalances = queriesStore.get(
-                  //         ibcSwapConfigs.amountConfig.chainId
-                  //       ).queryBalances;
-                  //       queryBalances
-                  //         .getQueryEthereumHexAddress(sender)
-                  //         .balances.forEach((balance) => {
-                  //           if (
-                  //             balance.currency.coinMinimalDenom ===
-                  //               ibcSwapConfigs.amountConfig.currency
-                  //                 .coinMinimalDenom ||
-                  //             ibcSwapConfigs.feeConfig.fees.some(
-                  //               (fee) =>
-                  //                 fee.currency.coinMinimalDenom ===
-                  //                 balance.currency.coinMinimalDenom
-                  //             )
-                  //           ) {
-                  //             balance.fetch();
-                  //           }
-                  //         });
-                  //       if (txReceipt.status === EthTxStatus.Success) {
-                  //         notification.show(
-                  //           "success",
-                  //           intl.formatMessage({
-                  //             id: "notification.transaction-success",
-                  //           }),
-                  //           ""
-                  //         );
-                  //         if (erc20ApprovalTx) {
-                  //           delete (
-                  //             tx as UnsignedEVMTransactionWithErc20Approvals
-                  //           ).requiredErc20Approvals;
-                  //           ethereumAccount.setIsSendingTx(true);
-                  //           ethereumAccount
-                  //             .simulateGas(sender, tx as UnsignedEVMTransaction)
-                  //             .then(({ gasUsed }) => {
-                  //               const {
-                  //                 maxFeePerGas,
-                  //                 maxPriorityFeePerGas,
-                  //                 gasPrice,
-                  //               } = ibcSwapConfigs.feeConfig.getEIP1559TxFees(
-                  //                 ibcSwapConfigs.feeConfig.type
-                  //               );
-                  //               const feeObject =
-                  //                 maxFeePerGas && maxPriorityFeePerGas
-                  //                   ? {
-                  //                       type: 2,
-                  //                       maxFeePerGas: `0x${BigInt(
-                  //                         maxFeePerGas.truncate().toString()
-                  //                       ).toString(16)}`,
-                  //                       maxPriorityFeePerGas: `0x${BigInt(
-                  //                         maxPriorityFeePerGas
-                  //                           .truncate()
-                  //                           .toString()
-                  //                       ).toString(16)}`,
-                  //                       gasLimit: `0x${gasUsed.toString(16)}`,
-                  //                     }
-                  //                   : {
-                  //                       gasPrice: `0x${BigInt(
-                  //                         gasPrice.truncate().toString()
-                  //                       ).toString(16)}`,
-                  //                       gasLimit: `0x${gasUsed.toString(16)}`,
-                  //                     };
-                  //               ethereumAccount.sendEthereumTx(
-                  //                 sender,
-                  //                 {
-                  //                   ...(tx as UnsignedEVMTransactionWithErc20Approvals),
-                  //                   ...feeObject,
-                  //                 },
-                  //                 {
-                  //                   onBroadcasted: (txHash) => {
-                  //                     ethereumAccount.setIsSendingTx(false);
-                  //                     const msg = new RecordTxWithSkipSwapMsg(
-                  //                       inChainId,
-                  //                       outChainId,
-                  //                       {
-                  //                         chainId: outChainId,
-                  //                         denom: outCurrency.coinMinimalDenom,
-                  //                         expectedAmount:
-                  //                           ibcSwapConfigs.amountConfig.outAmount
-                  //                             .toDec()
-                  //                             .toString(),
-                  //                       },
-                  //                       simpleRoute,
-                  //                       sender,
-                  //                       chainStore.isEvmOnlyChain(outChainId)
-                  //                         ? accountStore.getAccount(outChainId)
-                  //                             .ethereumHexAddress
-                  //                         : accountStore.getAccount(outChainId)
-                  //                             .bech32Address,
-                  //                       [
-                  //                         ...ibcSwapConfigs.amountConfig.amount.map(
-                  //                           (amount) => {
-                  //                             return {
-                  //                               amount:
-                  //                                 DecUtils.getTenExponentN(
-                  //                                   amount.currency.coinDecimals
-                  //                                 )
-                  //                                   .mul(amount.toDec())
-                  //                                   .toString(),
-                  //                               denom:
-                  //                                 amount.currency
-                  //                                   .coinMinimalDenom,
-                  //                             };
-                  //                           }
-                  //                         ),
-                  //                         {
-                  //                           amount: DecUtils.getTenExponentN(
-                  //                             ibcSwapConfigs.amountConfig
-                  //                               .outAmount.currency.coinDecimals
-                  //                           )
-                  //                             .mul(
-                  //                               ibcSwapConfigs.amountConfig.outAmount.toDec()
-                  //                             )
-                  //                             .toString(),
-                  //                           denom:
-                  //                             ibcSwapConfigs.amountConfig
-                  //                               .outAmount.currency
-                  //                               .coinMinimalDenom,
-                  //                         },
-                  //                       ],
-                  //                       {
-                  //                         currencies:
-                  //                           chainStore.getChain(outChainId)
-                  //                             .currencies,
-                  //                       },
-                  //                       routeDurationSeconds ?? 0,
-                  //                       txHash
-                  //                     );
-                  //                     new InExtensionMessageRequester().sendMessage(
-                  //                       BACKGROUND_PORT,
-                  //                       msg
-                  //                     );
-                  //                     navigate("/", {
-                  //                       replace: true,
-                  //                     });
-                  //                   },
-                  //                   onFulfill: (txReceipt) => {
-                  //                     const queryBalances = queriesStore.get(
-                  //                       ibcSwapConfigs.amountConfig.chainId
-                  //                     ).queryBalances;
-                  //                     queryBalances
-                  //                       .getQueryEthereumHexAddress(sender)
-                  //                       .balances.forEach((balance) => {
-                  //                         if (
-                  //                           balance.currency
-                  //                             .coinMinimalDenom ===
-                  //                             ibcSwapConfigs.amountConfig
-                  //                               .currency.coinMinimalDenom ||
-                  //                           ibcSwapConfigs.feeConfig.fees.some(
-                  //                             (fee) =>
-                  //                               fee.currency
-                  //                                 .coinMinimalDenom ===
-                  //                               balance.currency
-                  //                                 .coinMinimalDenom
-                  //                           )
-                  //                         ) {
-                  //                           balance.fetch();
-                  //                         }
-                  //                       });
-                  //                     if (
-                  //                       txReceipt.status === EthTxStatus.Success
-                  //                     ) {
-                  //                       notification.show(
-                  //                         "success",
-                  //                         intl.formatMessage({
-                  //                           id: "notification.transaction-success",
-                  //                         }),
-                  //                         ""
-                  //                       );
-                  //                     } else {
-                  //                       notification.show(
-                  //                         "failed",
-                  //                         intl.formatMessage({
-                  //                           id: "error.transaction-failed",
-                  //                         }),
-                  //                         ""
-                  //                       );
-                  //                     }
-                  //                   },
-                  //                 }
-                  //               );
-                  //             })
-                  //             .catch((e) => {
-                  //               console.log(e);
-                  //               ethereumAccount.setIsSendingTx(false);
-                  //             });
-                  //         }
-                  //       } else {
-                  //         notification.show(
-                  //           "failed",
-                  //           intl.formatMessage({
-                  //             id: "error.transaction-failed",
-                  //           }),
-                  //           ""
-                  //         );
-                  //       }
-                  //     },
-                  //   }
-                  // );
+                  const ethereumAccount = ethereumAccountStore.getAccount(
+                    ibcSwapConfigsForBridge.amountConfig.chainId
+                  );
+                  const sender = ibcSwapConfigsForBridge.senderConfig.sender;
+
+                  const inCurrency =
+                    ibcSwapConfigsForBridge.amountConfig.currency;
+                  const inChainId =
+                    ibcSwapConfigsForBridge.amountConfig.chainId;
+                  const outChainId =
+                    ibcSwapConfigsForBridge.amountConfig.outChainId;
+                  const outCurrency =
+                    ibcSwapConfigsForBridge.amountConfig.outCurrency;
+
+                  const isErc20InCurrency =
+                    ("type" in inCurrency && inCurrency.type === "erc20") ||
+                    inCurrency.coinMinimalDenom.startsWith("erc20:");
+                  const erc20Approval = tx.requiredErc20Approvals?.[0];
+                  const erc20ApprovalTx =
+                    erc20Approval && isErc20InCurrency
+                      ? ethereumAccount.makeErc20ApprovalTx(
+                          {
+                            ...inCurrency,
+                            type: "erc20",
+                            contractAddress:
+                              inCurrency.coinMinimalDenom.replace("erc20:", ""),
+                          },
+                          erc20Approval.spender,
+                          erc20Approval.amount
+                        )
+                      : undefined;
+
+                  const { maxFeePerGas, maxPriorityFeePerGas, gasPrice } =
+                    ibcSwapConfigsForBridge.feeConfig.getEIP1559TxFees(
+                      ibcSwapConfigsForBridge.feeConfig.type
+                    );
+
+                  const feeObject =
+                    maxFeePerGas && maxPriorityFeePerGas
+                      ? {
+                          type: 2,
+                          maxFeePerGas: `0x${BigInt(
+                            maxFeePerGas.truncate().toString()
+                          ).toString(16)}`,
+                          maxPriorityFeePerGas: `0x${BigInt(
+                            maxPriorityFeePerGas.truncate().toString()
+                          ).toString(16)}`,
+                          gasLimit: `0x${ibcSwapConfigsForBridge.gasConfig.gas.toString(
+                            16
+                          )}`,
+                        }
+                      : {
+                          gasPrice: `0x${BigInt(
+                            gasPrice.truncate().toString()
+                          ).toString(16)}`,
+                          gasLimit: `0x${ibcSwapConfigsForBridge.gasConfig.gas.toString(
+                            16
+                          )}`,
+                        };
+                  ethereumAccount.setIsSendingTx(true);
+
+                  if (erc20ApprovalTx) {
+                    hasApprovalTxWhenBridge = true;
+                  }
+
+                  await ethereumAccount.sendEthereumTx(
+                    sender,
+                    {
+                      ...(erc20ApprovalTx ?? tx),
+                      ...feeObject,
+                    },
+                    {
+                      onBroadcasted: (txHash) => {
+                        if (!erc20ApprovalTx) {
+                          ethereumAccount.setIsSendingTx(false);
+                          const msg = new RecordTxWithSkipSwapMsg(
+                            inChainId,
+                            outChainId,
+                            {
+                              chainId: outChainId,
+                              denom: outCurrency.coinMinimalDenom,
+                              expectedAmount:
+                                ibcSwapConfigsForBridge.amountConfig.outAmount
+                                  .toDec()
+                                  .toString(),
+                            },
+                            simpleRoute,
+                            sender,
+                            chainStore.isEvmOnlyChain(outChainId)
+                              ? accountStore.getAccount(outChainId)
+                                  .ethereumHexAddress
+                              : accountStore.getAccount(outChainId)
+                                  .bech32Address,
+                            [
+                              ...ibcSwapConfigsForBridge.amountConfig.amount.map(
+                                (amount) => {
+                                  return {
+                                    amount: DecUtils.getTenExponentN(
+                                      amount.currency.coinDecimals
+                                    )
+                                      .mul(amount.toDec())
+                                      .toString(),
+                                    denom: amount.currency.coinMinimalDenom,
+                                  };
+                                }
+                              ),
+                              {
+                                amount: DecUtils.getTenExponentN(
+                                  ibcSwapConfigsForBridge.amountConfig.outAmount
+                                    .currency.coinDecimals
+                                )
+                                  .mul(
+                                    ibcSwapConfigsForBridge.amountConfig.outAmount.toDec()
+                                  )
+                                  .toString(),
+                                denom:
+                                  ibcSwapConfigsForBridge.amountConfig.outAmount
+                                    .currency.coinMinimalDenom,
+                              },
+                            ],
+                            {
+                              currencies:
+                                chainStore.getChain(outChainId).currencies,
+                            },
+                            routeDurationSeconds ?? 0,
+                            txHash
+                          );
+                          new InExtensionMessageRequester().sendMessage(
+                            BACKGROUND_PORT,
+                            msg
+                          );
+
+                          if (!isDetachedMode) {
+                            navigate("/", {
+                              replace: true,
+                            });
+                          } else {
+                            window.close();
+                          }
+                        }
+                      },
+                      onFulfill: (txReceipt) => {
+                        const queryBalances = queriesStore.get(
+                          ibcSwapConfigsForBridge.amountConfig.chainId
+                        ).queryBalances;
+                        queryBalances
+                          .getQueryEthereumHexAddress(sender)
+                          .balances.forEach((balance) => {
+                            if (
+                              balance.currency.coinMinimalDenom ===
+                                ibcSwapConfigsForBridge.amountConfig.currency
+                                  .coinMinimalDenom ||
+                              ibcSwapConfigsForBridge.feeConfig.fees.some(
+                                (fee) =>
+                                  fee.currency.coinMinimalDenom ===
+                                  balance.currency.coinMinimalDenom
+                              )
+                            ) {
+                              balance.fetch();
+                            }
+                          });
+                        if (txReceipt.status === EthTxStatus.Success) {
+                          notification.show(
+                            "success",
+                            intl.formatMessage({
+                              id: "notification.transaction-success",
+                            }),
+                            ""
+                          );
+                          if (erc20ApprovalTx) {
+                            delete (
+                              tx as UnsignedEVMTransactionWithErc20Approvals
+                            ).requiredErc20Approvals;
+                            ethereumAccount.setIsSendingTx(true);
+                            ethereumAccount
+                              .simulateGas(sender, tx as UnsignedEVMTransaction)
+                              .then(({ gasUsed }) => {
+                                const {
+                                  maxFeePerGas,
+                                  maxPriorityFeePerGas,
+                                  gasPrice,
+                                } =
+                                  ibcSwapConfigsForBridge.feeConfig.getEIP1559TxFees(
+                                    ibcSwapConfigsForBridge.feeConfig.type
+                                  );
+                                const feeObject =
+                                  maxFeePerGas && maxPriorityFeePerGas
+                                    ? {
+                                        type: 2,
+                                        maxFeePerGas: `0x${BigInt(
+                                          maxFeePerGas.truncate().toString()
+                                        ).toString(16)}`,
+                                        maxPriorityFeePerGas: `0x${BigInt(
+                                          maxPriorityFeePerGas
+                                            .truncate()
+                                            .toString()
+                                        ).toString(16)}`,
+                                        gasLimit: `0x${gasUsed.toString(16)}`,
+                                      }
+                                    : {
+                                        gasPrice: `0x${BigInt(
+                                          gasPrice.truncate().toString()
+                                        ).toString(16)}`,
+                                        gasLimit: `0x${gasUsed.toString(16)}`,
+                                      };
+                                ethereumAccount.sendEthereumTx(
+                                  sender,
+                                  {
+                                    ...(tx as UnsignedEVMTransactionWithErc20Approvals),
+                                    ...feeObject,
+                                  },
+                                  {
+                                    onBroadcasted: (txHash) => {
+                                      ethereumAccount.setIsSendingTx(false);
+                                      const msg = new RecordTxWithSkipSwapMsg(
+                                        inChainId,
+                                        outChainId,
+                                        {
+                                          chainId: outChainId,
+                                          denom: outCurrency.coinMinimalDenom,
+                                          expectedAmount:
+                                            ibcSwapConfigsForBridge.amountConfig.outAmount
+                                              .toDec()
+                                              .toString(),
+                                        },
+                                        simpleRoute,
+                                        sender,
+                                        chainStore.isEvmOnlyChain(outChainId)
+                                          ? accountStore.getAccount(outChainId)
+                                              .ethereumHexAddress
+                                          : accountStore.getAccount(outChainId)
+                                              .bech32Address,
+                                        [
+                                          ...ibcSwapConfigsForBridge.amountConfig.amount.map(
+                                            (amount) => {
+                                              return {
+                                                amount:
+                                                  DecUtils.getTenExponentN(
+                                                    amount.currency.coinDecimals
+                                                  )
+                                                    .mul(amount.toDec())
+                                                    .toString(),
+                                                denom:
+                                                  amount.currency
+                                                    .coinMinimalDenom,
+                                              };
+                                            }
+                                          ),
+                                          {
+                                            amount: DecUtils.getTenExponentN(
+                                              ibcSwapConfigsForBridge
+                                                .amountConfig.outAmount.currency
+                                                .coinDecimals
+                                            )
+                                              .mul(
+                                                ibcSwapConfigsForBridge.amountConfig.outAmount.toDec()
+                                              )
+                                              .toString(),
+                                            denom:
+                                              ibcSwapConfigsForBridge
+                                                .amountConfig.outAmount.currency
+                                                .coinMinimalDenom,
+                                          },
+                                        ],
+                                        {
+                                          currencies:
+                                            chainStore.getChain(outChainId)
+                                              .currencies,
+                                        },
+                                        routeDurationSeconds ?? 0,
+                                        txHash
+                                      );
+                                      new InExtensionMessageRequester().sendMessage(
+                                        BACKGROUND_PORT,
+                                        msg
+                                      );
+
+                                      if (!isDetachedMode) {
+                                        navigate("/", {
+                                          replace: true,
+                                        });
+                                      } else {
+                                        window.close();
+                                      }
+                                    },
+                                    onFulfill: (txReceipt) => {
+                                      const queryBalances = queriesStore.get(
+                                        ibcSwapConfigsForBridge.amountConfig
+                                          .chainId
+                                      ).queryBalances;
+                                      queryBalances
+                                        .getQueryEthereumHexAddress(sender)
+                                        .balances.forEach((balance) => {
+                                          if (
+                                            balance.currency
+                                              .coinMinimalDenom ===
+                                              ibcSwapConfigsForBridge
+                                                .amountConfig.currency
+                                                .coinMinimalDenom ||
+                                            ibcSwapConfigsForBridge.feeConfig.fees.some(
+                                              (fee) =>
+                                                fee.currency
+                                                  .coinMinimalDenom ===
+                                                balance.currency
+                                                  .coinMinimalDenom
+                                            )
+                                          ) {
+                                            balance.fetch();
+                                          }
+                                        });
+                                      if (
+                                        txReceipt.status === EthTxStatus.Success
+                                      ) {
+                                        notification.show(
+                                          "success",
+                                          intl.formatMessage({
+                                            id: "notification.transaction-success",
+                                          }),
+                                          ""
+                                        );
+                                      } else {
+                                        notification.show(
+                                          "failed",
+                                          intl.formatMessage({
+                                            id: "error.transaction-failed",
+                                          }),
+                                          ""
+                                        );
+                                      }
+                                    },
+                                  }
+                                );
+                              })
+                              .catch((e) => {
+                                console.log(e);
+                                ethereumAccount.setIsSendingTx(false);
+                              });
+                          }
+                        } else {
+                          notification.show(
+                            "failed",
+                            intl.formatMessage({
+                              id: "error.transaction-failed",
+                            }),
+                            ""
+                          );
+                        }
+                      },
+                    }
+                  );
                 }
               } catch (e) {
                 if (e?.message === "Request rejected") {
@@ -1599,9 +1628,13 @@ export const SendAmountPage: FunctionComponent = observer(() => {
                   intl.formatMessage({ id: "error.transaction-failed" }),
                   ""
                 );
-                navigate("/", {
-                  replace: true,
-                });
+                if (!isDetachedMode) {
+                  navigate("/", {
+                    replace: true,
+                  });
+                } else {
+                  window.close();
+                }
               } finally {
                 // setIsTxLoading(false);
               }
@@ -1912,6 +1945,12 @@ export const SendAmountPage: FunctionComponent = observer(() => {
                   },
                 }
               );
+            }
+
+            //NOTE - For evmTx on bridge, erc20 approve may be present, in which case evm tx processing will handle navigation,
+            // so using early return here
+            if (hasApprovalTxWhenBridge) {
+              return;
             }
 
             if (!isDetachedMode) {

--- a/apps/extension/src/pages/send/amount/index.tsx
+++ b/apps/extension/src/pages/send/amount/index.tsx
@@ -66,11 +66,7 @@ import { useIBCChannelConfigQueryString } from "../../../hooks/use-ibc-channel-c
 import { VerticalCollapseTransition } from "../../../components/transition/vertical-collapse";
 import { GuideBox } from "../../../components/guide-box";
 import { ChainIdHelper } from "@keplr-wallet/cosmos";
-import {
-  amountToAmbiguousAverage,
-  amountToAmbiguousString,
-  isRunningInSidePanel,
-} from "../../../utils";
+import { amountToAmbiguousAverage, isRunningInSidePanel } from "../../../utils";
 import { AppCurrency, EthTxStatus } from "@keplr-wallet/types";
 import {
   IBCSwapAmountConfig,
@@ -1049,7 +1045,7 @@ export const SendAmountPage: FunctionComponent = observer(() => {
                             currencies:
                               chainStore.getChain(outChainId).currencies,
                           },
-                          false // bridge의 경우 무조건 interChainSwap이므로 무조건 false
+                          false // bridge의 경우 무조건 interChainSwap이므로 무조건 false, 정확히는 swap이 아니지만 swap 페이지에서 그렇게 적혀있어서 해당 용어로 사용
                         );
 
                         return await new InExtensionMessageRequester().sendMessage(
@@ -1062,8 +1058,7 @@ export const SendAmountPage: FunctionComponent = observer(() => {
                       onBroadcasted: (txHash) => {
                         const inChainId =
                           ibcSwapConfigsForBridge.amountConfig.chainId;
-                        const inCurrency =
-                          ibcSwapConfigsForBridge.amountConfig.currency;
+
                         const outChainId =
                           ibcSwapConfigsForBridge.amountConfig.outChainId;
                         const outCurrency =
@@ -1126,123 +1121,124 @@ export const SendAmountPage: FunctionComponent = observer(() => {
                           msg
                         );
 
-                        const params: Record<
-                          string,
-                          | number
-                          | string
-                          | boolean
-                          | number[]
-                          | string[]
-                          | undefined
-                        > = {
-                          inChainId: inChainId,
-                          inChainIdentifier:
-                            ChainIdHelper.parse(inChainId).identifier,
-                          inCurrencyMinimalDenom: inCurrency.coinMinimalDenom,
-                          inCurrencyDenom: inCurrency.coinDenom,
-                          inCurrencyCommonMinimalDenom:
-                            inCurrency.coinMinimalDenom,
-                          inCurrencyCommonDenom: inCurrency.coinDenom,
-                          outChainId: outChainId,
-                          outChainIdentifier:
-                            ChainIdHelper.parse(outChainId).identifier,
-                          outCurrencyMinimalDenom: outCurrency.coinMinimalDenom,
-                          outCurrencyDenom: outCurrency.coinDenom,
-                          outCurrencyCommonMinimalDenom:
-                            outCurrency.coinMinimalDenom,
-                          outCurrencyCommonDenom: outCurrency.coinDenom,
-                          swapType: ibcSwapConfigsForBridge.amountConfig.type,
-                        };
-                        if (
-                          "originChainId" in inCurrency &&
-                          inCurrency.originChainId
-                        ) {
-                          const originChainId = inCurrency.originChainId;
-                          params["inOriginChainId"] = originChainId;
-                          params["inOriginChainIdentifier"] =
-                            ChainIdHelper.parse(originChainId).identifier;
+                        //NOTE - GA에서 어떤 제목으로 기록할지가 먼저 필요함 그 이후 해당 로직 주석 제가 필요
+                        // const params: Record<
+                        //   string,
+                        //   | number
+                        //   | string
+                        //   | boolean
+                        //   | number[]
+                        //   | string[]
+                        //   | undefined
+                        // > = {
+                        //   inChainId: inChainId,
+                        //   inChainIdentifier:
+                        //     ChainIdHelper.parse(inChainId).identifier,
+                        //   inCurrencyMinimalDenom: inCurrency.coinMinimalDenom,
+                        //   inCurrencyDenom: inCurrency.coinDenom,
+                        //   inCurrencyCommonMinimalDenom:
+                        //     inCurrency.coinMinimalDenom,
+                        //   inCurrencyCommonDenom: inCurrency.coinDenom,
+                        //   outChainId: outChainId,
+                        //   outChainIdentifier:
+                        //     ChainIdHelper.parse(outChainId).identifier,
+                        //   outCurrencyMinimalDenom: outCurrency.coinMinimalDenom,
+                        //   outCurrencyDenom: outCurrency.coinDenom,
+                        //   outCurrencyCommonMinimalDenom:
+                        //     outCurrency.coinMinimalDenom,
+                        //   outCurrencyCommonDenom: outCurrency.coinDenom,
+                        //   swapType: ibcSwapConfigsForBridge.amountConfig.type,
+                        // };
+                        // if (
+                        //   "originChainId" in inCurrency &&
+                        //   inCurrency.originChainId
+                        // ) {
+                        //   const originChainId = inCurrency.originChainId;
+                        //   params["inOriginChainId"] = originChainId;
+                        //   params["inOriginChainIdentifier"] =
+                        //     ChainIdHelper.parse(originChainId).identifier;
 
-                          params["inToDifferentChain"] = true;
-                        }
-                        if (
-                          "originCurrency" in inCurrency &&
-                          inCurrency.originCurrency
-                        ) {
-                          params["inCurrencyCommonMinimalDenom"] =
-                            inCurrency.originCurrency.coinMinimalDenom;
-                          params["inCurrencyCommonDenom"] =
-                            inCurrency.originCurrency.coinDenom;
-                        }
-                        if (
-                          "originChainId" in outCurrency &&
-                          outCurrency.originChainId
-                        ) {
-                          const originChainId = outCurrency.originChainId;
-                          params["outOriginChainId"] = originChainId;
-                          params["outOriginChainIdentifier"] =
-                            ChainIdHelper.parse(originChainId).identifier;
+                        //   params["inToDifferentChain"] = true;
+                        // }
+                        // if (
+                        //   "originCurrency" in inCurrency &&
+                        //   inCurrency.originCurrency
+                        // ) {
+                        //   params["inCurrencyCommonMinimalDenom"] =
+                        //     inCurrency.originCurrency.coinMinimalDenom;
+                        //   params["inCurrencyCommonDenom"] =
+                        //     inCurrency.originCurrency.coinDenom;
+                        // }
+                        // if (
+                        //   "originChainId" in outCurrency &&
+                        //   outCurrency.originChainId
+                        // ) {
+                        //   const originChainId = outCurrency.originChainId;
+                        //   params["outOriginChainId"] = originChainId;
+                        //   params["outOriginChainIdentifier"] =
+                        //     ChainIdHelper.parse(originChainId).identifier;
 
-                          params["outToDifferentChain"] = true;
-                        }
-                        if (
-                          "originCurrency" in outCurrency &&
-                          outCurrency.originCurrency
-                        ) {
-                          params["outCurrencyCommonMinimalDenom"] =
-                            outCurrency.originCurrency.coinMinimalDenom;
-                          params["outCurrencyCommonDenom"] =
-                            outCurrency.originCurrency.coinDenom;
-                        }
-                        params["inRange"] = amountToAmbiguousString(
-                          ibcSwapConfigsForBridge.amountConfig.amount[0]
-                        );
-                        params["outRange"] = amountToAmbiguousString(
-                          ibcSwapConfigsForBridge.amountConfig.outAmount
-                        );
+                        //   params["outToDifferentChain"] = true;
+                        // }
+                        // if (
+                        //   "originCurrency" in outCurrency &&
+                        //   outCurrency.originCurrency
+                        // ) {
+                        //   params["outCurrencyCommonMinimalDenom"] =
+                        //     outCurrency.originCurrency.coinMinimalDenom;
+                        //   params["outCurrencyCommonDenom"] =
+                        //     outCurrency.originCurrency.coinDenom;
+                        // }
+                        // params["inRange"] = amountToAmbiguousString(
+                        //   ibcSwapConfigsForBridge.amountConfig.amount[0]
+                        // );
+                        // params["outRange"] = amountToAmbiguousString(
+                        //   ibcSwapConfigsForBridge.amountConfig.outAmount
+                        // );
 
-                        // UI 상에서 in currency의 가격은 in input에서 표시되고
-                        // out currency의 가격은 swap fee에서 표시된다.
-                        // price store에서 usd는 무조건 쿼리하므로 in, out currency의 usd는 보장된다.
-                        const inCurrencyPrice = priceStore.calculatePrice(
-                          ibcSwapConfigsForBridge.amountConfig.amount[0],
-                          "usd"
-                        );
-                        if (inCurrencyPrice) {
-                          params["inFiatRange"] =
-                            amountToAmbiguousString(inCurrencyPrice);
-                          params["inFiatAvg"] =
-                            amountToAmbiguousAverage(inCurrencyPrice);
-                        }
-                        const outCurrencyPrice = priceStore.calculatePrice(
-                          ibcSwapConfigsForBridge.amountConfig.outAmount,
-                          "usd"
-                        );
-                        if (outCurrencyPrice) {
-                          params["outFiatRange"] =
-                            amountToAmbiguousString(outCurrencyPrice);
-                          params["outFiatAvg"] =
-                            amountToAmbiguousAverage(outCurrencyPrice);
-                        }
+                        // // UI 상에서 in currency의 가격은 in input에서 표시되고
+                        // // out currency의 가격은 swap fee에서 표시된다.
+                        // // price store에서 usd는 무조건 쿼리하므로 in, out currency의 usd는 보장된다.
+                        // const inCurrencyPrice = priceStore.calculatePrice(
+                        //   ibcSwapConfigsForBridge.amountConfig.amount[0],
+                        //   "usd"
+                        // );
+                        // if (inCurrencyPrice) {
+                        //   params["inFiatRange"] =
+                        //     amountToAmbiguousString(inCurrencyPrice);
+                        //   params["inFiatAvg"] =
+                        //     amountToAmbiguousAverage(inCurrencyPrice);
+                        // }
+                        // const outCurrencyPrice = priceStore.calculatePrice(
+                        //   ibcSwapConfigsForBridge.amountConfig.outAmount,
+                        //   "usd"
+                        // );
+                        // if (outCurrencyPrice) {
+                        //   params["outFiatRange"] =
+                        //     amountToAmbiguousString(outCurrencyPrice);
+                        //   params["outFiatAvg"] =
+                        //     amountToAmbiguousAverage(outCurrencyPrice);
+                        // }
 
-                        new InExtensionMessageRequester().sendMessage(
-                          BACKGROUND_PORT,
-                          new LogAnalyticsEventMsg("ibc_swap", params)
-                        );
+                        // new InExtensionMessageRequester().sendMessage(
+                        //   BACKGROUND_PORT,
+                        //   new LogAnalyticsEventMsg("ibc_swap", params)
+                        // );
 
-                        analyticsStore.logEvent("swap_occurred", {
-                          in_chain_id: inChainId,
-                          in_chain_identifier:
-                            ChainIdHelper.parse(inChainId).identifier,
-                          in_currency_minimal_denom:
-                            inCurrency.coinMinimalDenom,
-                          in_currency_denom: inCurrency.coinDenom,
-                          out_chain_id: outChainId,
-                          out_chain_identifier:
-                            ChainIdHelper.parse(outChainId).identifier,
-                          out_currency_minimal_denom:
-                            outCurrency.coinMinimalDenom,
-                          out_currency_denom: outCurrency.coinDenom,
-                        });
+                        // analyticsStore.logEvent("swap_occurred", {
+                        //   in_chain_id: inChainId,
+                        //   in_chain_identifier:
+                        //     ChainIdHelper.parse(inChainId).identifier,
+                        //   in_currency_minimal_denom:
+                        //     inCurrency.coinMinimalDenom,
+                        //   in_currency_denom: inCurrency.coinDenom,
+                        //   out_chain_id: outChainId,
+                        //   out_chain_identifier:
+                        //     ChainIdHelper.parse(outChainId).identifier,
+                        //   out_currency_minimal_denom:
+                        //     outCurrency.coinMinimalDenom,
+                        //   out_currency_denom: outCurrency.coinDenom,
+                        // });
                       },
                       onFulfill: (tx: any) => {
                         if (tx.code != null && tx.code !== 0) {

--- a/apps/hooks-internal/src/ibc-swap/amount.ts
+++ b/apps/hooks-internal/src/ibc-swap/amount.ts
@@ -158,7 +158,11 @@ export class IBCSwapAmountConfig extends AmountConfig {
   async getTx(
     slippageTolerancePercent: number,
     affiliateFeeReceiver: string | undefined,
-    priorOutAmount?: Int
+    priorOutAmount?: Int,
+    customRecipient?: {
+      chainId: string;
+      recipient: string;
+    }
   ): Promise<MakeTxResponse | UnsignedEVMTransactionWithErc20Approvals> {
     const queryIBCSwap = this.getQueryIBCSwap();
     if (!queryIBCSwap) {
@@ -224,6 +228,11 @@ export class IBCSwapAmountConfig extends AmountConfig {
           : destinationAccount.bech32Address;
     }
 
+    if (customRecipient) {
+      chainIdsToAddresses[customRecipient.chainId.replace("eip155:", "")] =
+        customRecipient.recipient;
+    }
+
     for (const swapVenue of queryRouteResponse.data.swap_venues ?? [
       queryRouteResponse.data.swap_venue,
     ]) {
@@ -287,7 +296,8 @@ export class IBCSwapAmountConfig extends AmountConfig {
 
     const tx = this.getTxIfReady(
       slippageTolerancePercent,
-      affiliateFeeReceiver
+      affiliateFeeReceiver,
+      customRecipient
     );
     if (!tx) {
       throw new Error("Tx is not ready");
@@ -327,7 +337,11 @@ export class IBCSwapAmountConfig extends AmountConfig {
 
   getTxIfReady(
     slippageTolerancePercent: number,
-    affiliateFeeReceiver?: string
+    affiliateFeeReceiver?: string,
+    customRecipient?: {
+      chainId: string;
+      recipient: string;
+    }
   ): MakeTxResponse | UnsignedEVMTransactionWithErc20Approvals | undefined {
     if (!this.currency) {
       return;
@@ -403,6 +417,11 @@ export class IBCSwapAmountConfig extends AmountConfig {
         isDestinationChainEVMOnly
           ? destinationAccount.ethereumHexAddress
           : destinationAccount.bech32Address;
+    }
+
+    if (customRecipient) {
+      chainIdsToAddresses[customRecipient.chainId.replace("eip155:", "")] =
+        customRecipient.recipient;
     }
 
     for (const swapVenue of queryRouteResponse.data.swap_venues ?? [

--- a/apps/hooks-internal/src/ibc-swap/amount.ts
+++ b/apps/hooks-internal/src/ibc-swap/amount.ts
@@ -32,6 +32,11 @@ export class IBCSwapAmountConfig extends AmountConfig {
   protected _swapFeeBps: number;
   @observable
   protected _allowSwaps?: boolean;
+  @observable
+  protected _smartSwapOptions?: {
+    evmSwaps?: boolean;
+    splitRoutes?: boolean;
+  };
 
   constructor(
     chainGetter: ChainGetter,
@@ -46,7 +51,11 @@ export class IBCSwapAmountConfig extends AmountConfig {
     initialOutChainId: string,
     initialOutCurrency: AppCurrency,
     swapFeeBps: number,
-    allowSwaps?: boolean
+    allowSwaps?: boolean,
+    smartSwapOptions?: {
+      evmSwaps?: boolean;
+      splitRoutes?: boolean;
+    }
   ) {
     super(chainGetter, queriesStore, initialChainId, senderConfig);
 
@@ -54,6 +63,7 @@ export class IBCSwapAmountConfig extends AmountConfig {
     this._outCurrency = initialOutCurrency;
     this._swapFeeBps = swapFeeBps;
     this._allowSwaps = allowSwaps;
+    this._smartSwapOptions = smartSwapOptions;
     makeObservable(this);
   }
 
@@ -75,6 +85,15 @@ export class IBCSwapAmountConfig extends AmountConfig {
 
   get allowSwaps(): boolean | undefined {
     return this._allowSwaps;
+  }
+
+  get smartSwapOptions():
+    | {
+        evmSwaps?: boolean;
+        splitRoutes?: boolean;
+      }
+    | undefined {
+    return this._smartSwapOptions;
   }
 
   get swapPriceImpact(): RatePretty | undefined {
@@ -726,7 +745,8 @@ export class IBCSwapAmountConfig extends AmountConfig {
       this.outChainId,
       this.outCurrency.coinMinimalDenom,
       this.swapFeeBps,
-      this.allowSwaps
+      this.allowSwaps,
+      this.smartSwapOptions
     );
   }
 }
@@ -742,7 +762,11 @@ export const useIBCSwapAmountConfig = (
   outChainId: string,
   outCurrency: AppCurrency,
   swapFeeBps: number,
-  allowSwaps?: boolean
+  allowSwaps?: boolean,
+  smartSwapOptions?: {
+    evmSwaps?: boolean;
+    splitRoutes?: boolean;
+  }
 ) => {
   const [txConfig] = useState(
     () =>
@@ -757,7 +781,8 @@ export const useIBCSwapAmountConfig = (
         outChainId,
         outCurrency,
         swapFeeBps,
-        allowSwaps
+        allowSwaps,
+        smartSwapOptions
       )
   );
   txConfig.setChain(chainId);

--- a/apps/hooks-internal/src/ibc-swap/amount.ts
+++ b/apps/hooks-internal/src/ibc-swap/amount.ts
@@ -30,6 +30,8 @@ export class IBCSwapAmountConfig extends AmountConfig {
   protected _outCurrency: AppCurrency;
   @observable
   protected _swapFeeBps: number;
+  @observable
+  protected _allowSwaps?: boolean;
 
   constructor(
     chainGetter: ChainGetter,
@@ -43,14 +45,15 @@ export class IBCSwapAmountConfig extends AmountConfig {
     senderConfig: ISenderConfig,
     initialOutChainId: string,
     initialOutCurrency: AppCurrency,
-    swapFeeBps: number
+    swapFeeBps: number,
+    allowSwaps?: boolean
   ) {
     super(chainGetter, queriesStore, initialChainId, senderConfig);
 
     this._outChainId = initialOutChainId;
     this._outCurrency = initialOutCurrency;
     this._swapFeeBps = swapFeeBps;
-
+    this._allowSwaps = allowSwaps;
     makeObservable(this);
   }
 
@@ -68,6 +71,10 @@ export class IBCSwapAmountConfig extends AmountConfig {
 
   get outCurrency(): AppCurrency {
     return this._outCurrency;
+  }
+
+  get allowSwaps(): boolean | undefined {
+    return this._allowSwaps;
   }
 
   get swapPriceImpact(): RatePretty | undefined {
@@ -676,7 +683,8 @@ export class IBCSwapAmountConfig extends AmountConfig {
       this.amount[0],
       this.outChainId,
       this.outCurrency.coinMinimalDenom,
-      this.swapFeeBps
+      this.swapFeeBps,
+      this.allowSwaps
     );
   }
 }
@@ -691,7 +699,8 @@ export const useIBCSwapAmountConfig = (
   senderConfig: ISenderConfig,
   outChainId: string,
   outCurrency: AppCurrency,
-  swapFeeBps: number
+  swapFeeBps: number,
+  allowSwaps?: boolean
 ) => {
   const [txConfig] = useState(
     () =>
@@ -705,7 +714,8 @@ export const useIBCSwapAmountConfig = (
         senderConfig,
         outChainId,
         outCurrency,
-        swapFeeBps
+        swapFeeBps,
+        allowSwaps
       )
   );
   txConfig.setChain(chainId);

--- a/apps/hooks-internal/src/ibc-swap/use.ts
+++ b/apps/hooks-internal/src/ibc-swap/use.ts
@@ -27,7 +27,8 @@ export const useIBCSwapConfig = (
   initialGas: number,
   outChainId: string,
   outCurrency: AppCurrency,
-  swapFeeBps: number
+  swapFeeBps: number,
+  allowSwaps?: boolean
 ) => {
   const senderConfig = useSenderConfig(chainGetter, chainId, sender);
   const amountConfig = useIBCSwapAmountConfig(
@@ -40,7 +41,8 @@ export const useIBCSwapConfig = (
     senderConfig,
     outChainId,
     outCurrency,
-    swapFeeBps
+    swapFeeBps,
+    allowSwaps
   );
 
   const memoConfig = useMemoConfig(chainGetter, chainId);

--- a/apps/hooks-internal/src/ibc-swap/use.ts
+++ b/apps/hooks-internal/src/ibc-swap/use.ts
@@ -28,7 +28,11 @@ export const useIBCSwapConfig = (
   outChainId: string,
   outCurrency: AppCurrency,
   swapFeeBps: number,
-  allowSwaps?: boolean
+  allowSwaps?: boolean,
+  smartSwapOptions?: {
+    evmSwaps?: boolean;
+    splitRoutes?: boolean;
+  }
 ) => {
   const senderConfig = useSenderConfig(chainGetter, chainId, sender);
   const amountConfig = useIBCSwapAmountConfig(
@@ -42,7 +46,8 @@ export const useIBCSwapConfig = (
     outChainId,
     outCurrency,
     swapFeeBps,
-    allowSwaps
+    allowSwaps,
+    smartSwapOptions
   );
 
   const memoConfig = useMemoConfig(chainGetter, chainId);

--- a/apps/stores-internal/src/skip/ibc-swap.ts
+++ b/apps/stores-internal/src/skip/ibc-swap.ts
@@ -30,7 +30,11 @@ export class ObservableQueryIBCSwapInner {
       readonly name: string;
       readonly chainId: string;
     }[],
-    public readonly allowSwaps?: boolean
+    public readonly allowSwaps?: boolean,
+    public readonly smartSwapOptions?: {
+      evmSwaps?: boolean;
+      splitRoutes?: boolean;
+    }
   ) {}
 
   getQueryMsgsDirect(
@@ -54,7 +58,8 @@ export class ObservableQueryIBCSwapInner {
       slippageTolerancePercent,
       this.affiliateFeeBps,
       affiliateFeeReceiver,
-      this.swapVenues
+      this.swapVenues,
+      this.smartSwapOptions
     );
   }
 
@@ -73,7 +78,8 @@ export class ObservableQueryIBCSwapInner {
       this.destAssetDenom,
       this.affiliateFeeBps,
       this.swapVenues,
-      this.allowSwaps
+      this.allowSwaps,
+      this.smartSwapOptions
     );
   }
 }
@@ -106,7 +112,8 @@ export class ObservableQueryIbcSwap extends HasMapStore<ObservableQueryIBCSwapIn
         parsed.destChainId,
         parsed.affiliateFeeBps,
         parsed.swapVenues,
-        parsed.allowSwaps
+        parsed.allowSwaps,
+        parsed.smartSwapOptions
       );
     });
 
@@ -119,7 +126,11 @@ export class ObservableQueryIbcSwap extends HasMapStore<ObservableQueryIBCSwapIn
     destChainId: string,
     destDenom: string,
     affiliateFeeBps: number,
-    allowSwaps?: boolean
+    allowSwaps?: boolean,
+    smartSwapOptions?: {
+      evmSwaps?: boolean;
+      splitRoutes?: boolean;
+    }
   ): ObservableQueryIBCSwapInner {
     const str = JSON.stringify({
       sourceChainId,
@@ -130,6 +141,7 @@ export class ObservableQueryIbcSwap extends HasMapStore<ObservableQueryIBCSwapIn
       affiliateFeeBps,
       swapVenues: this.swapVenues,
       allowSwaps,
+      smartSwapOptions,
     });
     return this.get(str);
   }

--- a/apps/stores-internal/src/skip/ibc-swap.ts
+++ b/apps/stores-internal/src/skip/ibc-swap.ts
@@ -29,7 +29,8 @@ export class ObservableQueryIBCSwapInner {
     public readonly swapVenues: {
       readonly name: string;
       readonly chainId: string;
-    }[]
+    }[],
+    public readonly allowSwaps?: boolean
   ) {}
 
   getQueryMsgsDirect(
@@ -71,7 +72,8 @@ export class ObservableQueryIBCSwapInner {
       this.destAssetChainId,
       this.destAssetDenom,
       this.affiliateFeeBps,
-      this.swapVenues
+      this.swapVenues,
+      this.allowSwaps
     );
   }
 }
@@ -92,6 +94,7 @@ export class ObservableQueryIbcSwap extends HasMapStore<ObservableQueryIBCSwapIn
   ) {
     super((str) => {
       const parsed = JSON.parse(str);
+
       return new ObservableQueryIBCSwapInner(
         this.chainStore,
         this.queryRoute,
@@ -102,7 +105,8 @@ export class ObservableQueryIbcSwap extends HasMapStore<ObservableQueryIBCSwapIn
         parsed.destDenom,
         parsed.destChainId,
         parsed.affiliateFeeBps,
-        parsed.swapVenues
+        parsed.swapVenues,
+        parsed.allowSwaps
       );
     });
 
@@ -114,7 +118,8 @@ export class ObservableQueryIbcSwap extends HasMapStore<ObservableQueryIBCSwapIn
     amount: CoinPretty,
     destChainId: string,
     destDenom: string,
-    affiliateFeeBps: number
+    affiliateFeeBps: number,
+    allowSwaps?: boolean
   ): ObservableQueryIBCSwapInner {
     const str = JSON.stringify({
       sourceChainId,
@@ -124,6 +129,7 @@ export class ObservableQueryIbcSwap extends HasMapStore<ObservableQueryIBCSwapIn
       destDenom,
       affiliateFeeBps,
       swapVenues: this.swapVenues,
+      allowSwaps,
     });
     return this.get(str);
   }

--- a/apps/stores-internal/src/skip/msgs-direct.ts
+++ b/apps/stores-internal/src/skip/msgs-direct.ts
@@ -93,7 +93,11 @@ export class ObservableQueryMsgsDirectInner extends ObservableQuery<MsgsDirectRe
     public readonly swapVenues: {
       readonly name: string;
       readonly chainId: string;
-    }[]
+    }[],
+    public readonly smartSwapOptions?: {
+      evmSwaps?: boolean;
+      splitRoutes?: boolean;
+    }
   ) {
     super(sharedContext, skipURL, "/v2/fungible/msgs_direct");
 
@@ -343,8 +347,14 @@ export class ObservableQueryMsgsDirectInner extends ObservableQuery<MsgsDirectRe
           go_fast: true,
           experimental_features: ["hyperlane"],
           smart_swap_options: {
-            evm_swaps: true,
-            split_routes: true,
+            evm_swaps:
+              this.smartSwapOptions?.evmSwaps === undefined
+                ? true
+                : this.smartSwapOptions.evmSwaps,
+            split_routes:
+              this.smartSwapOptions?.splitRoutes === undefined
+                ? true
+                : this.smartSwapOptions.splitRoutes,
           },
         }),
         signal: abortController.signal,
@@ -404,7 +414,8 @@ export class ObservableQueryMsgsDirect extends HasMapStore<ObservableQueryMsgsDi
         parsed.slippageTolerancePercent,
         parsed.affiliateFeeBps,
         parsed.affiliateFeeReceiver,
-        parsed.swapVenues
+        parsed.swapVenues,
+        parsed.smartSwapOptions
       );
     });
   }
@@ -421,7 +432,11 @@ export class ObservableQueryMsgsDirect extends HasMapStore<ObservableQueryMsgsDi
     swapVenues: {
       readonly name: string;
       readonly chainId: string;
-    }[]
+    }[],
+    smartSwapOptions?: {
+      evmSwaps?: boolean;
+      splitRoutes?: boolean;
+    }
   ): ObservableQueryMsgsDirectInner {
     const amountInCoin = amountIn.toCoin();
     const str = JSON.stringify({
@@ -435,6 +450,7 @@ export class ObservableQueryMsgsDirect extends HasMapStore<ObservableQueryMsgsDi
       affiliateFeeBps,
       affiliateFeeReceiver,
       swapVenues,
+      smartSwapOptions,
     });
     return this.get(str);
   }

--- a/apps/stores-internal/src/skip/route.ts
+++ b/apps/stores-internal/src/skip/route.ts
@@ -250,7 +250,11 @@ export class ObservableQueryRouteInner extends ObservableQuery<RouteResponse> {
       readonly name: string;
       readonly chainId: string;
     }[],
-    public readonly allowSwaps?: boolean
+    public readonly allowSwaps?: boolean,
+    public readonly smartSwapOptions?: {
+      evmSwaps?: boolean;
+      splitRoutes?: boolean;
+    }
   ) {
     super(sharedContext, skipURL, "/v2/fungible/route");
     makeObservable(this);
@@ -411,8 +415,14 @@ export class ObservableQueryRouteInner extends ObservableQuery<RouteResponse> {
         go_fast: true,
         experimental_features: ["hyperlane"],
         smart_swap_options: {
-          evm_swaps: true,
-          split_routes: true,
+          evm_swaps:
+            this.smartSwapOptions?.evmSwaps === undefined
+              ? true
+              : this.smartSwapOptions.evmSwaps,
+          split_routes:
+            this.smartSwapOptions?.splitRoutes === undefined
+              ? true
+              : this.smartSwapOptions.splitRoutes,
         },
         ...(this.allowSwaps !== undefined && {
           allow_swaps: this.allowSwaps,
@@ -459,6 +469,7 @@ export class ObservableQueryRoute extends HasMapStore<ObservableQueryRouteInner>
   ) {
     super((str) => {
       const parsed = JSON.parse(str);
+
       return new ObservableQueryRouteInner(
         this.sharedContext,
         this.chainGetter,
@@ -470,7 +481,10 @@ export class ObservableQueryRoute extends HasMapStore<ObservableQueryRouteInner>
         parsed.destDenom,
         parsed.affiliateFeeBps,
         parsed.swapVenues,
-        parsed.allowSwaps
+        parsed.allowSwaps,
+        {
+          evmSwaps: parsed.smartSwapOptions?.evmSwaps,
+        }
       );
     });
   }
@@ -485,7 +499,11 @@ export class ObservableQueryRoute extends HasMapStore<ObservableQueryRouteInner>
       readonly name: string;
       readonly chainId: string;
     }[],
-    allowSwaps?: boolean
+    allowSwaps?: boolean,
+    smartSwapOptions?: {
+      evmSwaps?: boolean;
+      splitRoutes?: boolean;
+    }
   ): ObservableQueryRouteInner {
     const str = JSON.stringify({
       sourceChainId,
@@ -496,6 +514,7 @@ export class ObservableQueryRoute extends HasMapStore<ObservableQueryRouteInner>
       affiliateFeeBps,
       swapVenues,
       allowSwaps,
+      smartSwapOptions,
     });
     return this.get(str);
   }

--- a/apps/stores-internal/src/skip/route.ts
+++ b/apps/stores-internal/src/skip/route.ts
@@ -249,10 +249,10 @@ export class ObservableQueryRouteInner extends ObservableQuery<RouteResponse> {
     public readonly swapVenues: {
       readonly name: string;
       readonly chainId: string;
-    }[]
+    }[],
+    public readonly allowSwaps?: boolean
   ) {
     super(sharedContext, skipURL, "/v2/fungible/route");
-
     makeObservable(this);
   }
 
@@ -414,6 +414,9 @@ export class ObservableQueryRouteInner extends ObservableQuery<RouteResponse> {
           evm_swaps: true,
           split_routes: true,
         },
+        ...(this.allowSwaps !== undefined && {
+          allow_swaps: this.allowSwaps,
+        }),
       }),
       signal: abortController.signal,
     });
@@ -466,7 +469,8 @@ export class ObservableQueryRoute extends HasMapStore<ObservableQueryRouteInner>
         parsed.destChainId,
         parsed.destDenom,
         parsed.affiliateFeeBps,
-        parsed.swapVenues
+        parsed.swapVenues,
+        parsed.allowSwaps
       );
     });
   }
@@ -480,7 +484,8 @@ export class ObservableQueryRoute extends HasMapStore<ObservableQueryRouteInner>
     swapVenues: {
       readonly name: string;
       readonly chainId: string;
-    }[]
+    }[],
+    allowSwaps?: boolean
   ): ObservableQueryRouteInner {
     const str = JSON.stringify({
       sourceChainId,
@@ -490,6 +495,7 @@ export class ObservableQueryRoute extends HasMapStore<ObservableQueryRouteInner>
       destDenom,
       affiliateFeeBps,
       swapVenues,
+      allowSwaps,
     });
     return this.get(str);
   }

--- a/packages/background/src/tx-ethereum/messages.ts
+++ b/packages/background/src/tx-ethereum/messages.ts
@@ -89,10 +89,6 @@ export class SendTxEthereumMsgAndRecordMsg extends Message<string> {
     if (!this.amount) {
       throw new Error("amount is empty");
     }
-
-    if (!this.memo) {
-      throw new Error("memo is empty");
-    }
   }
 
   override approveExternal(): boolean {


### PR DESCRIPTION
# 변경 사항
- send페이지에서 bridge를 실행 하는 경우 skip를 통해서 swap을 허용 하지 않기위해서 allowSwaps와 smartSwapOptions를 IBCSwapAmountConfig, ObservableQueryIBCSwapInner, ObservableQueryMsgsDirectInner등에 추가
- bridge의 경우 기존 ibc처럼 다른 주소로 보낼수도 있기 때문에 getTx, getReadyTx에 customRecipient를 받도록 수정하고, 해당 값이 있을경우 chainIdsToAddresses리스트 에서 목적 체인의 주소를 Recipient로 수정 하도록 함
- amount 페이지에서 bridge의 경우 swap을 통해서 tx를 전송 하는 로직 추가 
- allowSwaps를 false로 지정 했을때 route에서 swap을 사용하는 경우 에러를 반환 하는 로직 추가

# 이후 구현
-실제 디자인에 맞춰서 ui 변경, keplr Fee나 브릿지 fee 보여주는 부분 구현 필요
