### PR TITLE
Enable to claim rewards on Elys network

### DIFF
--- a/apps/extension/src/pages/main/components/claim-all/index.tsx
+++ b/apps/extension/src/pages/main/components/claim-all/index.tsx
@@ -163,6 +163,10 @@ export const ClaimAll: FunctionComponent<{ isNotReady?: boolean }> = observer(
             return "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5";
           }
 
+          if (chainInfo.chainIdentifier === "elys") {
+            return "ueden";
+          }
+
           return chainInfo.stakeCurrency?.coinMinimalDenom;
         })();
 


### PR DESCRIPTION
- chain registry의 Elys currency 항목에 EDEN 추가 및 익스텐션에서 ueden을 target asset으로 잡도록 추가