### PR TITLE
기타 수정 사항들

### DIFF
--- a/apps/extension/src/pages/earn/amount/index.tsx
+++ b/apps/extension/src/pages/earn/amount/index.tsx
@@ -29,14 +29,11 @@ export const EarnAmountPage: FunctionComponent = observer(() => {
   const [searchParams] = useSearchParams();
   const isFromEarnTransfer = searchParams.get("isFromEarnTransfer");
   const chainId = searchParams.get("chainId") || NOBLE_CHAIN_ID;
-  const coinMinimalDenom = searchParams.get("coinMinimalDenom");
+  const coinMinimalDenom = searchParams.get("coinMinimalDenom") || "uusdc";
 
   const chainInfo = chainStore.getChain(chainId);
   const account = accountStore.getAccount(chainId);
-  const currency =
-    chainInfo.currencies.find(
-      (currency) => currency.coinMinimalDenom === coinMinimalDenom
-    ) ?? chainInfo.currencies[0];
+  const currency = chainInfo.forceFindCurrency(coinMinimalDenom);
 
   const balanceQuery = queriesStore
     .get(chainId)
@@ -101,6 +98,17 @@ export const EarnAmountPage: FunctionComponent = observer(() => {
             : {})}
         />
       }
+      onSubmit={(e) => {
+        e.preventDefault();
+
+        if (isSubmissionBlocked) {
+          return;
+        }
+
+        if (validateIsUsdcFromNoble(currency, chainId)) {
+          navigate(`/earn/confirm-usdn-estimation?amount=${amountInput}`);
+        }
+      }}
       bottomButtons={
         isSubmissionBlocked
           ? undefined
@@ -111,17 +119,6 @@ export const EarnAmountPage: FunctionComponent = observer(() => {
                 size: "large",
                 type: "submit",
                 disabled: isSubmissionBlocked,
-                onClick: async () => {
-                  if (isSubmissionBlocked) {
-                    return;
-                  }
-
-                  if (validateIsUsdcFromNoble(currency, chainId)) {
-                    navigate(
-                      `/earn/confirm-usdn-estimation?amount=${amountInput}`
-                    );
-                  }
-                },
               },
             ]
       }

--- a/apps/extension/src/pages/earn/confirm-usdn-estimation/index.tsx
+++ b/apps/extension/src/pages/earn/confirm-usdn-estimation/index.tsx
@@ -30,7 +30,7 @@ export const EarnConfirmUsdnEstimationPage: FunctionComponent = observer(() => {
 
   const { chainStore } = useStore();
   const chainInfo = chainStore.getChain(NOBLE_CHAIN_ID);
-  const currency = chainInfo.currencies[0];
+  const currency = chainInfo.forceFindCurrency("uusdc");
 
   const amountValue = searchParams.get("amount");
   const usdcAmount = new CoinPretty(

--- a/apps/extension/src/pages/earn/intro/index.tsx
+++ b/apps/extension/src/pages/earn/intro/index.tsx
@@ -36,10 +36,7 @@ export const EarnIntroPage: FunctionComponent = observer(() => {
   const chainId = searchParams.get("chainId") || NOBLE_CHAIN_ID;
   const coinMinimalDenom = searchParams.get("coinMinimalDenom") || "uusdc";
   const chainInfo = chainStore.getChain(chainId);
-  const currency =
-    chainInfo.currencies.find(
-      (currency) => currency.coinMinimalDenom === coinMinimalDenom
-    ) ?? chainInfo.currencies[0];
+  const currency = chainInfo.forceFindCurrency(coinMinimalDenom);
 
   const { apy } = useGetEarnApy(chainId);
 

--- a/apps/extension/src/pages/earn/transfer/amount.tsx
+++ b/apps/extension/src/pages/earn/transfer/amount.tsx
@@ -475,6 +475,23 @@ export const EarnTransferAmountPage: FunctionComponent = observer(() => {
                           // 이미 여기서 ibc 성공까지 기다렸기 때문에 메인에서 보이는 history는 자동으로 삭제해준다...
                           const msg = new RemoveIBCHistoryMsg(recent.id);
                           await requester.sendMessage(BACKGROUND_PORT, msg);
+
+                          const destinationAccount = accountStore.getAccount(
+                            ibcTransferDestinationChainId
+                          );
+                          if (
+                            destinationAccount.walletStatus ===
+                            WalletStatus.NotInit
+                          ) {
+                            await destinationAccount.init();
+                          }
+                          queriesStore
+                            .get(ibcTransferDestinationChainId)
+                            .queryBalances.getQueryBech32Address(
+                              destinationAccount.bech32Address
+                            )
+                            .fetch();
+
                           navigate(
                             "/tx-result/success?isFromEarnTransfer=true"
                           );

--- a/apps/extension/src/pages/earn/transfer/amount.tsx
+++ b/apps/extension/src/pages/earn/transfer/amount.tsx
@@ -441,7 +441,7 @@ export const EarnTransferAmountPage: FunctionComponent = observer(() => {
                         window.location.hash.startsWith("#/tx-result/pending")
                       ) {
                         await new Promise((resolve) =>
-                          setTimeout(resolve, 3000)
+                          setTimeout(resolve, 1000)
                         );
 
                         const requester = new InExtensionMessageRequester();

--- a/apps/extension/src/pages/earn/transfer/amount.tsx
+++ b/apps/extension/src/pages/earn/transfer/amount.tsx
@@ -433,7 +433,6 @@ export const EarnTransferAmountPage: FunctionComponent = observer(() => {
 
                   if (initialIBCTransferDestinationChainId) {
                     (async () => {
-
                       while (
                         // tx pending 페이지에서만 처리되어야하는데 문제는 이미 tx pending page로 넘어갔기 때문에
                         // 이 페이지에서 unmount 등을 파악할 수가 없다...

--- a/apps/extension/src/pages/earn/transfer/amount.tsx
+++ b/apps/extension/src/pages/earn/transfer/amount.tsx
@@ -483,12 +483,18 @@ export const EarnTransferAmountPage: FunctionComponent = observer(() => {
                           ) {
                             await destinationAccount.init();
                           }
-                          queriesStore
+                          const balances = queriesStore
                             .get(ibcTransferDestinationChainId)
                             .queryBalances.getQueryBech32Address(
                               destinationAccount.bech32Address
-                            )
-                            .fetch();
+                            ).balances;
+                          if (balances.length > 0) {
+                            // native 토큰에 대해서 refresh를 해야하는데
+                            // 어차피 cosmos-sdk의 balance 쿼리는 묶어서 이뤄지기 때문에
+                            // 하나만 refresh를 하면 된다.
+                            // 거의 무조건 첫번째 currency는 native 토큰이기 때문에 첫번째 currency에 대해서만 refresh를 한다.
+                            balances[0].waitFreshResponse();
+                          }
 
                           navigate(
                             "/tx-result/success?isFromEarnTransfer=true"

--- a/apps/extension/src/pages/earn/transfer/amount.tsx
+++ b/apps/extension/src/pages/earn/transfer/amount.tsx
@@ -433,7 +433,6 @@ export const EarnTransferAmountPage: FunctionComponent = observer(() => {
 
                   if (initialIBCTransferDestinationChainId) {
                     (async () => {
-                      await new Promise((resolve) => setTimeout(resolve, 3000));
 
                       while (
                         // tx pending 페이지에서만 처리되어야하는데 문제는 이미 tx pending page로 넘어갔기 때문에

--- a/apps/extension/src/pages/earn/utils.ts
+++ b/apps/extension/src/pages/earn/utils.ts
@@ -1,16 +1,28 @@
-import { Currency, IBCCurrency } from "@keplr-wallet/types";
+import { AppCurrency } from "@keplr-wallet/types";
 import { NOBLE_CHAIN_ID } from "../../config.ui";
 
-export function validateIsUsdcFromNoble(currency: Currency, chainId: string) {
+export function validateIsUsdcFromNoble(
+  currency: AppCurrency,
+  chainId: string
+) {
   return (
     (currency.coinMinimalDenom === "uusdc" && chainId === NOBLE_CHAIN_ID) ||
-    (currency as IBCCurrency).originChainId === NOBLE_CHAIN_ID
+    ("originChainId" in currency &&
+      currency.originChainId === NOBLE_CHAIN_ID &&
+      currency.originCurrency &&
+      currency.originCurrency.coinMinimalDenom === "uusdc")
   );
 }
 
-export function validateIsUsdnFromNoble(currency: Currency, chainId: string) {
+export function validateIsUsdnFromNoble(
+  currency: AppCurrency,
+  chainId: string
+) {
   return (
     (currency.coinMinimalDenom === "uusdn" && chainId === NOBLE_CHAIN_ID) ||
-    (currency as IBCCurrency).originChainId === NOBLE_CHAIN_ID
+    ("originChainId" in currency &&
+      currency.originChainId === NOBLE_CHAIN_ID &&
+      currency.originCurrency &&
+      currency.coinMinimalDenom === "uusdn")
   );
 }

--- a/apps/extension/src/pages/send/select-asset/index.tsx
+++ b/apps/extension/src/pages/send/select-asset/index.tsx
@@ -102,7 +102,9 @@ export const SendSelectAssetPage: FunctionComponent = observer(() => {
     if (paramIsNobleEarn) {
       if (
         "originChainId" in token.token.currency &&
-        token.token.currency.originChainId === NOBLE_CHAIN_ID
+        token.token.currency.originChainId === NOBLE_CHAIN_ID &&
+        token.token.currency.originCurrency &&
+        token.token.currency.originCurrency.coinMinimalDenom === "uusdc"
       ) {
         return true;
       }

--- a/apps/extension/src/pages/tx-result/success.tsx
+++ b/apps/extension/src/pages/tx-result/success.tsx
@@ -37,18 +37,28 @@ export const TxResultSuccessPage: FunctionComponent = observer(() => {
     }
   }, []);
 
+  const unmountedRef = useRef(false);
+  useEffect(() => {
+    return () => {
+      unmountedRef.current = true;
+    };
+  }, []);
+
   useEffect(() => {
     if (isFromEarnTransfer) {
       setTimeout(() => {
-        navigate(
-          isFromEarnTransfer ? `/earn/amount?isFromEarnTransfer=true` : "/",
-          {
-            replace: true,
-          }
-        );
+        if (!unmountedRef.current) {
+          navigate(
+            isFromEarnTransfer ? `/earn/amount?isFromEarnTransfer=true` : "/",
+            {
+              replace: true,
+            }
+          );
+        }
       }, 3000);
     }
-  }, [isFromEarnTransfer, navigate]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isFromEarnTransfer]);
 
   return (
     <Container>

--- a/apps/hooks-internal/src/noble-earn/amount.ts
+++ b/apps/hooks-internal/src/noble-earn/amount.ts
@@ -15,7 +15,9 @@ import {
 } from "@keplr-wallet/stores";
 import { useState } from "react";
 import { makeObservable, observable } from "mobx";
-import { computedFn } from "mobx-utils";
+
+// Slippage is 0.1% referred from Osmosis
+const SLIPPAGE = new Dec(0.001);
 
 export class NobleEarnAmountConfig extends AmountConfig {
   @observable.ref
@@ -94,9 +96,9 @@ export class NobleEarnAmountConfig extends AmountConfig {
     );
   }
 
-  calculateMinOutAmount = computedFn((slippage: Dec): CoinPretty => {
-    return this.expectedOutAmount.mul(new Dec(1).sub(slippage));
-  });
+  get minOutAmount(): CoinPretty {
+    return this.expectedOutAmount.mul(new Dec(1).sub(SLIPPAGE));
+  }
 }
 
 export const useNobleEarnAmountConfig = (

--- a/apps/hooks-internal/src/noble-earn/amount.ts
+++ b/apps/hooks-internal/src/noble-earn/amount.ts
@@ -15,9 +15,7 @@ import {
 } from "@keplr-wallet/stores";
 import { useState } from "react";
 import { makeObservable, observable } from "mobx";
-
-// Slippage is 0.1% referred from Osmosis
-const SLIPPAGE = new Dec(0.001);
+import { computedFn } from "mobx-utils";
 
 export class NobleEarnAmountConfig extends AmountConfig {
   @observable.ref
@@ -96,9 +94,9 @@ export class NobleEarnAmountConfig extends AmountConfig {
     );
   }
 
-  get minOutAmount(): CoinPretty {
-    return this.expectedOutAmount.mul(new Dec(1).sub(SLIPPAGE));
-  }
+  calculateMinOutAmount = computedFn((slippage: Dec): CoinPretty => {
+    return this.expectedOutAmount.mul(new Dec(1).sub(slippage));
+  });
 }
 
 export const useNobleEarnAmountConfig = (


### PR DESCRIPTION
- 일부분 forceFindCurrency를 쓰도록 수정
- validateIsUsdcFromNoble, validateIsUsdnFromNoble에서 ibc token의 경우 origin currency의 coin minimal denom도 확인하도록 수정
- earn amount page에서 enter를 눌러서 다음 페이지로 이동할 수 있도록 수정
- /send/select-asset에서 paramIsNobleEarn일때 token.token.currency.originCurrency도 고려하도록 수정
- /earn/transfer/amount.tsx를 약간 간략화
- /earn/transfer/amount.tsx에 analytics 관련 TODO 코멘트 추가
- /earn/transfer/amount.tsx gas simulator 추가
- /earn/transfer/amount.tsx에서 /tx/success page를 보내기 전에 ibc history가 complete될때까지 기다리도록 수정
- /tx-result/success 페이지에서 자동 navigate가 두번 실행되는 버그 수정
- /tx-result/success에서 Done 버튼을 누르거나 기타 방법으로 페이지를 빠져나가면 자동 navigate가 실행되지 않도록 수정
- /earn/transfer/amount.tsx에서 usdc transfer 완료시 noble에서 잔고를 자동 새로고침 하도록 수정