### PR TITLE
Display bitcoin addresses

### DIFF
--- a/apps/extension/src/config.ts
+++ b/apps/extension/src/config.ts
@@ -3187,9 +3187,6 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
       rpc: "",
       rest: "",
       coinType: 0,
-      bech32: "bc",
-      messagePrefix: "\x18Bitcoin Signed Message:\n",
-      pubKeyHash: 0x00,
     },
   },
   {
@@ -3207,9 +3204,6 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
       rpc: "",
       rest: "",
       coinType: 0,
-      bech32: "bc",
-      messagePrefix: "\x18Bitcoin Signed Message:\n",
-      pubKeyHash: 0x00,
     },
   },
   {
@@ -3227,9 +3221,6 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
       rpc: "",
       rest: "",
       coinType: 1,
-      bech32: "tb",
-      messagePrefix: "\x18Bitcoin Signed Message:\n",
-      pubKeyHash: 0x6f,
     },
   },
   {
@@ -3247,9 +3238,6 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
       rpc: "",
       rest: "",
       coinType: 1,
-      bech32: "tb",
-      messagePrefix: "\x18Bitcoin Signed Message:\n",
-      pubKeyHash: 0x6f,
     },
   },
   {
@@ -3266,11 +3254,7 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
         "bip122:00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6",
       rpc: "",
       rest: "",
-      // signet shares parameters with testnet
       coinType: 1,
-      bech32: "tb",
-      messagePrefix: "\x18Bitcoin Signed Message:\n",
-      pubKeyHash: 0x6f,
     },
   },
   {
@@ -3288,9 +3272,6 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
       rpc: "",
       rest: "",
       coinType: 1,
-      bech32: "tb",
-      messagePrefix: "\x18Bitcoin Signed Message:\n",
-      pubKeyHash: 0x6f,
     },
   },
 ];

--- a/apps/extension/src/config.ts
+++ b/apps/extension/src/config.ts
@@ -3178,9 +3178,8 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
     chainName: "Bitcoin",
     chainSymbolImageUrl:
       "https://cryptologos.cc/logos/bitcoin-btc-logo.png?v=040",
-    linkedChainIds: [
-      "bip122:000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f:native-segwit",
-    ],
+    linkedChainKey:
+      "bip122:000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
     bitcoin: {
       chainId:
         "bip122:000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
@@ -3195,9 +3194,8 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
     chainName: "Bitcoin",
     chainSymbolImageUrl:
       "https://cryptologos.cc/logos/bitcoin-btc-logo.png?v=040",
-    linkedChainIds: [
-      "bip122:000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f:taproot",
-    ],
+    linkedChainKey:
+      "bip122:000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
     bitcoin: {
       chainId:
         "bip122:000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
@@ -3212,9 +3210,8 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
     chainName: "Bitcoin Testnet",
     chainSymbolImageUrl:
       "https://cryptologos.cc/logos/bitcoin-btc-logo.png?v=040",
-    linkedChainIds: [
-      "bip122:000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943:native-segwit",
-    ],
+    linkedChainKey:
+      "bip122:000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943",
     bitcoin: {
       chainId:
         "bip122:000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943",
@@ -3229,9 +3226,8 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
     chainName: "Bitcoin Testnet",
     chainSymbolImageUrl:
       "https://cryptologos.cc/logos/bitcoin-btc-logo.png?v=040",
-    linkedChainIds: [
-      "bip122:000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943:taproot",
-    ],
+    linkedChainKey:
+      "bip122:000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943",
     bitcoin: {
       chainId:
         "bip122:000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943",
@@ -3246,9 +3242,8 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
     chainName: "Bitcoin Signet",
     chainSymbolImageUrl:
       "https://cryptologos.cc/logos/bitcoin-btc-logo.png?v=040",
-    linkedChainIds: [
-      "bip122:00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6:native-segwit",
-    ],
+    linkedChainKey:
+      "bip122:00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6",
     bitcoin: {
       chainId:
         "bip122:00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6",
@@ -3263,9 +3258,8 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
     chainName: "Bitcoin Signet",
     chainSymbolImageUrl:
       "https://cryptologos.cc/logos/bitcoin-btc-logo.png?v=040",
-    linkedChainIds: [
-      "bip122:00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6:taproot",
-    ],
+    linkedChainKey:
+      "bip122:00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6",
     bitcoin: {
       chainId:
         "bip122:00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6",

--- a/apps/extension/src/config.ts
+++ b/apps/extension/src/config.ts
@@ -3172,6 +3172,90 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
     ],
     features: [],
   },
+  {
+    chainId:
+      "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f:taproot",
+    chainName: "Bitcoin",
+    chainSymbolImageUrl:
+      "https://cryptologos.cc/logos/bitcoin-btc-logo.png?v=040",
+    linkedChainIds: [
+      "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f:native-segwit",
+    ],
+    bitcoin: {
+      chainId:
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+      rpc: "",
+      rest: "",
+      paymentType: "taproot",
+      coinType: 0,
+      bech32: "bc",
+      messagePrefix: "\x18Bitcoin Signed Message:\n",
+      pubKeyHash: 0x00,
+    },
+  },
+  {
+    chainId:
+      "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f:native-segwit",
+    chainName: "Bitcoin",
+    chainSymbolImageUrl:
+      "https://cryptologos.cc/logos/bitcoin-btc-logo.png?v=040",
+    linkedChainIds: [
+      "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f:taproot",
+    ],
+    bitcoin: {
+      chainId:
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+      rpc: "",
+      rest: "",
+      paymentType: "native-segwit",
+      coinType: 0,
+      bech32: "bc",
+      messagePrefix: "\x18Bitcoin Signed Message:\n",
+      pubKeyHash: 0x00,
+    },
+  },
+  {
+    chainId:
+      "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943:taproot",
+    chainName: "Bitcoin Testnet",
+    chainSymbolImageUrl:
+      "https://cryptologos.cc/logos/bitcoin-btc-logo.png?v=040",
+    linkedChainIds: [
+      "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943:native-segwit",
+    ],
+    bitcoin: {
+      chainId:
+        "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943",
+      rpc: "",
+      rest: "",
+      paymentType: "taproot",
+      coinType: 1,
+      bech32: "tb",
+      messagePrefix: "\x18Bitcoin Signed Message:\n",
+      pubKeyHash: 0x6f,
+    },
+  },
+  {
+    chainId:
+      "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943:native-segwit",
+    chainName: "Bitcoin Testnet",
+    chainSymbolImageUrl:
+      "https://cryptologos.cc/logos/bitcoin-btc-logo.png?v=040",
+    linkedChainIds: [
+      "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943:taproot",
+    ],
+    bitcoin: {
+      chainId:
+        "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943",
+      rpc: "",
+      rest: "",
+      paymentType: "native-segwit",
+      coinType: 1,
+      bech32: "tb",
+      messagePrefix: "\x18Bitcoin Signed Message:\n",
+      pubKeyHash: 0x6f,
+    },
+  },
 ];
 
 // The origins that are able to pass any permission that external webpages can have.

--- a/apps/extension/src/config.ts
+++ b/apps/extension/src/config.ts
@@ -3256,6 +3256,49 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
       pubKeyHash: 0x6f,
     },
   },
+  {
+    chainId:
+      "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6:taproot",
+    chainName: "Bitcoin Signet",
+    chainSymbolImageUrl:
+      "https://cryptologos.cc/logos/bitcoin-btc-logo.png?v=040",
+    linkedChainIds: [
+      "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6:native-segwit",
+    ],
+    bitcoin: {
+      chainId:
+        "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6",
+      rpc: "",
+      rest: "",
+      paymentType: "taproot",
+      // signet shares parameters with testnet
+      coinType: 1,
+      bech32: "tb",
+      messagePrefix: "\x18Bitcoin Signed Message:\n",
+      pubKeyHash: 0x6f,
+    },
+  },
+  {
+    chainId:
+      "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6:native-segwit",
+    chainName: "Bitcoin Signet",
+    chainSymbolImageUrl:
+      "https://cryptologos.cc/logos/bitcoin-btc-logo.png?v=040",
+    linkedChainIds: [
+      "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6:taproot",
+    ],
+    bitcoin: {
+      chainId:
+        "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6",
+      rpc: "",
+      rest: "",
+      paymentType: "native-segwit",
+      coinType: 1,
+      bech32: "tb",
+      messagePrefix: "\x18Bitcoin Signed Message:\n",
+      pubKeyHash: 0x6f,
+    },
+  },
 ];
 
 // The origins that are able to pass any permission that external webpages can have.

--- a/apps/extension/src/config.ts
+++ b/apps/extension/src/config.ts
@@ -3174,19 +3174,18 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
   },
   {
     chainId:
-      "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f:taproot",
+      "bip122:000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f:taproot",
     chainName: "Bitcoin",
     chainSymbolImageUrl:
       "https://cryptologos.cc/logos/bitcoin-btc-logo.png?v=040",
     linkedChainIds: [
-      "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f:native-segwit",
+      "bip122:000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f:native-segwit",
     ],
     bitcoin: {
       chainId:
-        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+        "bip122:000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
       rpc: "",
       rest: "",
-      paymentType: "taproot",
       coinType: 0,
       bech32: "bc",
       messagePrefix: "\x18Bitcoin Signed Message:\n",
@@ -3195,19 +3194,18 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
   },
   {
     chainId:
-      "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f:native-segwit",
+      "bip122:000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f:native-segwit",
     chainName: "Bitcoin",
     chainSymbolImageUrl:
       "https://cryptologos.cc/logos/bitcoin-btc-logo.png?v=040",
     linkedChainIds: [
-      "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f:taproot",
+      "bip122:000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f:taproot",
     ],
     bitcoin: {
       chainId:
-        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+        "bip122:000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
       rpc: "",
       rest: "",
-      paymentType: "native-segwit",
       coinType: 0,
       bech32: "bc",
       messagePrefix: "\x18Bitcoin Signed Message:\n",
@@ -3216,19 +3214,18 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
   },
   {
     chainId:
-      "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943:taproot",
+      "bip122:000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943:taproot",
     chainName: "Bitcoin Testnet",
     chainSymbolImageUrl:
       "https://cryptologos.cc/logos/bitcoin-btc-logo.png?v=040",
     linkedChainIds: [
-      "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943:native-segwit",
+      "bip122:000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943:native-segwit",
     ],
     bitcoin: {
       chainId:
-        "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943",
+        "bip122:000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943",
       rpc: "",
       rest: "",
-      paymentType: "taproot",
       coinType: 1,
       bech32: "tb",
       messagePrefix: "\x18Bitcoin Signed Message:\n",
@@ -3237,19 +3234,18 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
   },
   {
     chainId:
-      "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943:native-segwit",
+      "bip122:000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943:native-segwit",
     chainName: "Bitcoin Testnet",
     chainSymbolImageUrl:
       "https://cryptologos.cc/logos/bitcoin-btc-logo.png?v=040",
     linkedChainIds: [
-      "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943:taproot",
+      "bip122:000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943:taproot",
     ],
     bitcoin: {
       chainId:
-        "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943",
+        "bip122:000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943",
       rpc: "",
       rest: "",
-      paymentType: "native-segwit",
       coinType: 1,
       bech32: "tb",
       messagePrefix: "\x18Bitcoin Signed Message:\n",
@@ -3258,19 +3254,18 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
   },
   {
     chainId:
-      "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6:taproot",
+      "bip122:00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6:taproot",
     chainName: "Bitcoin Signet",
     chainSymbolImageUrl:
       "https://cryptologos.cc/logos/bitcoin-btc-logo.png?v=040",
     linkedChainIds: [
-      "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6:native-segwit",
+      "bip122:00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6:native-segwit",
     ],
     bitcoin: {
       chainId:
-        "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6",
+        "bip122:00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6",
       rpc: "",
       rest: "",
-      paymentType: "taproot",
       // signet shares parameters with testnet
       coinType: 1,
       bech32: "tb",
@@ -3280,19 +3275,18 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
   },
   {
     chainId:
-      "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6:native-segwit",
+      "bip122:00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6:native-segwit",
     chainName: "Bitcoin Signet",
     chainSymbolImageUrl:
       "https://cryptologos.cc/logos/bitcoin-btc-logo.png?v=040",
     linkedChainIds: [
-      "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6:taproot",
+      "bip122:00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6:taproot",
     ],
     bitcoin: {
       chainId:
-        "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6",
+        "bip122:00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6",
       rpc: "",
       rest: "",
-      paymentType: "native-segwit",
       coinType: 1,
       bech32: "tb",
       messagePrefix: "\x18Bitcoin Signed Message:\n",

--- a/apps/extension/src/content-scripts/events.ts
+++ b/apps/extension/src/content-scripts/events.ts
@@ -64,6 +64,19 @@ export function initEvents(router: Router) {
                 },
               })
             );
+          case "keplr_bitcoinChainChanged":
+            return window.dispatchEvent(
+              new CustomEvent("keplr_bitcoinChainChanged", {
+                detail: {
+                  ...(
+                    msg as PushEventDataMsg<{
+                      origin: string;
+                      bitcoinChainId: string;
+                    }>
+                  ).data.data,
+                },
+              })
+            );
           case "keplr_ethSubscription":
             return window.dispatchEvent(
               new CustomEvent("keplr_ethSubscription", {

--- a/apps/extension/src/content-scripts/events.ts
+++ b/apps/extension/src/content-scripts/events.ts
@@ -72,6 +72,7 @@ export function initEvents(router: Router) {
                     msg as PushEventDataMsg<{
                       origin: string;
                       bitcoinChainId: string;
+                      network: string;
                     }>
                   ).data.data,
                 },

--- a/apps/extension/src/pages/main/token-detail/staked-balance.tsx
+++ b/apps/extension/src/pages/main/token-detail/staked-balance.tsx
@@ -24,9 +24,13 @@ export const StakedBalance: FunctionComponent<{
     );
   }
 
+  if ("cosmos" in modularChainInfo) {
+    return <CosmosStakedBalance chainInfo={modularChainInfo.cosmos} />;
+  }
+
   // modularChainInfo가 추가됨에 따라 새로운 분기 처리가 필요할 수 있음
 
-  return <CosmosStakedBalance chainInfo={modularChainInfo.cosmos} />;
+  return null;
 });
 
 const CosmosStakedBalance: FunctionComponent<{

--- a/apps/extension/src/pages/register/enable-chains/index.tsx
+++ b/apps/extension/src/pages/register/enable-chains/index.tsx
@@ -910,13 +910,23 @@ export const EnableChainsScene: FunctionComponent<{
                   onClick={() => {
                     const isEnabled =
                       enabledChainIdentifierMap.get(chainIdentifier);
-                    const chainIdentifiersSet = new Set([chainIdentifier]);
+                    const linkedChainIdentifiers = new Set<string>([
+                      chainIdentifier,
+                    ]);
 
-                    if ("linkedChainIds" in modularChainInfo) {
-                      modularChainInfo.linkedChainIds.forEach((linkedChainId) =>
-                        chainIdentifiersSet.add(
-                          ChainIdHelper.parse(linkedChainId).identifier
-                        )
+                    if ("linkedChainKey" in modularChainInfo) {
+                      const linkedChainKey = modularChainInfo.linkedChainKey;
+                      chainStore.modularChainInfos.forEach(
+                        (modularChainInfo) => {
+                          if (
+                            "linkedChainKey" in modularChainInfo &&
+                            modularChainInfo.linkedChainKey === linkedChainKey
+                          ) {
+                            linkedChainIdentifiers.add(
+                              modularChainInfo.chainId
+                            );
+                          }
+                        }
                       );
                     }
 
@@ -927,13 +937,9 @@ export const EnableChainsScene: FunctionComponent<{
                       // Otherwise, enable all linked chains including selected chain.
                       const shouldEnable = !isEnabled;
 
-                      chainIdentifiersSet.forEach((id) => {
-                        if (shouldEnable) {
-                          result.add(id);
-                        } else {
-                          result.delete(id);
-                        }
-                      });
+                      linkedChainIdentifiers.forEach((id) =>
+                        shouldEnable ? result.add(id) : result.delete(id)
+                      );
 
                       return Array.from(result);
                     });

--- a/apps/extension/webpack.config.js
+++ b/apps/extension/webpack.config.js
@@ -72,9 +72,6 @@ module.exports = {
     ),
     filename: "[name].bundle.js",
   },
-  experiments: {
-    asyncWebAssembly: true,
-  },
   optimization: {
     splitChunks: {
       chunks(chunk) {

--- a/packages/background/package.json
+++ b/packages/background/package.json
@@ -58,6 +58,7 @@
     "utility-types": "^3.10.0"
   },
   "peerDependencies": {
+    "bitcoinjs-lib": "^6",
     "mobx": "^6",
     "mobx-utils": "^6",
     "starknet": "^6"

--- a/packages/background/src/chains/service.ts
+++ b/packages/background/src/chains/service.ts
@@ -1250,4 +1250,42 @@ export class ChainsService {
 
     return starknetChainInfo;
   }
+
+  /**
+   * 여러 주소 체계가 존재하는 체인의 경우, chainId에서 주소 체계를 제외한 공통된 부분을 사용하여 하나의 체인으로 취급해야 한다.
+   * 예를 들어, Bitcoin의 경우 `bip122:123456:taproot`와 `bip122:123456:native-segwit`를 사용해
+   * 각 주소 체계를 구분하고 있지만, 공통된 `bip122:123456`을 사용하여 하나의 체인으로 취급되어야 한다.
+   * TODO: 비트 코인 외에도 여러 주소 체계가 존재하는 체인이 추가될 경우, 이 메서드의 부분적인 수정이 필요하다.
+   */
+  getBaseChainId(chainId: string): string | undefined {
+    const modularChainInfos = this.getModularChainInfos();
+
+    const directMatch = modularChainInfos.find(
+      (info) => info.chainId === chainId
+    );
+    if (directMatch) {
+      if ("bitcoin" in directMatch) {
+        return directMatch.bitcoin.chainId;
+      }
+      return chainId;
+    }
+
+    const baseChainMatch = modularChainInfos.find(
+      (info) => "bitcoin" in info && info.bitcoin.chainId === chainId
+    );
+    if (baseChainMatch) {
+      return chainId;
+    }
+
+    return undefined;
+  }
+
+  getBaseChainIdOrThrow(chainId: string): string {
+    const baseChainId = this.getBaseChainId(chainId);
+    if (!baseChainId) {
+      throw new Error(`There is no modular chain info for ${chainId}`);
+    }
+
+    return baseChainId;
+  }
 }

--- a/packages/background/src/index.ts
+++ b/packages/background/src/index.ts
@@ -24,6 +24,7 @@ import * as KeyRingPrivateKey from "./keyring-private-key/internal";
 import * as KeyRingCosmos from "./keyring-cosmos/internal";
 import * as KeyRingEthereum from "./keyring-ethereum/internal";
 import * as KeyRingStarknet from "./keyring-starknet/internal";
+import * as KeyRingBitcoin from "./keyring-bitcoin/internal";
 import * as PermissionInteractive from "./permission-interactive/internal";
 import * as TokenScan from "./token-scan/internal";
 import * as RecentSendHistory from "./recent-send-history/internal";
@@ -49,6 +50,7 @@ export * from "./keyring-cosmos";
 export * from "./keyring-ethereum";
 export * from "./keyring-starknet";
 export * from "./keyring-keystone";
+export * from "./keyring-bitcoin";
 export * from "./token-scan";
 export * from "./recent-send-history";
 export * from "./side-panel";
@@ -221,6 +223,14 @@ export function init(
     backgroundTxService
   );
 
+  const keyRingBitcoinService = new KeyRingBitcoin.KeyRingBitcoinService(
+    chainsService,
+    vaultService,
+    keyRingV2Service,
+    interactionService,
+    permissionService
+  );
+
   const autoLockAccountService = new AutoLocker.AutoLockAccountService(
     storeCreator("auto-lock-account"),
     keyRingV2Service,
@@ -313,6 +323,11 @@ export function init(
     keyRingStarknetService,
     permissionInteractiveService
   );
+  KeyRingBitcoin.init(
+    router,
+    keyRingBitcoinService,
+    permissionInteractiveService
+  );
   PermissionInteractive.init(router, permissionInteractiveService);
   ChainsUI.init(router, chainsUIService);
   ChainsUpdate.init(router, chainsUpdateService);
@@ -343,6 +358,7 @@ export function init(
       await keyRingCosmosService.init();
       await keyRingEthereumService.init();
       await keyRingStarknetService.init();
+      await keyRingBitcoinService.init();
       await permissionService.init();
       await tokenCW20Service.init();
       await tokenERC20Service.init();

--- a/packages/background/src/keyring-bitcoin/bip322.ts
+++ b/packages/background/src/keyring-bitcoin/bip322.ts
@@ -1,0 +1,138 @@
+import * as bitcoin from "bitcoinjs-lib";
+
+/**
+ * https://github.com/ACken2/bip322-js/blob/main/src/BIP322.ts
+ * use the existing the bip322-js file with some modification, use the file directly instead of install the whole package,
+ * because the package will introduce too many dependencies.
+ * Class that handles BIP-322 related operations.
+ */
+export class BIP322 {
+  // BIP322 message tag
+  static TAG = Buffer.from("BIP0322-signed-message");
+
+  /**
+   * Compute the message hash as specified in the BIP-322.
+   * The standard is specified in BIP-340 as:
+   *      The function hashtag(x) where tag is a UTF-8 encoded tag name and x is a byte array returns the 32-byte hash SHA256(SHA256(tag) || SHA256(tag) || x).
+   * @param message Message to be hashed
+   * @returns Hashed message
+   */
+  public static hashMessage(message: string): Buffer {
+    // Compute the message hash - SHA256(SHA256(tag) || SHA256(tag) || message)
+    const { sha256 } = bitcoin.crypto;
+    const tagHash = sha256(this.TAG);
+    const result = sha256(
+      Buffer.concat([tagHash, tagHash, Buffer.from(message)])
+    );
+    return result;
+  }
+
+  /**
+   * Build a to_spend transaction using simple signature in accordance to the BIP-322.
+   * @param message Message to be signed using BIP-322
+   * @param scriptPublicKey The script public key for the signing wallet
+   * @returns Bitcoin transaction that correspond to the to_spend transaction
+   */
+  public static buildToSpendTx(
+    message: string,
+    scriptPublicKey: Buffer
+  ): bitcoin.Transaction {
+    // Create PSBT object for constructing the transaction
+    const psbt = new bitcoin.Psbt();
+    // Set default value for nVersion and nLockTime
+    psbt.setVersion(0); // nVersion = 0
+    psbt.setLocktime(0); // nLockTime = 0
+    // Compute the message hash - SHA256(SHA256(tag) || SHA256(tag) || message)
+    const messageHash = this.hashMessage(message);
+    // Construct the scriptSig - OP_0 PUSH32[ message_hash ]
+    const OP_0_CODE = 0x00; // OP_0
+    const PUSH32_CODE = 0x20; // PUSH32
+    const scriptSigPartOne = new Uint8Array([OP_0_CODE, PUSH32_CODE]); // OP_0 PUSH32
+    const scriptSig = new Uint8Array(
+      scriptSigPartOne.length + messageHash.length
+    );
+    scriptSig.set(scriptSigPartOne);
+    scriptSig.set(messageHash, scriptSigPartOne.length);
+    // Set the input
+    psbt.addInput({
+      hash: "0".repeat(64), // vin[0].prevout.hash = 0000...000
+      index: 0xffffffff, // vin[0].prevout.n = 0xFFFFFFFF
+      sequence: 0, // vin[0].nSequence = 0
+      finalScriptSig: Buffer.from(scriptSig), // vin[0].scriptSig = OP_0 PUSH32[ message_hash ]
+      witnessScript: Buffer.from([]), // vin[0].scriptWitness = []
+    });
+    // Set the output
+    psbt.addOutput({
+      value: 0, // vout[0].nValue = 0
+      script: scriptPublicKey, // vout[0].scriptPubKey = message_challenge
+    });
+    // Return transaction
+    return psbt.extractTransaction();
+  }
+
+  /**
+   * Build a to_sign transaction using simple signature in accordance to the BIP-322.
+   * @param toSpendTxId Transaction ID of the to_spend transaction as constructed by buildToSpendTx
+   * @param witnessScript The script public key for the signing wallet, or the redeemScript for P2SH-P2WPKH address
+   * @param isRedeemScript Set to true if the provided witnessScript is a redeemScript for P2SH-P2WPKH address, default to false
+   * @param tapInternalKey Used to set the taproot internal public key of a taproot signing address when provided, default to undefined
+   * @returns Ready-to-be-signed bitcoinjs.Psbt transaction
+   */
+  public static buildToSignTx(
+    toSpendTxId: string,
+    witnessScript: Buffer,
+    isRedeemScript: boolean = false,
+    tapInternalKey?: Buffer
+  ): bitcoin.Psbt {
+    // Create PSBT object for constructing the transaction
+    const psbt = new bitcoin.Psbt();
+    // Set default value for nVersion and nLockTime
+    psbt.setVersion(0); // nVersion = 0
+    psbt.setLocktime(0); // nLockTime = 0
+    // Set the input
+    psbt.addInput({
+      hash: toSpendTxId, // vin[0].prevout.hash = to_spend.txid
+      index: 0, // vin[0].prevout.n = 0
+      sequence: 0, // vin[0].nSequence = 0
+      witnessUtxo: {
+        script: witnessScript,
+        value: 0,
+      },
+    });
+    // Set redeemScript as witnessScript if isRedeemScript
+    if (isRedeemScript) {
+      psbt.updateInput(0, {
+        redeemScript: witnessScript,
+      });
+    }
+    // Set tapInternalKey if provided
+    if (tapInternalKey) {
+      psbt.updateInput(0, {
+        tapInternalKey: tapInternalKey,
+      });
+    }
+    // Set the output
+    const OP_RETURN_CODE = 0x6a; // OP_RETURN
+    psbt.addOutput({
+      value: 0, // vout[0].nValue = 0
+      script: Buffer.from([OP_RETURN_CODE]), // vout[0].scriptPubKey = OP_RETURN
+    });
+    return psbt;
+  }
+
+  /**
+   * Encode witness stack in a signed BIP-322 PSBT into its base-64 encoded format.
+   * @param signedPsbt Signed PSBT
+   * @returns Base-64 encoded witness data
+   */
+  public static encodeWitness(signedPsbt: bitcoin.Psbt): string {
+    // Obtain the signed witness data
+    const witness = signedPsbt.data.inputs[0].finalScriptWitness;
+    // Check if the witness data is present
+    if (!witness) {
+      throw new Error("Cannot encode empty witness stack.");
+    }
+    // Return the base-64 encoded witness stack
+    return witness.toString("base64");
+  }
+}

--- a/packages/background/src/keyring-bitcoin/constants.ts
+++ b/packages/background/src/keyring-bitcoin/constants.ts
@@ -1,0 +1,1 @@
+export const ROUTE = "keyring-bitcoin";

--- a/packages/background/src/keyring-bitcoin/constants.ts
+++ b/packages/background/src/keyring-bitcoin/constants.ts
@@ -1,1 +1,27 @@
 export const ROUTE = "keyring-bitcoin";
+
+export const mainnet = {
+  messagePrefix: "\x18Bitcoin Signed Message:\n",
+  bech32: "bc",
+  bip32: {
+    public: 0x0488b21e,
+    private: 0x0488ade4,
+  },
+  pubKeyHash: 0x00,
+  scriptHash: 0x05,
+  wif: 0x80,
+};
+
+export const testnet = {
+  messagePrefix: "\x18Bitcoin Signed Message:\n",
+  bech32: "tb",
+  bip32: {
+    public: 0x043587cf,
+    private: 0x04358394,
+  },
+  pubKeyHash: 0x6f,
+  scriptHash: 0xc4,
+  wif: 0xef,
+};
+
+export const signet = testnet;

--- a/packages/background/src/keyring-bitcoin/handler.ts
+++ b/packages/background/src/keyring-bitcoin/handler.ts
@@ -1,0 +1,186 @@
+import {
+  Handler,
+  InternalHandler,
+  KeplrError,
+  Message,
+} from "@keplr-wallet/router";
+
+import { Env } from "@keplr-wallet/router";
+import { KeyRingBitcoinService } from "./service";
+import { PermissionInteractiveService } from "src/permission-interactive";
+import {
+  GetBitcoinKeyMsg,
+  GetBitcoinKeysForEachVaultSettledMsg,
+  GetBitcoinKeysSettledMsg,
+  GetSupportedPaymentTypesMsg,
+  RequestSignBitcoinMessageMsg,
+  RequestSignBitcoinPsbtMsg,
+  RequestSignBitcoinPsbtsMsg,
+} from "./messages";
+
+export const getHandler: (
+  service: KeyRingBitcoinService,
+  permissionInteractionService: PermissionInteractiveService
+) => Handler = (
+  _service: KeyRingBitcoinService,
+  _permissionInteractionService
+) => {
+  return (env: Env, msg: Message<unknown>) => {
+    switch (msg.constructor) {
+      case GetBitcoinKeyMsg:
+        return handleGetBitcoinKeyMsg(_service, _permissionInteractionService)(
+          env,
+          msg as GetBitcoinKeyMsg
+        );
+      case GetBitcoinKeysSettledMsg:
+        return handleGetBitcoinKeysSettledMsg(
+          _service,
+          _permissionInteractionService
+        )(env, msg as GetBitcoinKeysSettledMsg);
+      case GetBitcoinKeysForEachVaultSettledMsg:
+        return handleGetBitcoinKeysForEachVaultSettledMsg(_service)(
+          env,
+          msg as GetBitcoinKeysForEachVaultSettledMsg
+        );
+      case RequestSignBitcoinPsbtMsg:
+        return handleRequestSignBitcoinPsbtMsg(
+          _service,
+          _permissionInteractionService
+        )(env, msg as RequestSignBitcoinPsbtMsg);
+      case RequestSignBitcoinPsbtsMsg:
+        return handleRequestSignBitcoinPsbtsMsg(
+          _service,
+          _permissionInteractionService
+        )(env, msg as RequestSignBitcoinPsbtsMsg);
+
+      case RequestSignBitcoinMessageMsg:
+        return handleRequestSignBitcoinMessageMsg(
+          _service,
+          _permissionInteractionService
+        )(env, msg as RequestSignBitcoinMessageMsg);
+      case GetSupportedPaymentTypesMsg:
+        return handleGetSupportedPaymentTypesMsg(_service)(
+          env,
+          msg as GetSupportedPaymentTypesMsg
+        );
+      default:
+        throw new KeplrError("keyring", 221, "Unknown msg type");
+    }
+  };
+};
+
+const handleGetBitcoinKeyMsg: (
+  service: KeyRingBitcoinService,
+  permissionInteractionService: PermissionInteractiveService
+) => InternalHandler<GetBitcoinKeyMsg> = (
+  service,
+  permissionInteractionService
+) => {
+  return async (env, msg) => {
+    await permissionInteractionService.ensureEnabledForBitcoin(env, msg.origin);
+
+    return await service.getBitcoinKeySelected(msg.chainId);
+  };
+};
+
+const handleGetBitcoinKeysSettledMsg: (
+  service: KeyRingBitcoinService,
+  permissionInteractionService: PermissionInteractiveService
+) => InternalHandler<GetBitcoinKeysSettledMsg> = (
+  service,
+  permissionInteractionService
+) => {
+  return async (env, msg) => {
+    await permissionInteractionService.ensureEnabledForBitcoin(env, msg.origin);
+
+    return await Promise.allSettled(
+      msg.chainConfigs.map((chainConfig) =>
+        service.getBitcoinKeySelected(chainConfig.chainId)
+      )
+    );
+  };
+};
+
+const handleGetBitcoinKeysForEachVaultSettledMsg: (
+  service: KeyRingBitcoinService
+) => InternalHandler<GetBitcoinKeysForEachVaultSettledMsg> = (service) => {
+  return async (_, msg) => {
+    return await Promise.allSettled(
+      msg.vaultIds.map((vaultId) =>
+        (async () => {
+          const key = await service.getBitcoinKey(vaultId, msg.chainId);
+          return {
+            vaultId,
+            ...key,
+          };
+        })()
+      )
+    );
+  };
+};
+
+const handleRequestSignBitcoinPsbtMsg: (
+  service: KeyRingBitcoinService,
+  permissionInteractionService: PermissionInteractiveService
+) => InternalHandler<RequestSignBitcoinPsbtMsg> = (
+  service,
+  permissionInteractionService
+) => {
+  return async (env, msg) => {
+    await permissionInteractionService.ensureEnabledForBitcoin(env, msg.origin);
+
+    return await service.signPsbtSelected(
+      env,
+      msg.origin,
+      msg.chainId,
+      msg.psbt
+    );
+  };
+};
+
+const handleRequestSignBitcoinPsbtsMsg: (
+  service: KeyRingBitcoinService,
+  permissionInteractionService: PermissionInteractiveService
+) => InternalHandler<RequestSignBitcoinPsbtsMsg> = (
+  service,
+  permissionInteractionService
+) => {
+  return async (env, msg) => {
+    await permissionInteractionService.ensureEnabledForBitcoin(env, msg.origin);
+
+    return await service.signPsbtsSelected(
+      env,
+      msg.origin,
+      msg.chainId,
+      msg.psbts
+    );
+  };
+};
+
+const handleRequestSignBitcoinMessageMsg: (
+  service: KeyRingBitcoinService,
+  permissionInteractionService: PermissionInteractiveService
+) => InternalHandler<RequestSignBitcoinMessageMsg> = (
+  service,
+  permissionInteractionService
+) => {
+  return async (env, msg) => {
+    await permissionInteractionService.ensureEnabledForBitcoin(env, msg.origin);
+
+    return await service.signMessageSelected(
+      env,
+      msg.origin,
+      msg.chainId,
+      msg.message,
+      msg.signType
+    );
+  };
+};
+
+const handleGetSupportedPaymentTypesMsg: (
+  service: KeyRingBitcoinService
+) => InternalHandler<GetSupportedPaymentTypesMsg> = (service) => {
+  return async (_) => {
+    return await service.getSupportedPaymentTypes();
+  };
+};

--- a/packages/background/src/keyring-bitcoin/handler.ts
+++ b/packages/background/src/keyring-bitcoin/handler.ts
@@ -79,7 +79,7 @@ const handleGetBitcoinKeyMsg: (
   return async (env, msg) => {
     await permissionInteractionService.ensureEnabledForBitcoin(env, msg.origin);
 
-    return await service.getBitcoinKeySelected(msg.chainId);
+    return await service.getBitcoinKeySelected(msg.chainId, msg.paymentType);
   };
 };
 
@@ -94,9 +94,7 @@ const handleGetBitcoinKeysSettledMsg: (
     await permissionInteractionService.ensureEnabledForBitcoin(env, msg.origin);
 
     return await Promise.allSettled(
-      msg.chainConfigs.map((chainConfig) =>
-        service.getBitcoinKeySelected(chainConfig.chainId)
-      )
+      msg.chainIds.map((chainId) => service.getBitcoinKeySelected(chainId))
     );
   };
 };
@@ -181,6 +179,6 @@ const handleGetSupportedPaymentTypesMsg: (
   service: KeyRingBitcoinService
 ) => InternalHandler<GetSupportedPaymentTypesMsg> = (service) => {
   return async (_) => {
-    return await service.getSupportedPaymentTypes();
+    return service.getSupportedPaymentTypes();
   };
 };

--- a/packages/background/src/keyring-bitcoin/handler.ts
+++ b/packages/background/src/keyring-bitcoin/handler.ts
@@ -79,7 +79,7 @@ const handleGetBitcoinKeyMsg: (
   return async (env, msg) => {
     await permissionInteractionService.ensureEnabledForBitcoin(env, msg.origin);
 
-    return await service.getBitcoinKeySelected(msg.chainId, msg.paymentType);
+    return await service.getBitcoinKeySelected(msg.chainId);
   };
 };
 

--- a/packages/background/src/keyring-bitcoin/helper.ts
+++ b/packages/background/src/keyring-bitcoin/helper.ts
@@ -1,0 +1,70 @@
+export function encodeLegacyMessage(
+  message: string,
+  messagePrefix?: string
+): Uint8Array {
+  const encoder = new TextEncoder();
+
+  const magicBytes = encoder.encode(
+    messagePrefix || "\u0018Bitcoin Signed Message:\n"
+  );
+  const messageBytes = encoder.encode(message);
+
+  const messageLength = encodeVarInt(messageBytes.length);
+
+  const totalLength =
+    magicBytes.length + messageLength.length + messageBytes.length;
+  const buffer = new Uint8Array(totalLength);
+
+  let offset = 0;
+  buffer.set(magicBytes, offset);
+  offset += magicBytes.length;
+  buffer.set(messageLength, offset);
+  offset += messageLength.length;
+  buffer.set(messageBytes, offset);
+
+  return buffer;
+}
+
+// https://github.com/bitcoinjs/bitcoinjs-message
+export function encodeLegacySignature(
+  r: Uint8Array,
+  s: Uint8Array,
+  recovery: number,
+  compressed: boolean,
+  segwitType: "p2wpkh" | "p2sh-p2wpkh"
+) {
+  if (segwitType !== undefined) {
+    recovery += 8;
+    if (segwitType === "p2wpkh") recovery += 4;
+  } else {
+    if (compressed) recovery += 4;
+  }
+  return Buffer.concat([Buffer.alloc(1, recovery + 27), r, s]);
+}
+
+function encodeVarInt(value: number): Uint8Array {
+  let buffer: Uint8Array;
+  let dataView: DataView;
+
+  if (value < 253) {
+    buffer = new Uint8Array(1);
+    buffer[0] = value;
+  } else if (value < 0x10000) {
+    buffer = new Uint8Array(3);
+    buffer[0] = 253;
+    dataView = new DataView(buffer.buffer);
+    dataView.setUint16(1, value, true);
+  } else if (value < 0x100000000) {
+    buffer = new Uint8Array(5);
+    buffer[0] = 254;
+    dataView = new DataView(buffer.buffer);
+    dataView.setUint32(1, value, true);
+  } else {
+    buffer = new Uint8Array(9);
+    buffer[0] = 255;
+    dataView = new DataView(buffer.buffer);
+    dataView.setInt32(1, value & -1, true);
+    dataView.setUint32(5, Math.floor(value / 0x100000000), true);
+  }
+  return buffer;
+}

--- a/packages/background/src/keyring-bitcoin/index.ts
+++ b/packages/background/src/keyring-bitcoin/index.ts
@@ -1,0 +1,2 @@
+export * from "./service";
+export * from "./messages";

--- a/packages/background/src/keyring-bitcoin/init.ts
+++ b/packages/background/src/keyring-bitcoin/init.ts
@@ -1,0 +1,28 @@
+import { Router } from "@keplr-wallet/router";
+import { KeyRingBitcoinService } from "./service";
+import { ROUTE } from "./constants";
+import { getHandler } from "./handler";
+import { PermissionInteractiveService } from "../permission-interactive";
+import {
+  GetBitcoinKeyMsg,
+  GetBitcoinKeysSettledMsg,
+  GetBitcoinKeysForEachVaultSettledMsg,
+  RequestSignBitcoinMessageMsg,
+  RequestSignBitcoinPsbtMsg,
+  RequestSignBitcoinPsbtsMsg,
+} from "./messages";
+
+export function init(
+  router: Router,
+  service: KeyRingBitcoinService,
+  permissionInteractionService: PermissionInteractiveService
+): void {
+  router.registerMessage(GetBitcoinKeyMsg);
+  router.registerMessage(GetBitcoinKeysSettledMsg);
+  router.registerMessage(GetBitcoinKeysForEachVaultSettledMsg);
+  router.registerMessage(RequestSignBitcoinMessageMsg);
+  router.registerMessage(RequestSignBitcoinPsbtMsg);
+  router.registerMessage(RequestSignBitcoinPsbtsMsg);
+
+  router.addHandler(ROUTE, getHandler(service, permissionInteractionService));
+}

--- a/packages/background/src/keyring-bitcoin/internal.ts
+++ b/packages/background/src/keyring-bitcoin/internal.ts
@@ -1,0 +1,2 @@
+export * from "./service";
+export * from "./init";

--- a/packages/background/src/keyring-bitcoin/messages.ts
+++ b/packages/background/src/keyring-bitcoin/messages.ts
@@ -1,12 +1,18 @@
 import { Message } from "@keplr-wallet/router";
-import { SettledResponses, SupportedPaymentType } from "@keplr-wallet/types";
+import {
+  BitcoinSignMessageType,
+  SettledResponses,
+  SupportedPaymentType,
+} from "@keplr-wallet/types";
 import { ROUTE } from "./constants";
 import { Psbt } from "bitcoinjs-lib";
 
 export class GetBitcoinKeyMsg extends Message<{
+  name: string;
   pubKey: Uint8Array;
   address: string;
   paymentType: SupportedPaymentType;
+  isNanoLedger: boolean;
 }> {
   public static type() {
     return "get-bitcoin-key";
@@ -51,26 +57,21 @@ export class GetBitcoinKeysSettledMsg extends Message<
     return "get-bitcoin-keys-settled";
   }
 
-  constructor(
-    public readonly chainConfigs: Array<{
-      chainId: string;
-      paymentType?: SupportedPaymentType;
-    }>
-  ) {
+  constructor(public readonly chainIds: string[]) {
     super();
   }
 
   validateBasic(): void {
-    if (!this.chainConfigs || this.chainConfigs.length === 0) {
-      throw new Error("chainConfigs are not set");
+    if (!this.chainIds || this.chainIds.length === 0) {
+      throw new Error("chainIds are not set");
     }
 
     const seen = new Map<string, boolean>();
-    for (const config of this.chainConfigs) {
-      if (seen.has(config.chainId)) {
-        throw new Error(`chainId ${config.chainId} is duplicated`);
+    for (const chainId of this.chainIds) {
+      if (seen.has(chainId)) {
+        throw new Error(`chainId ${chainId} is duplicated`);
       }
-      seen.set(config.chainId, true);
+      seen.set(chainId, true);
     }
   }
 
@@ -208,7 +209,7 @@ export class RequestSignBitcoinMessageMsg extends Message<string> {
   constructor(
     public readonly chainId: string,
     public readonly message: string,
-    public readonly signType: "ecdsa" | "bip322-simple"
+    public readonly signType: BitcoinSignMessageType
   ) {
     super();
   }

--- a/packages/background/src/keyring-bitcoin/messages.ts
+++ b/packages/background/src/keyring-bitcoin/messages.ts
@@ -18,10 +18,7 @@ export class GetBitcoinKeyMsg extends Message<{
     return "get-bitcoin-key";
   }
 
-  constructor(
-    public readonly chainId: string,
-    public readonly paymentType?: SupportedPaymentType
-  ) {
+  constructor(public readonly chainId: string) {
     super();
   }
 

--- a/packages/background/src/keyring-bitcoin/messages.ts
+++ b/packages/background/src/keyring-bitcoin/messages.ts
@@ -1,0 +1,267 @@
+import { Message } from "@keplr-wallet/router";
+import { SettledResponses, SupportedPaymentType } from "@keplr-wallet/types";
+import { ROUTE } from "./constants";
+import { Psbt } from "bitcoinjs-lib";
+
+export class GetBitcoinKeyMsg extends Message<{
+  pubKey: Uint8Array;
+  address: string;
+  paymentType: SupportedPaymentType;
+}> {
+  public static type() {
+    return "get-bitcoin-key";
+  }
+
+  constructor(
+    public readonly chainId: string,
+    public readonly paymentType?: SupportedPaymentType
+  ) {
+    super();
+  }
+
+  validateBasic(): void {
+    if (!this.chainId) {
+      throw new Error("chainId is not set");
+    }
+  }
+
+  override approveExternal(): boolean {
+    return true;
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return GetBitcoinKeyMsg.type();
+  }
+}
+
+export class GetBitcoinKeysSettledMsg extends Message<
+  SettledResponses<{
+    name: string;
+    pubKey: Uint8Array;
+    address: string;
+    paymentType: SupportedPaymentType;
+    isNanoLedger: boolean;
+  }>
+> {
+  public static type() {
+    return "get-bitcoin-keys-settled";
+  }
+
+  constructor(
+    public readonly chainConfigs: Array<{
+      chainId: string;
+      paymentType?: SupportedPaymentType;
+    }>
+  ) {
+    super();
+  }
+
+  validateBasic(): void {
+    if (!this.chainConfigs || this.chainConfigs.length === 0) {
+      throw new Error("chainConfigs are not set");
+    }
+
+    const seen = new Map<string, boolean>();
+    for (const config of this.chainConfigs) {
+      if (seen.has(config.chainId)) {
+        throw new Error(`chainId ${config.chainId} is duplicated`);
+      }
+      seen.set(config.chainId, true);
+    }
+  }
+
+  override approveExternal(): boolean {
+    return true;
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return GetBitcoinKeysSettledMsg.type();
+  }
+}
+
+export class GetBitcoinKeysForEachVaultSettledMsg extends Message<
+  SettledResponses<
+    {
+      name: string;
+      pubKey: Uint8Array;
+      address: string;
+      paymentType: SupportedPaymentType;
+      isNanoLedger: boolean;
+    } & {
+      vaultId: string;
+    }
+  >
+> {
+  public static type() {
+    return "get-bitcoin-keys-for-each-vault-settled";
+  }
+
+  constructor(
+    public readonly chainId: string,
+    public readonly vaultIds: string[]
+  ) {
+    super();
+  }
+
+  validateBasic(): void {
+    if (!this.chainId) {
+      throw new Error("chain id not set");
+    }
+
+    if (!this.vaultIds || this.vaultIds.length === 0) {
+      throw new Error("vaultIds are not set");
+    }
+
+    const seen = new Map<string, boolean>();
+    for (const vaultId of this.vaultIds) {
+      if (seen.has(vaultId)) {
+        throw new Error(`vaultId ${vaultId} is duplicated`);
+      }
+      seen.set(vaultId, true);
+    }
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return GetBitcoinKeysForEachVaultSettledMsg.type();
+  }
+}
+
+export class RequestSignBitcoinPsbtMsg extends Message<string> {
+  public static type() {
+    return "request-sign-bitcoin-psbt";
+  }
+
+  constructor(public readonly chainId: string, public readonly psbt: Psbt) {
+    super();
+  }
+
+  validateBasic(): void {
+    if (!this.chainId) {
+      throw new Error("chainId is not set");
+    }
+    if (!this.psbt) {
+      throw new Error("psbt is not set");
+    }
+  }
+
+  override approveExternal(): boolean {
+    return true;
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return RequestSignBitcoinPsbtMsg.type();
+  }
+}
+
+export class RequestSignBitcoinPsbtsMsg extends Message<string[]> {
+  public static type() {
+    return "request-sign-bitcoin-psbts";
+  }
+
+  constructor(public readonly chainId: string, public readonly psbts: Psbt[]) {
+    super();
+  }
+
+  validateBasic(): void {
+    if (!this.chainId) {
+      throw new Error("chainId is not set");
+    }
+    if (!this.psbts || this.psbts.length === 0) {
+      throw new Error("psbts are not set or empty");
+    }
+  }
+
+  override approveExternal(): boolean {
+    return true;
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return RequestSignBitcoinPsbtsMsg.type();
+  }
+}
+
+export class RequestSignBitcoinMessageMsg extends Message<string> {
+  public static type() {
+    return "request-sign-bitcoin-message";
+  }
+
+  constructor(
+    public readonly chainId: string,
+    public readonly message: string,
+    public readonly signType: "ecdsa" | "bip322-simple"
+  ) {
+    super();
+  }
+
+  validateBasic(): void {
+    if (!this.chainId) {
+      throw new Error("chainId is not set");
+    }
+    if (!this.message) {
+      throw new Error("message is not set");
+    }
+    if (!this.signType) {
+      throw new Error("signType is not set");
+    }
+  }
+
+  override approveExternal(): boolean {
+    return true;
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return RequestSignBitcoinMessageMsg.type();
+  }
+}
+
+export class GetSupportedPaymentTypesMsg extends Message<
+  SupportedPaymentType[]
+> {
+  public static type() {
+    return "get-supported-payment-types";
+  }
+
+  constructor() {
+    super();
+  }
+
+  validateBasic(): void {
+    // noop
+  }
+
+  override approveExternal(): boolean {
+    return true;
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return GetSupportedPaymentTypesMsg.type();
+  }
+}

--- a/packages/background/src/keyring-bitcoin/service.ts
+++ b/packages/background/src/keyring-bitcoin/service.ts
@@ -1,0 +1,391 @@
+import { ChainsService } from "../chains";
+import { VaultService } from "../vault";
+import { KeyRingService } from "../keyring";
+import { InteractionService } from "../interaction";
+import { AnalyticsService } from "../analytics";
+import { PermissionService } from "../permission";
+import { PermissionInteractiveService } from "../permission-interactive";
+import { BackgroundTxService } from "src/tx";
+import { SupportedPaymentType } from "@keplr-wallet/types";
+import { Env, KeplrError } from "@keplr-wallet/router";
+import { Psbt, payments } from "bitcoinjs-lib";
+import { encodeLegacyMessage, encodeLegacySignature } from "./helper";
+import { toXOnly } from "@keplr-wallet/crypto";
+import { BIP322 } from "./bip322";
+
+export class KeyRingBitcoinService {
+  constructor(
+    protected readonly chainsService: ChainsService,
+    protected readonly vaultService: VaultService,
+    protected readonly keyRingService: KeyRingService,
+    protected readonly interactionService: InteractionService,
+    protected readonly analyticsService: AnalyticsService,
+    protected readonly permissionService: PermissionService,
+    protected readonly permissionInteractiveService: PermissionInteractiveService,
+    protected readonly backgroundTxService: BackgroundTxService
+  ) {}
+
+  async init() {
+    // noop
+  }
+
+  async getBitcoinKey(
+    vaultId: string,
+    chainId: string,
+    paymentType?: SupportedPaymentType
+  ): Promise<{
+    name: string;
+    pubKey: Uint8Array;
+    address: string;
+    paymentType: SupportedPaymentType;
+    isNanoLedger: boolean;
+  }> {
+    const keyInfo = this.keyRingService.getKeyInfo(vaultId);
+    if (!keyInfo) {
+      throw new KeplrError("keyring", 221, "Null key info");
+    }
+
+    const params = await this.getBitcoinKeyParams(
+      vaultId,
+      chainId,
+      paymentType
+    );
+
+    return {
+      name: keyInfo.name,
+      pubKey: params.pubKey,
+      address: params.address,
+      paymentType: params.paymentType,
+      isNanoLedger: keyInfo.type === "ledger",
+    };
+  }
+
+  async getBitcoinKeySelected(
+    chainId: string,
+    paymentType?: SupportedPaymentType
+  ): Promise<{
+    name: string;
+    pubKey: Uint8Array;
+    address: string;
+    paymentType: SupportedPaymentType;
+    isNanoLedger: boolean;
+  }> {
+    return await this.getBitcoinKey(
+      this.keyRingService.selectedVaultId,
+      chainId,
+      paymentType
+    );
+  }
+
+  async getBitcoinKeyParams(
+    vaultId: string,
+    chainId: string,
+    paymentType?: SupportedPaymentType
+  ): Promise<{
+    pubKey: Uint8Array;
+    address: string;
+    paymentType: SupportedPaymentType;
+  }> {
+    const chainInfo = this.chainsService.getModularChainInfoOrThrow(chainId);
+    if (!("bitcoin" in chainInfo)) {
+      throw new KeplrError("keyring", 221, "Chain is not a bitcoin chain");
+    }
+
+    const vault = this.vaultService.getVault("keyRing", vaultId);
+    if (!vault) {
+      throw new KeplrError("keyring", 221, "Vault not found");
+    }
+
+    // TODO: Ledger support
+    // const isLedger = vault.insensitive["keyRingType"] === "ledger";
+
+    const bitcoinPubKey = (
+      await this.keyRingService.getPubKey(chainId, vaultId)
+    ).toBitcoinPubKey();
+
+    const network = this.getNetwork(chainId);
+
+    let address: string | undefined;
+
+    if (paymentType === SupportedPaymentType.NATIVE_SEGWIT) {
+      const nativeSegwitAddress = bitcoinPubKey.getNativeSegwitAddress(network);
+      if (nativeSegwitAddress) {
+        address = nativeSegwitAddress;
+      }
+    } else {
+      const taprootAddress = bitcoinPubKey.getTaprootAddress(network);
+      if (taprootAddress) {
+        address = taprootAddress;
+      }
+    }
+
+    if (!address) {
+      throw new KeplrError("keyring", 221, "No payment address found");
+    }
+
+    return {
+      pubKey: bitcoinPubKey.toBytes(),
+      address,
+      paymentType: paymentType || SupportedPaymentType.TAPROOT,
+    };
+  }
+
+  async signPsbtSelected(
+    env: Env,
+    origin: string,
+    chainId: string,
+    psbt: Psbt
+  ) {
+    return await this.signPsbt(
+      env,
+      origin,
+      this.keyRingService.selectedVaultId,
+      chainId,
+      psbt
+    );
+  }
+
+  async signPsbtsSelected(
+    env: Env,
+    origin: string,
+    chainId: string,
+    psbts: Psbt[]
+  ) {
+    return await this.signPsbts(
+      env,
+      origin,
+      this.keyRingService.selectedVaultId,
+      chainId,
+      psbts
+    );
+  }
+
+  async signPsbts(
+    env: Env,
+    origin: string,
+    vaultId: string,
+    chainId: string,
+    psbts: Psbt[]
+  ) {
+    const keyInfo = this.keyRingService.getKeyInfo(vaultId);
+    if (!keyInfo) {
+      throw new KeplrError("keyring", 221, "Null key info");
+    }
+
+    const bitcoinPubKey = await this.getBitcoinKeySelected(chainId);
+
+    const network = this.getNetwork(chainId);
+
+    return await this.interactionService.waitApproveV2(
+      env,
+      "/sign-bitcoin-psbt",
+      "request-sign-bitcoin-psbt",
+      {
+        origin,
+        vaultId,
+        chainId,
+        address: bitcoinPubKey.address,
+        pubKey: bitcoinPubKey.pubKey,
+        network,
+        psbts,
+        keyType: keyInfo.type,
+        keyInsensitive: keyInfo.insensitive,
+      },
+      async (res: { signedPsbts: Psbt[] }) => {
+        if (res.signedPsbts) {
+          return res.signedPsbts.map((psbt) => psbt.toHex());
+        }
+
+        const signedPsbts = await Promise.all(
+          psbts.map((psbt) =>
+            this.keyRingService.signPsbt(chainId, vaultId, psbt)
+          )
+        );
+
+        return signedPsbts.map((psbt) => psbt.toHex());
+      }
+    );
+  }
+
+  async signPsbt(
+    env: Env,
+    origin: string,
+    vaultId: string,
+    chainId: string,
+    psbt: Psbt
+  ) {
+    const keyInfo = this.keyRingService.getKeyInfo(vaultId);
+    if (!keyInfo) {
+      throw new KeplrError("keyring", 221, "Null key info");
+    }
+
+    const bitcoinPubKey = await this.getBitcoinKeySelected(chainId);
+
+    const network = this.getNetwork(chainId);
+
+    return await this.interactionService.waitApproveV2(
+      env,
+      "/sign-bitcoin-psbt",
+      "request-sign-bitcoin-psbt",
+      {
+        origin,
+        vaultId,
+        chainId,
+        address: bitcoinPubKey.address,
+        pubKey: bitcoinPubKey.pubKey,
+        network,
+        psbt,
+        keyType: keyInfo.type,
+        keyInsensitive: keyInfo.insensitive,
+      },
+      async (res: { signedPsbt: Psbt }) => {
+        if (res.signedPsbt) {
+          return res.signedPsbt.toHex();
+        }
+
+        const signedPsbt = await this.keyRingService.signPsbt(
+          chainId,
+          vaultId,
+          psbt
+        );
+
+        return signedPsbt.toHex();
+      }
+    );
+  }
+
+  async signMessageSelected(
+    env: Env,
+    origin: string,
+    chainId: string,
+    message: string,
+    signType: "ecdsa" | "bip322-simple"
+  ) {
+    return await this.signMessage(
+      env,
+      origin,
+      this.keyRingService.selectedVaultId,
+      chainId,
+      message,
+      signType
+    );
+  }
+
+  async signMessage(
+    env: Env,
+    origin: string,
+    vaultId: string,
+    chainId: string,
+    message: string,
+    signType: "ecdsa" | "bip322-simple"
+  ) {
+    const keyInfo = this.keyRingService.getKeyInfo(vaultId);
+    if (!keyInfo) {
+      throw new KeplrError("keyring", 221, "Null key info");
+    }
+
+    const bitcoinPubKey = await this.getBitcoinKey(
+      vaultId,
+      chainId,
+      signType === "ecdsa"
+        ? SupportedPaymentType.NATIVE_SEGWIT
+        : SupportedPaymentType.TAPROOT
+    );
+
+    const network = this.getNetwork(chainId);
+
+    return await this.interactionService.waitApproveV2(
+      env,
+      "/sign-bitcoin-message",
+      "request-sign-bitcoin-message",
+      {
+        origin,
+        vaultId,
+        chainId,
+        address: bitcoinPubKey.address,
+        pubKey: bitcoinPubKey.pubKey,
+        network,
+        message,
+        signType,
+        keyType: keyInfo.type,
+        keyInsensitive: keyInfo.insensitive,
+      },
+      async (res: { message: string; signatureHex: string }) => {
+        const { signatureHex } = res;
+        if (signatureHex) {
+          return signatureHex;
+        }
+
+        // legacy signature
+        if (signType === "ecdsa") {
+          const data = encodeLegacyMessage(network.messagePrefix, message);
+
+          const sig = await this.keyRingService.sign(
+            chainId,
+            vaultId,
+            data,
+            "hash256"
+          );
+
+          const encodedSignature = encodeLegacySignature(
+            sig.r,
+            sig.s,
+            sig.v ?? 0, // TODO: check if this is correct
+            true,
+            "p2wpkh"
+          );
+
+          return encodedSignature.toString("hex");
+        }
+
+        const internalPubkey = toXOnly(Buffer.from(bitcoinPubKey.pubKey));
+        const p2tr = payments.p2tr({
+          internalPubkey,
+          network,
+        });
+        if (!p2tr.output) {
+          throw new KeplrError("keyring", 221, "Invalid pubkey");
+        }
+
+        const txToSpend = BIP322.buildToSpendTx(message, p2tr.output);
+        const txToSign = BIP322.buildToSignTx(
+          txToSpend.getId(),
+          p2tr.output,
+          false,
+          internalPubkey
+        );
+
+        const signedPsbt = await this.keyRingService.signPsbt(
+          chainId,
+          vaultId,
+          txToSign
+        );
+
+        return BIP322.encodeWitness(signedPsbt);
+      }
+    );
+  }
+
+  async getSupportedPaymentTypes() {
+    return [SupportedPaymentType.NATIVE_SEGWIT, SupportedPaymentType.TAPROOT];
+  }
+
+  private getNetwork(chainId: string) {
+    const chainInfo = this.chainsService.getModularChainInfoOrThrow(chainId);
+    if (!("bitcoin" in chainInfo)) {
+      throw new KeplrError("keyring", 221, "Chain is not a bitcoin chain");
+    }
+
+    return {
+      messagePrefix: chainInfo.bitcoin.messagePrefix,
+      bech32: chainInfo.bitcoin.bech32,
+      bip32: {
+        public: -1,
+        private: -1,
+      },
+      pubKeyHash: chainInfo.bitcoin.pubKeyHash,
+      scriptHash: -1,
+      wif: -1,
+    };
+  }
+}

--- a/packages/background/src/keyring-bitcoin/service.ts
+++ b/packages/background/src/keyring-bitcoin/service.ts
@@ -340,8 +340,8 @@ export class KeyRingBitcoinService {
           const encodedSignature = encodeLegacySignature(
             sig.r,
             sig.s,
-            sig.v ?? 0, // TODO: check if this is correct
-            true,
+            sig.v!,
+            true, // @noble/curves/secp256k1 is using compressed pubkey
             "p2wpkh"
           );
 

--- a/packages/background/src/keyring-mnemonic/service.ts
+++ b/packages/background/src/keyring-mnemonic/service.ts
@@ -1,11 +1,15 @@
 import { VaultService, PlainObject, Vault } from "../vault";
 import { Buffer } from "buffer/";
+import { Buffer as NodeBuffer } from "buffer";
 import {
   Hash,
   Mnemonic,
   PrivKeySecp256k1,
   PubKeySecp256k1,
+  toXOnly,
 } from "@keplr-wallet/crypto";
+import { Psbt, payments } from "bitcoinjs-lib";
+import { taggedHash } from "bitcoinjs-lib/src/crypto";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const bip39 = require("bip39");
 
@@ -85,7 +89,7 @@ export class KeyRingMnemonicService {
     vault: Vault,
     coinType: number,
     data: Uint8Array,
-    digestMethod: "sha256" | "keccak256" | "noop"
+    digestMethod: "sha256" | "keccak256" | "hash256" | "noop"
   ): {
     readonly r: Uint8Array;
     readonly s: Uint8Array;
@@ -101,6 +105,9 @@ export class KeyRingMnemonicService {
       case "keccak256":
         digest = Hash.keccak256(data);
         break;
+      case "hash256":
+        digest = Hash.hash256(data);
+        break;
       case "noop":
         digest = data.slice();
         break;
@@ -109,6 +116,79 @@ export class KeyRingMnemonicService {
     }
 
     return privKey.signDigest32(digest);
+  }
+
+  signPsbt(vault: Vault, _coinType: number, psbt: Psbt): Promise<Psbt> {
+    const privKey = this.getPrivKey(vault, _coinType);
+    const signer = privKey.toKeyPair();
+    const tapInternalKey = toXOnly(signer.publicKey);
+    const taprootSigner = signer.tweak(taggedHash("TapTweak", tapInternalKey));
+
+    const isP2TR = (script: NodeBuffer): boolean => {
+      try {
+        payments.p2tr({ output: script });
+        return true;
+      } catch (err) {
+        return false;
+      }
+    };
+
+    const isTaprootInput = (input: any) => {
+      if (
+        !!(
+          input.tapInternalKey ||
+          input.tapMerkleRoot ||
+          (input.tapLeafScript && input.tapLeafScript.length) ||
+          (input.tapBip32Derivation && input.tapBip32Derivation.length) ||
+          (input.witnessUtxo && isP2TR(input.witnessUtxo.script))
+        )
+      ) {
+        return true;
+      }
+      return false;
+    };
+
+    for (const [index, input] of psbt.data.inputs.entries()) {
+      if (isTaprootInput(input)) {
+        if (!input.tapInternalKey) {
+          input.tapInternalKey = tapInternalKey;
+        }
+
+        // CHECK: signInputAsync might be required for hardware wallets
+
+        // sign taproot
+        psbt.signInput(index, taprootSigner);
+
+        // verify taproot
+        const isValid = psbt.validateSignaturesOfInput(
+          index,
+          (_, msgHash, signature) => {
+            return taprootSigner.verifySchnorr(msgHash, signature);
+          }
+        );
+
+        if (!isValid) {
+          throw new Error("Invalid taproot signature");
+        }
+      } else {
+        // sign ecdsa
+        psbt.signInput(index, signer);
+
+        // verify ecdsa
+        const isValid = psbt.validateSignaturesOfInput(
+          index,
+          (_, msgHash, signature) => {
+            return signer.verify(msgHash, signature);
+          }
+        );
+
+        if (!isValid) {
+          throw new Error("Invalid ecdsa signature");
+        }
+      }
+    }
+
+    return Promise.resolve(psbt.finalizeAllInputs());
   }
 
   protected getPrivKey(vault: Vault, coinType: number): PrivKeySecp256k1 {

--- a/packages/background/src/keyring-private-key/service.ts
+++ b/packages/background/src/keyring-private-key/service.ts
@@ -1,6 +1,14 @@
 import { VaultService, PlainObject, Vault } from "../vault";
 import { Buffer } from "buffer/";
-import { Hash, PrivKeySecp256k1, PubKeySecp256k1 } from "@keplr-wallet/crypto";
+import { Buffer as NodeBuffer } from "buffer";
+import {
+  Hash,
+  PrivKeySecp256k1,
+  PubKeySecp256k1,
+  toXOnly,
+} from "@keplr-wallet/crypto";
+import { Psbt, payments } from "bitcoinjs-lib";
+import { taggedHash } from "bitcoinjs-lib/src/crypto";
 
 export class KeyRingPrivateKeyService {
   constructor(protected readonly vaultService: VaultService) {}
@@ -48,7 +56,7 @@ export class KeyRingPrivateKeyService {
     vault: Vault,
     _coinType: number,
     data: Uint8Array,
-    digestMethod: "sha256" | "keccak256" | "noop"
+    digestMethod: "sha256" | "keccak256" | "hash256" | "noop"
   ): {
     readonly r: Uint8Array;
     readonly s: Uint8Array;
@@ -67,6 +75,9 @@ export class KeyRingPrivateKeyService {
       case "keccak256":
         digest = Hash.keccak256(data);
         break;
+      case "hash256":
+        digest = Hash.hash256(data);
+        break;
       case "noop":
         digest = data.slice();
         break;
@@ -75,5 +86,81 @@ export class KeyRingPrivateKeyService {
     }
 
     return privateKey.signDigest32(digest);
+  }
+
+  signPsbt(vault: Vault, _coinType: number, psbt: Psbt): Promise<Psbt> {
+    const privateKeyText = this.vaultService.decrypt(vault.sensitive)[
+      "privateKey"
+    ] as string;
+    const privateKey = new PrivKeySecp256k1(Buffer.from(privateKeyText, "hex"));
+    const signer = privateKey.toKeyPair();
+    const tapInternalKey = toXOnly(signer.publicKey);
+    const taprootSigner = signer.tweak(taggedHash("TapTweak", tapInternalKey));
+
+    const isP2TR = (script: NodeBuffer): boolean => {
+      try {
+        payments.p2tr({ output: script });
+        return true;
+      } catch (err) {
+        return false;
+      }
+    };
+
+    const isTaprootInput = (input: any) => {
+      if (
+        !!(
+          input.tapInternalKey ||
+          input.tapMerkleRoot ||
+          (input.tapLeafScript && input.tapLeafScript.length) ||
+          (input.tapBip32Derivation && input.tapBip32Derivation.length) ||
+          (input.witnessUtxo && isP2TR(input.witnessUtxo.script))
+        )
+      ) {
+        return true;
+      }
+      return false;
+    };
+
+    for (const [index, input] of psbt.data.inputs.entries()) {
+      if (isTaprootInput(input)) {
+        if (!input.tapInternalKey) {
+          input.tapInternalKey = tapInternalKey;
+        }
+
+        // CHECK: signInputAsync might be required for hardware wallets
+
+        // sign taproot
+        psbt.signInput(index, taprootSigner);
+
+        // verify taproot
+        const isValid = psbt.validateSignaturesOfInput(
+          index,
+          (_, msgHash, signature) => {
+            return taprootSigner.verifySchnorr(msgHash, signature);
+          }
+        );
+
+        if (!isValid) {
+          throw new Error("Invalid taproot signature");
+        }
+      } else {
+        // sign ecdsa
+        psbt.signInput(index, signer);
+
+        // verify ecdsa
+        const isValid = psbt.validateSignaturesOfInput(
+          index,
+          (_, msgHash, signature) => {
+            return signer.verify(msgHash, signature);
+          }
+        );
+
+        if (!isValid) {
+          throw new Error("Invalid ecdsa signature");
+        }
+      }
+    }
+
+    return Promise.resolve(psbt.finalizeAllInputs());
   }
 }

--- a/packages/background/src/keyring/types.ts
+++ b/packages/background/src/keyring/types.ts
@@ -1,6 +1,7 @@
 import { PlainObject, Vault } from "../vault";
 import { PubKeySecp256k1, PubKeyStarknet } from "@keplr-wallet/crypto";
 import { ModularChainInfo } from "@keplr-wallet/types";
+import { Psbt } from "bitcoinjs-lib";
 
 export type KeyRingStatus = "empty" | "locked" | "unlocked";
 
@@ -38,7 +39,7 @@ export interface KeyRing {
     vault: Vault,
     coinType: number,
     data: Uint8Array,
-    digestMethod: "sha256" | "keccak256" | "noop",
+    digestMethod: "sha256" | "keccak256" | "hash256" | "noop",
     modularChainInfo: ModularChainInfo
   ):
     | {
@@ -51,6 +52,12 @@ export interface KeyRing {
         readonly s: Uint8Array;
         readonly v: number | null;
       }>;
+  signPsbt?(
+    vault: Vault,
+    coinType: number,
+    psbt: Psbt,
+    modularChainInfo: ModularChainInfo
+  ): Promise<Psbt>;
 }
 
 export interface ExportedKeyRingVault {

--- a/packages/background/src/permission-interactive/service.ts
+++ b/packages/background/src/permission-interactive/service.ts
@@ -171,8 +171,8 @@ export class PermissionInteractiveService {
 
     const currentChainIdForBitcoin =
       this.permissionService.getCurrentChainIdForBitcoin(origin) ?? [
-        `${GenesisHash.MAINNET}:taproot`,
-        `${GenesisHash.MAINNET}:native-segwit`,
+        `bip122:${GenesisHash.MAINNET}:taproot`,
+        `bip122:${GenesisHash.MAINNET}:native-segwit`,
       ];
 
     await this.permissionService.checkOrGrantBasicAccessPermission(

--- a/packages/background/src/permission-interactive/service.ts
+++ b/packages/background/src/permission-interactive/service.ts
@@ -4,7 +4,6 @@ import { PermissionService } from "../permission";
 import { ChainsService } from "../chains";
 import { KVStore } from "@keplr-wallet/common";
 import { autorun, makeObservable, observable, runInAction } from "mobx";
-import { SupportedPaymentType } from "@keplr-wallet/types";
 import { GenesisHash } from "@keplr-wallet/types";
 
 export class PermissionInteractiveService {
@@ -172,8 +171,8 @@ export class PermissionInteractiveService {
 
     const currentChainIdForBitcoin =
       this.permissionService.getCurrentChainIdForBitcoin(origin) ?? [
-        `${GenesisHash.MAINNET}:${SupportedPaymentType.TAPROOT}`,
-        `${GenesisHash.MAINNET}:${SupportedPaymentType.NATIVE_SEGWIT}`,
+        `${GenesisHash.MAINNET}:taproot`,
+        `${GenesisHash.MAINNET}:native-segwit`,
       ];
 
     await this.permissionService.checkOrGrantBasicAccessPermission(

--- a/packages/background/src/permission-interactive/service.ts
+++ b/packages/background/src/permission-interactive/service.ts
@@ -4,6 +4,8 @@ import { PermissionService } from "../permission";
 import { ChainsService } from "../chains";
 import { KVStore } from "@keplr-wallet/common";
 import { autorun, makeObservable, observable, runInAction } from "mobx";
+import { SupportedPaymentType } from "@keplr-wallet/types";
+import { GenesisHash } from "@keplr-wallet/types";
 
 export class PermissionInteractiveService {
   @observable
@@ -158,6 +160,28 @@ export class PermissionInteractiveService {
       origin,
       {
         isForStarknet: true,
+      }
+    );
+  }
+
+  async ensureEnabledForBitcoin(env: Env, origin: string): Promise<void> {
+    await this.keyRingService.ensureUnlockInteractive(env);
+
+    // TODO: support ledger
+    // await this.ensureKeyRingLedgerAppConnected(env, "Bitcoin");
+
+    const currentChainIdForBitcoin =
+      this.permissionService.getCurrentChainIdForBitcoin(origin) ?? [
+        `${GenesisHash.MAINNET}:${SupportedPaymentType.TAPROOT}`,
+        `${GenesisHash.MAINNET}:${SupportedPaymentType.NATIVE_SEGWIT}`,
+      ];
+
+    await this.permissionService.checkOrGrantBasicAccessPermission(
+      env,
+      currentChainIdForBitcoin,
+      origin,
+      {
+        isForBitcoin: true,
       }
     );
   }

--- a/packages/background/src/permission-interactive/service.ts
+++ b/packages/background/src/permission-interactive/service.ts
@@ -169,15 +169,13 @@ export class PermissionInteractiveService {
     // TODO: support ledger
     // await this.ensureKeyRingLedgerAppConnected(env, "Bitcoin");
 
-    const currentChainIdForBitcoin =
-      this.permissionService.getCurrentChainIdForBitcoin(origin) ?? [
-        `bip122:${GenesisHash.MAINNET}:taproot`,
-        `bip122:${GenesisHash.MAINNET}:native-segwit`,
-      ];
+    const currentBaseChainIdForBitcoin =
+      this.permissionService.getCurrentBaseChainIdForBitcoin(origin) ??
+      `bip122:${GenesisHash.MAINNET}`;
 
     await this.permissionService.checkOrGrantBasicAccessPermission(
       env,
-      currentChainIdForBitcoin,
+      currentBaseChainIdForBitcoin,
       origin,
       {
         isForBitcoin: true,

--- a/packages/background/src/permission/service.ts
+++ b/packages/background/src/permission/service.ts
@@ -11,7 +11,11 @@ import {
 } from "./types";
 import { KVStore } from "@keplr-wallet/common";
 import { ChainsService } from "../chains";
-import { ChainInfo } from "@keplr-wallet/types";
+import {
+  ChainInfo,
+  GENESIS_HASH_TO_NETWORK,
+  GenesisHash,
+} from "@keplr-wallet/types";
 import { action, autorun, makeObservable, observable, runInAction } from "mobx";
 import { migrate } from "./migrate";
 import { computedFn } from "mobx-utils";
@@ -31,7 +35,7 @@ export class PermissionService {
     new Map();
 
   @observable
-  protected currentChainIdForBitcoinByOriginMap: Map<string, string> =
+  protected currentBaseChainIdForBitcoinByOriginMap: Map<string, string> =
     new Map();
 
   constructor(
@@ -107,17 +111,18 @@ export class PermissionService {
           });
         }
 
-        const savedCurrentChainIdForBitcoinByOriginMap = await this.kvStore.get<
-          Record<string, string>
-        >("currentChainIdForBitcoinByOriginMap/v1");
-        if (savedCurrentChainIdForBitcoinByOriginMap) {
+        const savedCurrentBaseChainIdForBitcoinByOriginMap =
+          await this.kvStore.get<Record<string, string>>(
+            "currentBaseChainIdForBitcoinByOriginMap/v1"
+          );
+        if (savedCurrentBaseChainIdForBitcoinByOriginMap) {
           runInAction(() => {
             for (const key of Object.keys(
-              savedCurrentChainIdForBitcoinByOriginMap
+              savedCurrentBaseChainIdForBitcoinByOriginMap
             )) {
-              this.currentChainIdForBitcoinByOriginMap.set(
+              this.currentBaseChainIdForBitcoinByOriginMap.set(
                 key,
-                savedCurrentChainIdForBitcoinByOriginMap[key]
+                savedCurrentBaseChainIdForBitcoinByOriginMap[key]
               );
             }
           });
@@ -137,6 +142,10 @@ export class PermissionService {
       this.kvStore.set(
         "currentChainIdForStarknetByOriginMap/v1",
         Object.fromEntries(this.currentChainIdForStarknetByOriginMap)
+      );
+      this.kvStore.set(
+        "currentBaseChainIdForBitcoinByOriginMap/v1",
+        Object.fromEntries(this.currentBaseChainIdForBitcoinByOriginMap)
       );
     });
   }
@@ -181,6 +190,8 @@ export class PermissionService {
   clearAllPermissions() {
     this.permissionMap.clear();
     this.currentChainIdForEVMByOriginMap.clear();
+    this.currentChainIdForStarknetByOriginMap.clear();
+    this.currentBaseChainIdForBitcoinByOriginMap.clear();
   }
 
   async checkOrGrantBasicAccessPermission(
@@ -211,9 +222,13 @@ export class PermissionService {
       );
     }
 
-    // Skip the permission check `chainIds` if the permission for EVM chain.
+    // Skip the permission check `chainIds` if the permission is for EVM, Starknet, or Bitcoin.
     // Because the chain id for this permission can be changed, so it may not be the same as `chainIds`.
-    if (!options?.isForEVM && !options?.isForStarknet) {
+    if (
+      !options?.isForEVM &&
+      !options?.isForStarknet &&
+      !options?.isForBitcoin
+    ) {
       this.checkBasicAccessPermission(env, chainIds, origin);
     }
   }
@@ -292,7 +307,7 @@ export class PermissionService {
         } else if (options?.isForBitcoin) {
           const chainId = newChainId ?? chainIds[0];
           this.addPermission([chainId], type, origins);
-          this.setCurrentChainIdForBitcoin(origins, chainId);
+          this.setCurrentBaseChainIdForBitcoin(origins, chainId);
         } else {
           this.addPermission(chainIds, type, origins);
         }
@@ -308,7 +323,7 @@ export class PermissionService {
   ) {
     for (const chainId of chainIds) {
       // Make sure that the chain info is registered.
-      this.chainsService.getModularChainInfoOrThrow(chainId);
+      this.chainsService.getBaseChainIdOrThrow(chainId);
     }
 
     await this.grantPermission(
@@ -357,8 +372,7 @@ export class PermissionService {
     }
 
     for (const chainId of chainIds) {
-      // Make sure that the chain info is registered.
-      this.chainsService.getModularChainInfoOrThrow(chainId);
+      this.chainsService.getBaseChainIdOrThrow(chainId);
 
       this.checkPermission(
         env,
@@ -384,7 +398,7 @@ export class PermissionService {
 
     for (const chainId of chainIds) {
       // Make sure that the chain info is registered.
-      this.chainsService.getModularChainInfoOrThrow(chainId);
+      this.chainsService.getBaseChainIdOrThrow(chainId);
 
       if (
         !this.hasPermission(chainId, getBasicAccessPermissionType(), origin)
@@ -411,9 +425,14 @@ export class PermissionService {
       return true;
     }
 
+    const baseChainId = this.chainsService.getBaseChainId(chainId);
+    if (!baseChainId) {
+      return false;
+    }
+
     return (
       this.permissionMap.get(
-        PermissionKeyHelper.getPermissionKey(chainId, type, origin)
+        PermissionKeyHelper.getPermissionKey(baseChainId, type, origin)
       ) ?? false
     );
   }
@@ -433,11 +452,15 @@ export class PermissionService {
 
   getPermissionOrigins = computedFn(
     (chainId: string, type: string): string[] => {
+      const baseChainId = this.chainsService.getBaseChainId(chainId);
+      if (!baseChainId) {
+        return [];
+      }
       const origins = [];
 
       for (const key of this.permissionMap.keys()) {
         const origin = PermissionKeyHelper.getOriginFromPermissionKey(
-          chainId,
+          baseChainId,
           type,
           key
         );
@@ -501,7 +524,11 @@ export class PermissionService {
     for (const chainId of chainIds) {
       for (const origin of origins) {
         this.permissionMap.set(
-          PermissionKeyHelper.getPermissionKey(chainId, type, origin),
+          PermissionKeyHelper.getPermissionKey(
+            this.chainsService.getBaseChainIdOrThrow(chainId),
+            type,
+            origin
+          ),
           true
         );
       }
@@ -522,7 +549,11 @@ export class PermissionService {
   removePermission(chainId: string, type: string, origins: string[]) {
     for (const origin of origins) {
       this.permissionMap.delete(
-        PermissionKeyHelper.getPermissionKey(chainId, type, origin)
+        PermissionKeyHelper.getPermissionKey(
+          this.chainsService.getBaseChainIdOrThrow(chainId),
+          type,
+          origin
+        )
       );
 
       const currentChainIdForEVM = this.getCurrentChainIdForEVM(origin);
@@ -566,6 +597,8 @@ export class PermissionService {
         }
 
         this.currentChainIdForEVMByOriginMap.delete(origin);
+        this.currentChainIdForStarknetByOriginMap.delete(origin);
+        this.currentBaseChainIdForBitcoinByOriginMap.delete(origin);
       }
     }
 
@@ -576,11 +609,16 @@ export class PermissionService {
 
   @action
   removeAllTypePermissionToChainId(chainId: string, origins: string[]) {
+    const baseChainId = this.chainsService.getBaseChainId(chainId);
+    if (!baseChainId) {
+      return;
+    }
+
     const deletes: string[] = [];
 
     for (const key of this.permissionMap.keys()) {
       const typeAndOrigin =
-        PermissionKeyHelper.getTypeAndOriginFromPermissionKey(chainId, key);
+        PermissionKeyHelper.getTypeAndOriginFromPermissionKey(baseChainId, key);
       if (typeAndOrigin && origins.includes(typeAndOrigin.origin)) {
         deletes.push(key);
       }
@@ -592,8 +630,20 @@ export class PermissionService {
 
     for (const origin of origins) {
       const currentChainIdForEVM = this.getCurrentChainIdForEVM(origin);
-      if (chainId === currentChainIdForEVM) {
+      if (baseChainId === currentChainIdForEVM) {
         this.currentChainIdForEVMByOriginMap.delete(origin);
+      }
+
+      const currentChainIdForStarknet =
+        this.getCurrentChainIdForStarknet(origin);
+      if (baseChainId === currentChainIdForStarknet) {
+        this.currentChainIdForStarknetByOriginMap.delete(origin);
+      }
+
+      const currentBaseChainIdForBitcoin =
+        this.getCurrentBaseChainIdForBitcoin(origin);
+      if (baseChainId === currentBaseChainIdForBitcoin) {
+        this.currentBaseChainIdForBitcoinByOriginMap.delete(origin);
       }
     }
   }
@@ -651,6 +701,8 @@ export class PermissionService {
     }
 
     this.currentChainIdForEVMByOriginMap.clear();
+    this.currentChainIdForStarknetByOriginMap.clear();
+    this.currentBaseChainIdForBitcoinByOriginMap.clear();
   }
 
   getCurrentChainIdForEVM(origin: string): string | undefined {
@@ -771,48 +823,49 @@ export class PermissionService {
     }
   }
 
-  getCurrentChainIdForBitcoin(origin: string): string | undefined {
-    const currentChainId = this.currentChainIdForBitcoinByOriginMap.get(origin);
+  getCurrentBaseChainIdForBitcoin(origin: string): string | undefined {
+    const currentBaseChainId =
+      this.currentBaseChainIdForBitcoinByOriginMap.get(origin);
     if (
-      currentChainId &&
+      currentBaseChainId &&
       !this.hasPermission(
-        currentChainId,
+        currentBaseChainId,
         getBasicAccessPermissionType(),
         origin
       )
     ) {
-      this.currentChainIdForBitcoinByOriginMap.delete(origin);
+      this.currentBaseChainIdForBitcoinByOriginMap.delete(origin);
       return;
     }
 
-    return currentChainId;
+    return currentBaseChainId;
   }
 
   @action
-  setCurrentChainIdForBitcoin(origins: string[], chainId: string) {
-    for (const origin of origins) {
-      this.currentChainIdForBitcoinByOriginMap.set(origin, chainId);
+  setCurrentBaseChainIdForBitcoin(origins: string[], chainId: string) {
+    const baseChainId = this.chainsService.getBaseChainIdOrThrow(chainId);
 
-      // {genesis_hash}:{addr_format}
-      const bitcoinChainId =
-        "0x" +
-        Buffer.from(
-          chainId.replace(":native-segwit", "").replace(":taproot", "")
-        );
+    // {bip122}:{genesis_hash} -> 0x{genesis_hash}
+    const genesisHash = baseChainId.replace("bip122:", "");
+    const network = GENESIS_HASH_TO_NETWORK[genesisHash as GenesisHash];
+
+    for (const origin of origins) {
+      this.currentBaseChainIdForBitcoinByOriginMap.set(origin, baseChainId);
 
       this.interactionService.dispatchEvent(
         WEBPAGE_PORT,
         "keplr_bitcoinChainChanged",
         {
           origin,
-          bitcoinChainId,
+          bitcoinChainId: "0x" + genesisHash,
+          network,
         }
       );
     }
   }
 
   @action
-  async updateCurrentChainIdForBitcoin(
+  async updateCurrentBaseChainIdForBitcoin(
     env: Env,
     origin: string,
     chainId: string
@@ -823,8 +876,10 @@ export class PermissionService {
 
     if (!this.hasPermission(chainId, type, origin)) {
       if (env.isInternalMsg) {
+        // addPermission 및 setCurrentBaseChainIdForBitcoin 내부에서
+        // 체인 정보를 확인하기 때문에 여기서는 따로 확인하지 않는다.
         this.addPermission(chainIds, type, origins);
-        this.setCurrentChainIdForBitcoin(origins, chainId);
+        this.setCurrentBaseChainIdForBitcoin(origins, chainId);
       } else {
         await this.grantPermission(env, chainIds, type, origins, {
           isForBitcoin: true,
@@ -832,7 +887,7 @@ export class PermissionService {
         });
       }
     } else {
-      this.setCurrentChainIdForBitcoin(origins, chainId);
+      this.setCurrentBaseChainIdForBitcoin(origins, chainId);
     }
   }
 }

--- a/packages/background/src/permission/types.ts
+++ b/packages/background/src/permission/types.ts
@@ -13,6 +13,7 @@ export interface PermissionOptions {
   isUnableToChangeChainInUI?: boolean;
   isForEVM?: boolean;
   isForStarknet?: boolean;
+  isForBitcoin?: boolean;
 }
 
 export interface PermissionData {

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -22,8 +22,7 @@
     "bip39": "^3.0.3",
     "bs58check": "^2.1.2",
     "buffer": "^6.0.3",
-    "ecpair": "^2.1.0",
-    "tiny-secp256k1": "^2.2.3"
+    "ecpair": "^2.1.0"
   },
   "peerDependencies": {
     "bitcoinjs-lib": "^6",

--- a/packages/crypto/src/ecc-adapter.ts
+++ b/packages/crypto/src/ecc-adapter.ts
@@ -1,0 +1,298 @@
+// https://github.com/bitcoinerlab/secp256k1
+import { secp256k1, schnorr } from "@noble/curves/secp256k1";
+import * as mod from "@noble/curves/abstract/modular";
+import * as utils from "@noble/curves/abstract/utils";
+
+interface XOnlyPointAddTweakResult {
+  parity: 1 | 0;
+  xOnlyPubkey: Uint8Array;
+}
+
+const Point = secp256k1.ProjectivePoint;
+
+const THROW_BAD_PRIVATE = "Expected Private";
+const THROW_BAD_POINT = "Expected Point";
+const THROW_BAD_TWEAK = "Expected Tweak";
+const THROW_BAD_SIGNATURE = "Expected Signature";
+const THROW_BAD_EXTRA_DATA = "Expected Extra Data (32 bytes)";
+const THROW_BAD_SCALAR = "Expected Scalar";
+
+const HASH_SIZE = 32;
+const TWEAK_SIZE = 32;
+const BN32_N = new Uint8Array([
+  255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+  254, 186, 174, 220, 230, 175, 72, 160, 59, 191, 210, 94, 140, 208, 54, 65, 65,
+]);
+const EXTRA_DATA_SIZE = 32;
+
+const _1n = BigInt(1);
+
+function cmpBN32(data1: Uint8Array, data2: Uint8Array): number {
+  for (let i = 0; i < 32; ++i) {
+    if (data1[i] !== data2[i]) {
+      return data1[i] < data2[i] ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+function isTweak(tweak: any): boolean {
+  if (
+    !(tweak instanceof Uint8Array) ||
+    tweak.length !== TWEAK_SIZE ||
+    cmpBN32(tweak, BN32_N) >= 0
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function isSignature(signature: any): boolean {
+  return (
+    signature instanceof Uint8Array &&
+    signature.length === 64 &&
+    cmpBN32(signature.subarray(0, 32), BN32_N) < 0 &&
+    cmpBN32(signature.subarray(32, 64), BN32_N) < 0
+  );
+}
+
+function isHash(h: any): boolean {
+  return h instanceof Uint8Array && h.length === HASH_SIZE;
+}
+
+function isExtraData(e: any): boolean {
+  return (
+    e === undefined || (e instanceof Uint8Array && e.length === EXTRA_DATA_SIZE)
+  );
+}
+
+function normalizeScalar(scalar: any) {
+  let num;
+  if (typeof scalar === "bigint") {
+    num = scalar;
+  } else if (
+    typeof scalar === "number" &&
+    Number.isSafeInteger(scalar) &&
+    scalar >= 0
+  ) {
+    num = BigInt(scalar);
+  } else if (typeof scalar === "string") {
+    if (scalar.length !== 64)
+      throw new Error("Expected 32 bytes of private scalar");
+    num = utils.hexToNumber(scalar);
+  } else if (scalar instanceof Uint8Array) {
+    if (scalar.length !== 32)
+      throw new Error("Expected 32 bytes of private scalar");
+    num = utils.bytesToNumberBE(scalar);
+  } else {
+    throw new TypeError("Expected valid private scalar");
+  }
+  if (num < 0) throw new Error("Expected private scalar >= 0");
+  return num;
+}
+
+function normalizePrivateKey(privateKey: Uint8Array) {
+  return secp256k1.utils.normPrivateKeyToScalar(privateKey);
+}
+
+function _privateAdd(privateKey: Uint8Array, tweak: Uint8Array) {
+  const p = normalizePrivateKey(privateKey);
+  const t = normalizeScalar(tweak);
+  const add = utils.numberToBytesBE(mod.mod(p + t, secp256k1.CURVE.n), 32);
+  return secp256k1.utils.isValidPrivateKey(add) ? add : null;
+}
+
+function _privateNegate(privateKey: Uint8Array) {
+  const p = normalizePrivateKey(privateKey);
+  const not = utils.numberToBytesBE(secp256k1.CURVE.n - p, 32);
+  return secp256k1.utils.isValidPrivateKey(not) ? not : null;
+}
+
+function _pointAddScalar(
+  p: Uint8Array,
+  tweak: Uint8Array,
+  isCompressed: boolean
+) {
+  const P = fromHex(p);
+  const t = normalizeScalar(tweak);
+  // multiplyAndAddUnsafe(P, scalar, 1) = P + scalar*G
+  const Q = Point.BASE.multiplyAndAddUnsafe(P, t, _1n);
+  if (!Q) throw new Error("Tweaked point at infinity");
+  return Q.toRawBytes(isCompressed);
+}
+
+function assumeCompression(compressed?: boolean, p?: Uint8Array) {
+  if (compressed === undefined) {
+    return p !== undefined ? isPointCompressed(p) : true;
+  }
+  return !!compressed;
+}
+
+function throwToNull<T>(fn: () => T): T | null {
+  try {
+    return fn();
+  } catch (e) {
+    return null;
+  }
+}
+
+function fromXOnly(bytes: Uint8Array) {
+  return schnorr.utils.lift_x(utils.bytesToNumberBE(bytes));
+}
+
+function fromHex(bytes: Uint8Array) {
+  return bytes.length === 32 ? fromXOnly(bytes) : Point.fromHex(bytes);
+}
+
+function _isPoint(p: Uint8Array, xOnly: boolean) {
+  if ((p.length === 32) !== xOnly) return false;
+  try {
+    if (xOnly) return !!fromXOnly(p);
+    else return !!Point.fromHex(p);
+  } catch (e) {
+    return false;
+  }
+}
+
+export function isPoint(p: Uint8Array): boolean {
+  return _isPoint(p, false);
+}
+
+export function isPointCompressed(p: Uint8Array): boolean {
+  const PUBLIC_KEY_COMPRESSED_SIZE = 33;
+  return _isPoint(p, false) && p.length === PUBLIC_KEY_COMPRESSED_SIZE;
+}
+
+export function isPrivate(d: Uint8Array): boolean {
+  return secp256k1.utils.isValidPrivateKey(d);
+}
+
+export function isXOnlyPoint(p: Uint8Array): boolean {
+  return _isPoint(p, true);
+}
+
+export function xOnlyPointAddTweak(
+  p: Uint8Array,
+  tweak: Uint8Array
+): XOnlyPointAddTweakResult | null {
+  if (!isXOnlyPoint(p)) {
+    throw new Error(THROW_BAD_POINT);
+  }
+  if (!isTweak(tweak)) {
+    throw new Error(THROW_BAD_TWEAK);
+  }
+  return throwToNull(() => {
+    const P = _pointAddScalar(p, tweak, true);
+    const parity = P[0] % 2 === 1 ? 1 : 0;
+    return { parity, xOnlyPubkey: P.slice(1) };
+  });
+}
+
+export function pointFromScalar(
+  sk: Uint8Array,
+  compressed?: boolean
+): Uint8Array | null {
+  if (!isPrivate(sk)) {
+    throw new Error(THROW_BAD_PRIVATE);
+  }
+  return throwToNull(() =>
+    secp256k1.getPublicKey(sk, assumeCompression(compressed))
+  );
+}
+
+export function pointCompress(p: Uint8Array, compressed?: boolean): Uint8Array {
+  if (!isPoint(p)) {
+    throw new Error(THROW_BAD_POINT);
+  }
+  return fromHex(p).toRawBytes(assumeCompression(compressed, p));
+}
+
+export function privateAdd(
+  d: Uint8Array,
+  tweak: Uint8Array
+): Uint8Array | null {
+  if (!isPrivate(d)) {
+    throw new Error(THROW_BAD_PRIVATE);
+  }
+  if (!isTweak(tweak)) {
+    throw new Error(THROW_BAD_TWEAK);
+  }
+  return throwToNull(() => _privateAdd(d, tweak));
+}
+
+export function privateNegate(d: Uint8Array): Uint8Array {
+  if (!isPrivate(d)) {
+    throw new Error(THROW_BAD_PRIVATE);
+  }
+  const result = _privateNegate(d);
+  if (!result) {
+    throw new Error(THROW_BAD_PRIVATE);
+  }
+
+  return result;
+}
+
+export function sign(h: Uint8Array, d: Uint8Array, e?: Uint8Array): Uint8Array {
+  if (!isPrivate(d)) {
+    throw new Error(THROW_BAD_PRIVATE);
+  }
+  if (!isHash(h)) {
+    throw new Error(THROW_BAD_SCALAR);
+  }
+  if (!isExtraData(e)) {
+    throw new Error(THROW_BAD_EXTRA_DATA);
+  }
+  return secp256k1.sign(h, d, { extraEntropy: e }).toCompactRawBytes();
+}
+
+export function signSchnorr(
+  h: Uint8Array,
+  d: Uint8Array,
+  e?: Uint8Array
+): Uint8Array {
+  if (!isPrivate(d)) {
+    throw new Error(THROW_BAD_PRIVATE);
+  }
+  if (!isHash(h)) {
+    throw new Error(THROW_BAD_SCALAR);
+  }
+  if (!isExtraData(e)) {
+    throw new Error(THROW_BAD_EXTRA_DATA);
+  }
+  return schnorr.sign(h, d, e);
+}
+
+export function verify(
+  h: Uint8Array,
+  Q: Uint8Array,
+  signature: Uint8Array,
+  strict?: boolean
+): boolean {
+  if (!isPoint(Q)) {
+    throw new Error(THROW_BAD_POINT);
+  }
+  if (!isSignature(signature)) {
+    throw new Error(THROW_BAD_SIGNATURE);
+  }
+  if (!isHash(h)) {
+    throw new Error(THROW_BAD_SCALAR);
+  }
+  return secp256k1.verify(signature, h, Q, { lowS: strict });
+}
+
+export function verifySchnorr(
+  h: Uint8Array,
+  Q: Uint8Array,
+  signature: Uint8Array
+): boolean {
+  if (!isXOnlyPoint(Q)) {
+    throw new Error(THROW_BAD_POINT);
+  }
+  if (!isSignature(signature)) {
+    throw new Error(THROW_BAD_SIGNATURE);
+  }
+  if (!isHash(h)) {
+    throw new Error(THROW_BAD_SCALAR);
+  }
+  return schnorr.verify(signature, h, Q);
+}

--- a/packages/crypto/src/hash.spec.ts
+++ b/packages/crypto/src/hash.spec.ts
@@ -14,4 +14,10 @@ describe("Test hash", () => {
       )
     ).toBe("30ca65d5da355227c97ff836c9c6719af9d3835fc6bc72bddc50eeecc1bb2b25");
   });
+
+  it("hash256", () => {
+    expect(
+      Buffer.from(Hash.hash256(Buffer.from("12345678", "hex"))).toString("hex")
+    ).toBe("0757152190e14e5889b1270309d7c8e40219d45e04096fcb97d1b4c5a99064e1");
+  });
 });

--- a/packages/crypto/src/hash.ts
+++ b/packages/crypto/src/hash.ts
@@ -10,6 +10,10 @@ export class Hash {
     return keccak_256(data);
   }
 
+  static hash256(data: Uint8Array): Uint8Array {
+    return sha256(sha256(data));
+  }
+
   static truncHashPortion(
     str: string,
     firstCharCount = str.length,

--- a/packages/crypto/src/key.spec.ts
+++ b/packages/crypto/src/key.spec.ts
@@ -1,7 +1,7 @@
 import { Mnemonic } from "./mnemonic";
 import { PrivKeySecp256k1, PubKeySecp256k1 } from "./key";
 import { Hash } from "./hash";
-import * as ecc from "tiny-secp256k1";
+import * as ecc from "./ecc-adapter";
 import * as bitcoin from "bitcoinjs-lib";
 
 bitcoin.initEccLib(ecc);

--- a/packages/crypto/src/key.ts
+++ b/packages/crypto/src/key.ts
@@ -7,12 +7,11 @@ import { Buffer as NodeBuffer } from "buffer";
 import { Hash } from "./hash";
 import { hash as starknetHash } from "starknet";
 import { ECPairInterface, ECPairFactory } from "ecpair";
-import * as ecc from "tiny-secp256k1";
 import { Network, payments } from "bitcoinjs-lib";
+import * as ecc from "./ecc-adapter";
 import * as bitcoin from "bitcoinjs-lib";
 
 bitcoin.initEccLib(ecc);
-
 export class PrivKeySecp256k1 {
   static generateRandomKey(): PrivKeySecp256k1 {
     return new PrivKeySecp256k1(secp256k1.utils.randomPrivateKey());

--- a/packages/crypto/src/key.ts
+++ b/packages/crypto/src/key.ts
@@ -9,10 +9,9 @@ import { hash as starknetHash } from "starknet";
 import { ECPairInterface, ECPairFactory } from "ecpair";
 import * as ecc from "tiny-secp256k1";
 import { Network, payments } from "bitcoinjs-lib";
+import * as bitcoin from "bitcoinjs-lib";
 
-// This code is required before using bitcoinjs-lib.
-// import * as bitcoin from "bitcoinjs-lib";
-// bitcoin.initEccLib(ecc);
+bitcoin.initEccLib(ecc);
 
 export class PrivKeySecp256k1 {
   static generateRandomKey(): PrivKeySecp256k1 {
@@ -33,9 +32,9 @@ export class PrivKeySecp256k1 {
     return new PubKeySecp256k1(secp256k1.getPublicKey(this.privKey, true));
   }
 
-  getBitcoinPubKey(): BitcoinCompatiblePubKey {
+  getBitcoinPubKey(): PubKeyBitcoinCompatible {
     const pubKey = secp256k1.getPublicKey(this.toBytes(), false);
-    return new BitcoinCompatiblePubKey(pubKey);
+    return new PubKeyBitcoinCompatible(pubKey);
   }
 
   signDigest32(digest: Uint8Array): {
@@ -137,6 +136,10 @@ export class PubKeySecp256k1 {
     }
   }
 
+  toBitcoinPubKey(): PubKeyBitcoinCompatible {
+    return new PubKeyBitcoinCompatible(this.toBytes(false));
+  }
+
   /**
    * @deprecated Use `getCosmosAddress()` instead.
    */
@@ -229,7 +232,7 @@ export class PubKeySecp256k1 {
   }
 }
 
-export class BitcoinCompatiblePubKey extends PubKeySecp256k1 {
+export class PubKeyBitcoinCompatible extends PubKeySecp256k1 {
   /**
    * returns the legacy address of the public key compatible with Bitcoin.
    * both compressed and uncompressed are supported.

--- a/packages/provider-extension/src/keplr.ts
+++ b/packages/provider-extension/src/keplr.ts
@@ -620,17 +620,14 @@ export class Keplr implements IKeplr {
     ]);
   }
 
-  async getBitcoinKey(
-    chainId: string,
-    paymentType?: SupportedPaymentType
-  ): Promise<{
+  async getBitcoinKey(chainId: string): Promise<{
     name: string;
     pubKey: Uint8Array;
     address: string;
     paymentType: SupportedPaymentType;
     isNanoLedger: boolean;
   }> {
-    return await Keplr.requestMethod("getBitcoinKey", [chainId, paymentType]);
+    return await Keplr.requestMethod("getBitcoinKey", [chainId]);
   }
 
   async getBitcoinKeysSettled(chainIds: string[]): Promise<

--- a/packages/provider-extension/src/keplr.ts
+++ b/packages/provider-extension/src/keplr.ts
@@ -24,6 +24,7 @@ import {
   EIP6963ProviderDetail,
   EIP6963EventNames,
   IStarknetProvider,
+  SupportedPaymentType,
 } from "@keplr-wallet/types";
 import { JSONUint8Array } from "./uint8-array";
 import deepmerge from "deepmerge";
@@ -617,6 +618,31 @@ export class Keplr implements IKeplr {
       chainId,
       transaction,
     ]);
+  }
+
+  async getBitcoinKey(
+    chainId: string,
+    paymentType?: SupportedPaymentType
+  ): Promise<{
+    name: string;
+    pubKey: Uint8Array;
+    address: string;
+    paymentType: SupportedPaymentType;
+    isNanoLedger: boolean;
+  }> {
+    return await Keplr.requestMethod("getBitcoinKey", [chainId, paymentType]);
+  }
+
+  async getBitcoinKeysSettled(chainIds: string[]): Promise<
+    SettledResponses<{
+      name: string;
+      pubKey: Uint8Array;
+      address: string;
+      paymentType: SupportedPaymentType;
+      isNanoLedger: boolean;
+    }>
+  > {
+    return await Keplr.requestMethod("getBitcoinKeysSettled", [chainIds]);
   }
 
   public readonly ethereum = new EthereumProvider(this);

--- a/packages/provider-mock/src/mock.ts
+++ b/packages/provider-mock/src/mock.ts
@@ -18,6 +18,7 @@ import {
   SettledResponses,
   DirectAuxSignResponse,
   IEthereumProvider,
+  SupportedPaymentType,
 } from "@keplr-wallet/types";
 import {
   Bech32Address,
@@ -428,6 +429,31 @@ export class MockKeplr implements Keplr {
     signature: string[];
   }> {
     throw new Error("Not implemented");
+  }
+
+  getBitcoinKey(
+    _chainId: string,
+    _paymentType?: SupportedPaymentType
+  ): Promise<{
+    name: string;
+    pubKey: Uint8Array;
+    address: string;
+    paymentType: SupportedPaymentType;
+    isNanoLedger: boolean;
+  }> {
+    throw new Error("Not yet implemented");
+  }
+
+  getBitcoinKeysSettled(_chainIds: string[]): Promise<
+    SettledResponses<{
+      name: string;
+      pubKey: Uint8Array;
+      address: string;
+      paymentType: SupportedPaymentType;
+      isNanoLedger: boolean;
+    }>
+  > {
+    throw new Error("Not yet implemented");
   }
 
   public readonly ethereum = new MockEthereumProvider();

--- a/packages/provider-mock/src/mock.ts
+++ b/packages/provider-mock/src/mock.ts
@@ -431,10 +431,7 @@ export class MockKeplr implements Keplr {
     throw new Error("Not implemented");
   }
 
-  getBitcoinKey(
-    _chainId: string,
-    _paymentType?: SupportedPaymentType
-  ): Promise<{
+  getBitcoinKey(_chainId: string): Promise<{
     name: string;
     pubKey: Uint8Array;
     address: string;

--- a/packages/provider/src/core.ts
+++ b/packages/provider/src/core.ts
@@ -22,6 +22,7 @@ import {
   IEthereumProvider,
   IStarknetProvider,
   WalletEvents,
+  SupportedPaymentType,
 } from "@keplr-wallet/types";
 import {
   BACKGROUND_PORT,
@@ -1133,6 +1134,72 @@ export class Keplr implements IKeplr, KeplrCoreTypes {
           this.protectedTryOpenSidePanelIfEnabled();
         }
       });
+    });
+  }
+
+  async getBitcoinKey(
+    chainId: string,
+    paymentType?: SupportedPaymentType
+  ): Promise<{
+    name: string;
+    pubKey: Uint8Array;
+    address: string;
+    paymentType: SupportedPaymentType;
+    isNanoLedger: boolean;
+  }> {
+    return new Promise((resolve, reject) => {
+      let f = false;
+      sendSimpleMessage(
+        this.requester,
+        BACKGROUND_PORT,
+        "keyring-bitcoin",
+        "get-bitcoin-key",
+        {
+          chainId,
+          paymentType,
+        }
+      )
+        .then(resolve)
+        .catch(reject)
+        .finally(() => (f = true));
+
+      setTimeout(() => {
+        if (!f) {
+          this.protectedTryOpenSidePanelIfEnabled();
+        }
+      }, 100);
+    });
+  }
+
+  async getBitcoinKeysSettled(chainIds: string[]): Promise<
+    SettledResponses<{
+      name: string;
+      pubKey: Uint8Array;
+      address: string;
+      paymentType: SupportedPaymentType;
+      isNanoLedger: boolean;
+    }>
+  > {
+    return new Promise((resolve, reject) => {
+      let f = false;
+      sendSimpleMessage(
+        this.requester,
+        BACKGROUND_PORT,
+        "keyring-bitcoin",
+        "get-bitcoin-keys-settled",
+        {
+          chainIds,
+        }
+      )
+        .then(resolve)
+        .catch(reject)
+        .finally(() => (f = true));
+
+      setTimeout(() => {
+        if (!f) {
+          this.protectedTryOpenSidePanelIfEnabled();
+        }
+      }, 100);
     });
   }
 

--- a/packages/provider/src/core.ts
+++ b/packages/provider/src/core.ts
@@ -1137,10 +1137,7 @@ export class Keplr implements IKeplr, KeplrCoreTypes {
     });
   }
 
-  async getBitcoinKey(
-    chainId: string,
-    paymentType?: SupportedPaymentType
-  ): Promise<{
+  async getBitcoinKey(chainId: string): Promise<{
     name: string;
     pubKey: Uint8Array;
     address: string;
@@ -1156,7 +1153,6 @@ export class Keplr implements IKeplr, KeplrCoreTypes {
         "get-bitcoin-key",
         {
           chainId,
-          paymentType,
         }
       )
         .then(resolve)

--- a/packages/provider/src/core.ts
+++ b/packages/provider/src/core.ts
@@ -1690,3 +1690,5 @@ class StarknetProvider implements IStarknetProvider {
     throw new Error("Method not implemented.");
   }
 }
+
+// TODO: Implement bitcoin provider

--- a/packages/provider/src/inject.ts
+++ b/packages/provider/src/inject.ts
@@ -1578,3 +1578,5 @@ class StarknetProvider implements IStarknetProvider {
     }
   }
 }
+
+// TODO: Implement bitcoin provider

--- a/packages/provider/src/inject.ts
+++ b/packages/provider/src/inject.ts
@@ -1034,17 +1034,14 @@ export class InjectedKeplr implements IKeplr, KeplrCoreTypes {
     );
   }
 
-  async getBitcoinKey(
-    chainId: string,
-    paymentType?: SupportedPaymentType
-  ): Promise<{
+  async getBitcoinKey(chainId: string): Promise<{
     name: string;
     pubKey: Uint8Array;
     address: string;
     paymentType: SupportedPaymentType;
     isNanoLedger: boolean;
   }> {
-    return await this.requestMethod("getBitcoinKey", [chainId, paymentType]);
+    return await this.requestMethod("getBitcoinKey", [chainId]);
   }
 
   async getBitcoinKeysSettled(chainIds: string[]): Promise<

--- a/packages/provider/src/inject.ts
+++ b/packages/provider/src/inject.ts
@@ -28,6 +28,7 @@ import {
   WalletEvents,
   AccountChangeEventHandler,
   NetworkChangeEventHandler,
+  SupportedPaymentType,
 } from "@keplr-wallet/types";
 import {
   Result,
@@ -1031,6 +1032,31 @@ export class InjectedKeplr implements IKeplr, KeplrCoreTypes {
       this.eventListener,
       this.parseMessage
     );
+  }
+
+  async getBitcoinKey(
+    chainId: string,
+    paymentType?: SupportedPaymentType
+  ): Promise<{
+    name: string;
+    pubKey: Uint8Array;
+    address: string;
+    paymentType: SupportedPaymentType;
+    isNanoLedger: boolean;
+  }> {
+    return await this.requestMethod("getBitcoinKey", [chainId, paymentType]);
+  }
+
+  async getBitcoinKeysSettled(chainIds: string[]): Promise<
+    SettledResponses<{
+      name: string;
+      pubKey: Uint8Array;
+      address: string;
+      paymentType: SupportedPaymentType;
+      isNanoLedger: boolean;
+    }>
+  > {
+    return await this.requestMethod("getBitcoinKeysSettled", [chainIds]);
   }
 
   public readonly ethereum = new EthereumProvider(

--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -1,5 +1,5 @@
 import { action, computed, flow, makeObservable, observable } from "mobx";
-import { AppCurrency, Keplr } from "@keplr-wallet/types";
+import { AppCurrency, Keplr, SupportedPaymentType } from "@keplr-wallet/types";
 import { ChainGetter } from "../chain";
 import { DenomHelper, toGenerator } from "@keplr-wallet/common";
 import { MakeTxResponse } from "./types";
@@ -46,6 +46,13 @@ export class AccountSetBase {
   protected _ethereumHexAddress: string = "";
   @observable
   protected _starknetHexAddress: string = "";
+  @observable
+  protected _bitcoinAddress:
+    | {
+        bech32Address: string;
+        paymentType: SupportedPaymentType;
+      }
+    | undefined = undefined;
   @observable
   protected _isNanoLedger: boolean = false;
   @observable
@@ -167,50 +174,69 @@ export class AccountSetBase {
 
     const isStarknet =
       "starknet" in this.chainGetter.getModularChain(this.chainId);
+    const isBitcoin =
+      "bitcoin" in this.chainGetter.getModularChain(this.chainId);
 
-    yield this.sharedContext.getKeyMixed(this.chainId, isStarknet, (res) => {
-      if (res.status === "fulfilled") {
-        const key = res.value;
-        if ("bech32Address" in key) {
-          this._bech32Address = key.bech32Address;
-          this._ethereumHexAddress = key.ethereumHexAddress;
-          this._starknetHexAddress = "";
-          this._isNanoLedger = key.isNanoLedger;
-          this._isKeystone = key.isKeystone;
-          this._name = key.name;
-          this._pubKey = key.pubKey;
+    yield this.sharedContext.getKeyMixed(
+      this.chainId,
+      isStarknet,
+      isBitcoin,
+      (res) => {
+        if (res.status === "fulfilled") {
+          const key = res.value;
+          if ("bech32Address" in key) {
+            this._bech32Address = key.bech32Address;
+            this._ethereumHexAddress = key.ethereumHexAddress;
+            this._starknetHexAddress = "";
+            this._isNanoLedger = key.isNanoLedger;
+            this._isKeystone = key.isKeystone;
+            this._name = key.name;
+            this._pubKey = key.pubKey;
+          } else if ("paymentType" in key) {
+            this._bech32Address = "";
+            this._ethereumHexAddress = "";
+            this._starknetHexAddress = "";
+            this._bitcoinAddress = {
+              bech32Address: key.address,
+              paymentType: key.paymentType,
+            };
+            this._isNanoLedger = key.isNanoLedger;
+            this._isKeystone = false;
+            this._name = key.name;
+            this._pubKey = key.pubKey;
+          } else {
+            this._bech32Address = "";
+            this._ethereumHexAddress = "";
+            this._starknetHexAddress = key.hexAddress;
+            this._isNanoLedger = key.isNanoLedger;
+            this._isKeystone = false;
+            this._name = key.name;
+            this._pubKey = key.pubKey;
+          }
+
+          // Set the wallet status as loaded after getting all necessary infos.
+          this._walletStatus = WalletStatus.Loaded;
         } else {
+          // Caught error loading key
+          // Reset properties, and set status to Rejected
           this._bech32Address = "";
           this._ethereumHexAddress = "";
-          this._starknetHexAddress = key.hexAddress;
-          this._isNanoLedger = key.isNanoLedger;
+          this._starknetHexAddress = "";
+          this._isNanoLedger = false;
           this._isKeystone = false;
-          this._name = key.name;
-          this._pubKey = key.pubKey;
+          this._name = "";
+          this._pubKey = new Uint8Array(0);
+
+          this._walletStatus = WalletStatus.Rejected;
+          this._rejectionReason = res.reason;
         }
 
-        // Set the wallet status as loaded after getting all necessary infos.
-        this._walletStatus = WalletStatus.Loaded;
-      } else {
-        // Caught error loading key
-        // Reset properties, and set status to Rejected
-        this._bech32Address = "";
-        this._ethereumHexAddress = "";
-        this._starknetHexAddress = "";
-        this._isNanoLedger = false;
-        this._isKeystone = false;
-        this._name = "";
-        this._pubKey = new Uint8Array(0);
-
-        this._walletStatus = WalletStatus.Rejected;
-        this._rejectionReason = res.reason;
+        if (this._walletStatus !== WalletStatus.Rejected) {
+          // Reset previous rejection error message
+          this._rejectionReason = undefined;
+        }
       }
-
-      if (this._walletStatus !== WalletStatus.Rejected) {
-        // Reset previous rejection error message
-        this._rejectionReason = undefined;
-      }
-    });
+    );
   }
 
   @action
@@ -330,6 +356,15 @@ export class AccountSetBase {
 
   get starknetHexAddress(): string {
     return this._starknetHexAddress;
+  }
+
+  get bitcoinAddress():
+    | {
+        bech32Address: string;
+        paymentType: SupportedPaymentType;
+      }
+    | undefined {
+    return this._bitcoinAddress;
   }
 }
 

--- a/packages/stores/src/account/context.ts
+++ b/packages/stores/src/account/context.ts
@@ -3,6 +3,7 @@ import {
   Key,
   SettledResponse,
   SettledResponses,
+  SupportedPaymentType,
 } from "@keplr-wallet/types";
 import { DebounceActionTimer } from "@keplr-wallet/mobx-utils";
 
@@ -94,13 +95,20 @@ export class AccountSharedContext {
     return requests.map((req) => settledMap.get(req.args[0])!);
   });
   protected getKeyMixedDebounceTimer = new DebounceActionTimer<
-    [chainId: string, isStarknet: boolean],
+    [chainId: string, isStarknet: boolean, isBitcoin: boolean],
     | Key
     | {
         name: string;
         hexAddress: string;
         pubKey: Uint8Array;
         address: Uint8Array;
+        isNanoLedger: boolean;
+      }
+    | {
+        name: string;
+        pubKey: Uint8Array;
+        address: string;
+        paymentType: SupportedPaymentType;
         isNanoLedger: boolean;
       }
   >(0, async (requests) => {
@@ -115,8 +123,10 @@ export class AccountSharedContext {
       });
     }
 
-    const cosmosReqs = requests.filter((req) => !req.args[1]);
-    const starknetReqs = requests.filter((req) => req.args[1]);
+    const cosmosReqs = requests.filter((req) => !req.args[1] && !req.args[2]);
+    const starknetReqs = requests.filter((req) => req.args[1] && !req.args[2]);
+    const bitcoinReqs = requests.filter((req) => !req.args[1] && req.args[2]);
+
     const cosmosChainIdSet = new Set<string>(
       cosmosReqs.map((req) => req.args[0])
     );
@@ -125,6 +135,10 @@ export class AccountSharedContext {
       starknetReqs.map((req) => req.args[0])
     );
     const starknetChainIds = Array.from(starknetChainIdSet);
+    const bitcoinChainIdSet = new Set<string>(
+      bitcoinReqs.map((req) => req.args[0])
+    );
+    const bitcoinChainIds = Array.from(bitcoinChainIdSet);
 
     const settledMap = new Map<
       string,
@@ -135,6 +149,13 @@ export class AccountSharedContext {
             hexAddress: string;
             pubKey: Uint8Array;
             address: Uint8Array;
+            isNanoLedger: boolean;
+          }
+        | {
+            name: string;
+            pubKey: Uint8Array;
+            address: string;
+            paymentType: SupportedPaymentType;
             isNanoLedger: boolean;
           }
       >
@@ -156,6 +177,15 @@ export class AccountSharedContext {
       for (let i = 0; i < starknetChainIds.length; i++) {
         const chainId = starknetChainIds[i];
         const res = starknetSettled[i];
+        settledMap.set(chainId, res);
+      }
+    }
+
+    if (bitcoinChainIds.length > 0) {
+      const bitcoinSettled = await keplr.getBitcoinKeysSettled(bitcoinChainIds);
+      for (let i = 0; i < bitcoinChainIds.length; i++) {
+        const chainId = bitcoinChainIds[i];
+        const res = bitcoinSettled[i];
         settledMap.set(chainId, res);
       }
     }
@@ -220,6 +250,7 @@ export class AccountSharedContext {
   getKeyMixed(
     chainId: string,
     isStarknet: boolean,
+    isBitcoin: boolean,
     action: (
       res: SettledResponse<
         | Key
@@ -230,9 +261,19 @@ export class AccountSharedContext {
             address: Uint8Array;
             isNanoLedger: boolean;
           }
+        | {
+            name: string;
+            pubKey: Uint8Array;
+            address: string;
+            paymentType: SupportedPaymentType;
+            isNanoLedger: boolean;
+          }
       >
     ) => void
   ): Promise<void> {
-    return this.getKeyMixedDebounceTimer.call([chainId, isStarknet], action);
+    return this.getKeyMixedDebounceTimer.call(
+      [chainId, isStarknet, isBitcoin],
+      action
+    );
   }
 }

--- a/packages/types/src/chain-info.ts
+++ b/packages/types/src/chain-info.ts
@@ -97,6 +97,6 @@ export type ModularChainInfo =
       readonly chainId: string;
       readonly chainName: string;
       readonly chainSymbolImageUrl?: string;
-      readonly linkedChainIds: string[];
+      readonly linkedChainKey: string;
       readonly bitcoin: BitcoinChainInfo;
     };

--- a/packages/types/src/chain-info.ts
+++ b/packages/types/src/chain-info.ts
@@ -73,8 +73,9 @@ export interface StarknetChainInfo {
 
 export interface BitcoinChainInfo {
   readonly rpc: string;
+  readonly rest: string;
   readonly chainId: string;
-  readonly addrFormats: "segwit" | "taproot" | "legacy";
+  readonly paymentType: "native-segwit" | "taproot";
   readonly coinType: number;
   readonly bech32: string;
   readonly messagePrefix: string;
@@ -100,5 +101,6 @@ export type ModularChainInfo =
       readonly chainId: string;
       readonly chainName: string;
       readonly chainSymbolImageUrl?: string;
+      readonly linkedChainIds: string[];
       readonly bitcoin: BitcoinChainInfo;
     };

--- a/packages/types/src/chain-info.ts
+++ b/packages/types/src/chain-info.ts
@@ -75,7 +75,6 @@ export interface BitcoinChainInfo {
   readonly rpc: string;
   readonly rest: string;
   readonly chainId: string;
-  readonly paymentType: "native-segwit" | "taproot";
   readonly coinType: number;
   readonly bech32: string;
   readonly messagePrefix: string;

--- a/packages/types/src/chain-info.ts
+++ b/packages/types/src/chain-info.ts
@@ -76,9 +76,6 @@ export interface BitcoinChainInfo {
   readonly rest: string;
   readonly chainId: string;
   readonly coinType: number;
-  readonly bech32: string;
-  readonly messagePrefix: string;
-  readonly pubKeyHash: number;
 }
 
 export type ChainInfoModule = "cosmos" | "starknet" | "bitcoin";

--- a/packages/types/src/wallet/bitcoin.ts
+++ b/packages/types/src/wallet/bitcoin.ts
@@ -1,6 +1,8 @@
-export enum Network {
-  MAINNET = "mainnet",
-  TESTNET = "testnet",
+import EventEmitter from "events";
+
+export enum BitcoinSignMessageType {
+  MESSAGE = "message",
+  BIP322 = "bip-322",
 }
 
 export enum GenesisHash {
@@ -8,74 +10,29 @@ export enum GenesisHash {
   TESTNET = "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943",
 }
 
-export enum SupportedPaymentType {
-  NATIVE_SEGWIT = "native-segwit",
-  TAPROOT = "taproot",
-}
+export type SupportedNetwork = "mainnet" | "testnet";
+export type SupportedPaymentType = "native-segwit" | "taproot";
 
-export type Fees = {
-  // fee for inclusion in the next block
-  fastestFee: number;
-  // fee for inclusion in a block in 30 mins
-  halfHourFee: number;
-  // fee for inclusion in a block in 1 hour
-  hourFee: number;
-  // economy fee: inclusion not guaranteed
-  economyFee: number;
-  // minimum fee: the minimum fee of the network
-  minimumFee: number;
+export const GENESIS_HASH_TO_NETWORK: Record<GenesisHash, SupportedNetwork> = {
+  [GenesisHash.MAINNET]: "mainnet",
+  [GenesisHash.TESTNET]: "testnet",
 };
 
-// UTXO is a structure defining attributes for a UTXO
-export interface UTXO {
-  // hash of transaction that holds the UTXO
-  txid: string;
-  // index of the output in the transaction
-  vout: number;
-  // amount of satoshis the UTXO holds
-  value: number;
-  // the script that the UTXO contains
-  scriptPubKey: string;
-}
-
-export interface InscriptionResult {
-  list: Inscription[];
-  total: number;
-}
-
-export interface Inscription {
-  output: string;
-  inscriptionId: string;
-  address: string;
-  offset: number;
-  outputValue: number;
-  location: string;
-  contentType: string;
-  contentLength: number;
-  inscriptionNumber: number;
-  timestamp: number;
-  genesisTransaction: string;
-}
-
-export interface IBitcoinProvider {
-  connectWallet(): Promise<this>;
-  getAddress(): Promise<string>;
-  getPublicKeyHex(): Promise<string>;
-  signPsbt(psbtHex: string): Promise<string>;
-  signPsbts(psbtsHexes: string[]): Promise<string[]>;
-  getNetwork(): Promise<Network>;
-  signMessage(
+export interface IBitcoinProvider extends EventEmitter {
+  getAccounts: () => Promise<string[]>;
+  requestAccounts: () => Promise<string[]>;
+  disconnect: () => Promise<void>;
+  getNetwork: () => Promise<SupportedNetwork>;
+  switchNetwork: (network: SupportedNetwork) => Promise<void>;
+  getPublicKey: () => Promise<string>;
+  getBalance: () => Promise<string>;
+  getInscriptions: () => Promise<string[]>;
+  signMessage: (
     message: string,
-    type: "ecdsa" | "bip322-simple"
-  ): Promise<string>;
-  on(eventName: string, callBack: () => void): void;
-  off(eventName: string, callBack: () => void): void;
-  switchNetwork(network: Network): Promise<void>;
-  sendBitcoin(to: string, satAmount: number): Promise<string>;
-  getNetworkFees(): Promise<Fees>;
-  pushTx(txHex: string): Promise<string>;
-  getUtxos(address: string, amount?: number): Promise<UTXO[]>;
-  getBTCTipHeight(): Promise<number>;
-  getBalance(): Promise<number>;
-  getInscriptions(cursor?: number, size?: number): Promise<InscriptionResult>;
+    type: BitcoinSignMessageType
+  ) => Promise<string>;
+  sendBitcoin: (to: string, amount: string) => Promise<string>;
+  pushTx: (rawTxHex: string) => Promise<string>;
+  signPsbt: (psbtHex: string) => Promise<string>;
+  signPsbts: (psbtsHexes: string[]) => Promise<string[]>;
 }

--- a/packages/types/src/wallet/bitcoin.ts
+++ b/packages/types/src/wallet/bitcoin.ts
@@ -10,20 +10,25 @@ export enum GenesisHash {
   TESTNET = "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943",
 }
 
-export type SupportedNetwork = "mainnet" | "testnet";
+export enum Network {
+  MAINNET = "mainnet",
+  TESTNET = "testnet",
+  SIGNET = "signet",
+}
+
 export type SupportedPaymentType = "native-segwit" | "taproot";
 
-export const GENESIS_HASH_TO_NETWORK: Record<GenesisHash, SupportedNetwork> = {
-  [GenesisHash.MAINNET]: "mainnet",
-  [GenesisHash.TESTNET]: "testnet",
+export const GENESIS_HASH_TO_NETWORK: Record<GenesisHash, Network> = {
+  [GenesisHash.MAINNET]: Network.MAINNET,
+  [GenesisHash.TESTNET]: Network.TESTNET,
 };
 
 export interface IBitcoinProvider extends EventEmitter {
   getAccounts: () => Promise<string[]>;
   requestAccounts: () => Promise<string[]>;
   disconnect: () => Promise<void>;
-  getNetwork: () => Promise<SupportedNetwork>;
-  switchNetwork: (network: SupportedNetwork) => Promise<void>;
+  getNetwork: () => Promise<Network>;
+  switchNetwork: (network: Network) => Promise<void>;
   getPublicKey: () => Promise<string>;
   getBalance: () => Promise<string>;
   getInscriptions: () => Promise<string[]>;

--- a/packages/types/src/wallet/bitcoin.ts
+++ b/packages/types/src/wallet/bitcoin.ts
@@ -1,0 +1,81 @@
+export enum Network {
+  MAINNET = "mainnet",
+  TESTNET = "testnet",
+}
+
+export enum GenesisHash {
+  MAINNET = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+  TESTNET = "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943",
+}
+
+export enum SupportedPaymentType {
+  NATIVE_SEGWIT = "native-segwit",
+  TAPROOT = "taproot",
+}
+
+export type Fees = {
+  // fee for inclusion in the next block
+  fastestFee: number;
+  // fee for inclusion in a block in 30 mins
+  halfHourFee: number;
+  // fee for inclusion in a block in 1 hour
+  hourFee: number;
+  // economy fee: inclusion not guaranteed
+  economyFee: number;
+  // minimum fee: the minimum fee of the network
+  minimumFee: number;
+};
+
+// UTXO is a structure defining attributes for a UTXO
+export interface UTXO {
+  // hash of transaction that holds the UTXO
+  txid: string;
+  // index of the output in the transaction
+  vout: number;
+  // amount of satoshis the UTXO holds
+  value: number;
+  // the script that the UTXO contains
+  scriptPubKey: string;
+}
+
+export interface InscriptionResult {
+  list: Inscription[];
+  total: number;
+}
+
+export interface Inscription {
+  output: string;
+  inscriptionId: string;
+  address: string;
+  offset: number;
+  outputValue: number;
+  location: string;
+  contentType: string;
+  contentLength: number;
+  inscriptionNumber: number;
+  timestamp: number;
+  genesisTransaction: string;
+}
+
+export interface IBitcoinProvider {
+  connectWallet(): Promise<this>;
+  getAddress(): Promise<string>;
+  getPublicKeyHex(): Promise<string>;
+  signPsbt(psbtHex: string): Promise<string>;
+  signPsbts(psbtsHexes: string[]): Promise<string[]>;
+  getNetwork(): Promise<Network>;
+  signMessage(
+    message: string,
+    type: "ecdsa" | "bip322-simple"
+  ): Promise<string>;
+  on(eventName: string, callBack: () => void): void;
+  off(eventName: string, callBack: () => void): void;
+  switchNetwork(network: Network): Promise<void>;
+  sendBitcoin(to: string, satAmount: number): Promise<string>;
+  getNetworkFees(): Promise<Fees>;
+  pushTx(txHex: string): Promise<string>;
+  getUtxos(address: string, amount?: number): Promise<UTXO[]>;
+  getBTCTipHeight(): Promise<number>;
+  getBalance(): Promise<number>;
+  getInscriptions(cursor?: number, size?: number): Promise<InscriptionResult>;
+}

--- a/packages/types/src/wallet/bitcoin.ts
+++ b/packages/types/src/wallet/bitcoin.ts
@@ -8,6 +8,7 @@ export enum BitcoinSignMessageType {
 export enum GenesisHash {
   MAINNET = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
   TESTNET = "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943",
+  SIGNET = "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6",
 }
 
 export enum Network {
@@ -21,6 +22,7 @@ export type SupportedPaymentType = "native-segwit" | "taproot";
 export const GENESIS_HASH_TO_NETWORK: Record<GenesisHash, Network> = {
   [GenesisHash.MAINNET]: Network.MAINNET,
   [GenesisHash.TESTNET]: Network.TESTNET,
+  [GenesisHash.SIGNET]: Network.SIGNET,
 };
 
 export interface IBitcoinProvider extends EventEmitter {

--- a/packages/types/src/wallet/index.ts
+++ b/packages/types/src/wallet/index.ts
@@ -2,3 +2,4 @@ export * from "./keplr";
 export * from "./eip6963";
 export * from "./ethereum";
 export * from "./starknet";
+export * from "./bitcoin";

--- a/packages/types/src/wallet/keplr.ts
+++ b/packages/types/src/wallet/keplr.ts
@@ -282,6 +282,9 @@ export interface Keplr {
     signature: string[];
   }>;
 
+  // TODO: bitcoin handle
+  // readonly bitcoin: IBitcoinProvider;
+
   readonly ethereum: IEthereumProvider;
 
   readonly starknet: IStarknetProvider;

--- a/packages/types/src/wallet/keplr.ts
+++ b/packages/types/src/wallet/keplr.ts
@@ -282,10 +282,7 @@ export interface Keplr {
     details: InvocationsSignerDetails;
     signature: string[];
   }>;
-  getBitcoinKey(
-    chainId: string,
-    paymentType?: SupportedPaymentType
-  ): Promise<{
+  getBitcoinKey(chainId: string): Promise<{
     name: string;
     pubKey: Uint8Array;
     address: string;

--- a/packages/types/src/wallet/keplr.ts
+++ b/packages/types/src/wallet/keplr.ts
@@ -20,6 +20,7 @@ import {
   DeployAccountSignerDetails,
   InvocationsSignerDetails,
 } from "starknet";
+import { SupportedPaymentType } from "./bitcoin";
 
 export interface Key {
   // Name of the selected key store.
@@ -281,6 +282,26 @@ export interface Keplr {
     details: InvocationsSignerDetails;
     signature: string[];
   }>;
+  getBitcoinKey(
+    chainId: string,
+    paymentType?: SupportedPaymentType
+  ): Promise<{
+    name: string;
+    pubKey: Uint8Array;
+    address: string;
+    paymentType: SupportedPaymentType;
+    isNanoLedger: boolean;
+  }>;
+
+  getBitcoinKeysSettled(chainIds: string[]): Promise<
+    SettledResponses<{
+      name: string;
+      pubKey: Uint8Array;
+      address: string;
+      paymentType: SupportedPaymentType;
+      isNanoLedger: boolean;
+    }>
+  >;
 
   // TODO: bitcoin handle
   // readonly bitcoin: IBitcoinProvider;

--- a/packages/wc-client/src/index.ts
+++ b/packages/wc-client/src/index.ts
@@ -905,10 +905,7 @@ export class KeplrWalletConnectV2 implements Keplr {
     throw new Error("Not yet implemented");
   }
 
-  getBitcoinKey(
-    _chainId: string,
-    _paymentType?: SupportedPaymentType
-  ): Promise<{
+  getBitcoinKey(_chainId: string): Promise<{
     name: string;
     pubKey: Uint8Array;
     address: string;

--- a/packages/wc-client/src/index.ts
+++ b/packages/wc-client/src/index.ts
@@ -19,6 +19,7 @@ import {
   SettledResponses,
   StdSignature,
   StdSignDoc,
+  SupportedPaymentType,
 } from "@keplr-wallet/types";
 import SignClient from "@walletconnect/sign-client";
 import {
@@ -901,6 +902,31 @@ export class KeplrWalletConnectV2 implements Keplr {
     transaction: DeployAccountSignerDetails;
     signature: string[];
   }> {
+    throw new Error("Not yet implemented");
+  }
+
+  getBitcoinKey(
+    _chainId: string,
+    _paymentType?: SupportedPaymentType
+  ): Promise<{
+    name: string;
+    pubKey: Uint8Array;
+    address: string;
+    paymentType: SupportedPaymentType;
+    isNanoLedger: boolean;
+  }> {
+    throw new Error("Not yet implemented");
+  }
+
+  getBitcoinKeysSettled(_chainIds: string[]): Promise<
+    SettledResponses<{
+      name: string;
+      pubKey: Uint8Array;
+      address: string;
+      paymentType: SupportedPaymentType;
+      isNanoLedger: boolean;
+    }>
+  > {
     throw new Error("Not yet implemented");
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8705,6 +8705,7 @@ __metadata:
     pbkdf2: ^3.1.2
     utility-types: ^3.10.0
   peerDependencies:
+    bitcoinjs-lib: ^6
     mobx: ^6
     mobx-utils: ^6
     starknet: ^6

--- a/yarn.lock
+++ b/yarn.lock
@@ -8765,7 +8765,6 @@ __metadata:
     bs58check: ^2.1.2
     buffer: ^6.0.3
     ecpair: ^2.1.0
-    tiny-secp256k1: ^2.2.3
   peerDependencies:
     bitcoinjs-lib: ^6
     starknet: ^6
@@ -42068,15 +42067,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tiny-secp256k1@npm:^2.2.3":
-  version: 2.2.3
-  resolution: "tiny-secp256k1@npm:2.2.3"
-  dependencies:
-    uint8array-tools: 0.0.7
-  checksum: f7a74a1fceacab39d268907cd84798d3a07f3de2e00ba2557a043316ef45298d9acc96fb1614d72c728c3e512ecfef985b0fbd43b7fdb789fd9901df983e3e44
-  languageName: node
-  linkType: hard
-
 "tinyify@npm:^4.0.0":
   version: 4.0.0
   resolution: "tinyify@npm:4.0.0"
@@ -42768,13 +42758,6 @@ __metadata:
   version: 0.0.6
   resolution: "uid-number@npm:0.0.6"
   checksum: ff17525bb9b17313b839222efa1fe69baf136992cf675e8d1d50e9b1ef4563742968e390a96a57645d99cf8b283866c36ef9747bbf186bbbf2ef601b60ed4443
-  languageName: node
-  linkType: hard
-
-"uint8array-tools@npm:0.0.7":
-  version: 0.0.7
-  resolution: "uint8array-tools@npm:0.0.7"
-  checksum: 6ffc45c7d2136757d63c6e556eb8345f908948618a9de37c805fec1249d989c265187b3fbef6cffc4ce5129083204829025b3c58800a0f24c8548e243d42ba13
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### 1. `KeyRingBitcoinService` 구현

- `signPsbt`, `signPsbts`: bip-174, bip-371 psbt 서명 방식 구현
- `signMessage`: legacy, bip-322-simple 메시지 서명 방식 구현
- `getBitcoinKey`: 비트코인 pubkey와 payment type (native-segwit, taproot) 반환

### 2. `IBitcoinProvider` 정의

- 비트코인 provider 인터페이스 정의
- https://docs.tomo.inc/tomo-sdk/tomo-enterprise-sdk/for-babylon/bitcoin-provider

### 3. `Keplr` 인터페이스 부분 확장

- bitcoin 키를 가져오기 위한 `getBitcoinKey`, `getBitcoinKeysSettled` 메서드 추가

### 4. crypto 라이브러리 변경

- 비트코인 메시지 다이제스트 생성을 위해 `Hash` 클래스에 `hash256` 메서드 추가
- `tiny-secp256k1` 라이브러리로 인해 발생하는 wasm 의존성 제거
    - `tiny-secp256k1` 라이브러리를 제거하고 `@noble/curves` 라이브러리를 사용해 ecc-adapter 구현
    - https://github.com/bitcoinerlab/secp256k1

### 5. `linkedChainIds` 필드 정의 및 `ChainStore` 수정

- bitcoin같은 여러 개의 주소 체계를 가진 체인의 경우, select chain page 또는 copy address modal 등에서 enable/diable할 때 하나의 ui로 보여줄 필요가 있음
- 따라서 linkedChainIds를 추가하여 `groupedModularChainInfos`를 통해 각 ui 상에서 별도로 처리할 필요없이 하나로 보여주기

### 6. copy address modal에서 bitcoin 주소 표시

- 주소 표시 및 looking for chains 리스트에서 검색되도록 수정

### 7. enable chains 페이지에서 bitcoin 표시

- 여러 주소 체계를 단일 아이템으로 보여주면서, 선택했을 경우 `linkedChainIds`도 포함하여 enable/disable되도록 수정
