### PR TITLE
fix: fix async file handling by adding fs.promises import

### DIFF
--- a/scripts/post-install.mjs
+++ b/scripts/post-install.mjs
@@ -2,6 +2,7 @@
 
 import "zx/globals";
 import path from "path";
+import fs from "fs/promises";
 
 (async () => {
   try {


### PR DESCRIPTION
I noticed an issue where `fs.readFile` and `fs.writeFile` were being used synchronously, while they should be asynchronous. This was because `fs.promises` was not imported.
I've added the necessary import for `fs.promises` to ensure proper asynchronous behavior when handling files.