### PR TITLE
stores-bitcoin - balance query

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -43,6 +43,7 @@
     "@keplr-wallet/router-extension": "0.12.190",
     "@keplr-wallet/simple-fetch": "0.12.190",
     "@keplr-wallet/stores": "0.12.190",
+    "@keplr-wallet/stores-bitcoin": "0.12.190",
     "@keplr-wallet/stores-core": "0.12.190",
     "@keplr-wallet/stores-etc": "0.12.190",
     "@keplr-wallet/stores-eth": "0.12.190",

--- a/apps/extension/src/config.ts
+++ b/apps/extension/src/config.ts
@@ -3186,22 +3186,16 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
       rpc: "",
       rest: "",
       coinType: 0,
-<<<<<<< HEAD
-=======
-      bech32: "bc",
-      messagePrefix: "\x18Bitcoin Signed Message:\n",
-      pubKeyHash: 0x00,
       currencies: [
         {
           coinDenom: "BTC",
-          coinMinimalDenom: "bitcoin-native",
+          coinMinimalDenom: "taproot:bitcoinMainnet", // TODO: 추후 변경 필요
           coinDecimals: 8,
           coinGeckoId: "bitcoin",
           coinImageUrl:
             "https://cryptologos.cc/logos/bitcoin-btc-logo.png?v=040",
         },
       ],
->>>>>>> 7308bf2b7 (Add currencies field to bitcoin modular chain info)
     },
   },
   {
@@ -3218,6 +3212,16 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
       rpc: "",
       rest: "",
       coinType: 0,
+      currencies: [
+        {
+          coinDenom: "BTC",
+          coinMinimalDenom: "nativeSegwit:bitcoinMainnet",
+          coinDecimals: 8,
+          coinGeckoId: "bitcoin",
+          coinImageUrl:
+            "https://cryptologos.cc/logos/bitcoin-btc-logo.png?v=040",
+        },
+      ],
     },
   },
   {
@@ -3234,6 +3238,15 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
       rpc: "",
       rest: "https://blockstream.info/testnet/api",
       coinType: 1,
+      currencies: [
+        {
+          coinDenom: "tBTC",
+          coinMinimalDenom: "taproot:bitcoinTestnet",
+          coinDecimals: 8,
+          coinImageUrl:
+            "https://cryptologos.cc/logos/bitcoin-btc-logo.png?v=040",
+        },
+      ],
     },
   },
   {
@@ -3250,6 +3263,15 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
       rpc: "",
       rest: "https://blockstream.info/testnet/api",
       coinType: 1,
+      currencies: [
+        {
+          coinDenom: "tBTC",
+          coinMinimalDenom: "nativeSegwit:bitcoinTestnet",
+          coinDecimals: 8,
+          coinImageUrl:
+            "https://cryptologos.cc/logos/bitcoin-btc-logo.png?v=040",
+        },
+      ],
     },
   },
   {
@@ -3266,6 +3288,16 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
       rpc: "",
       rest: "",
       coinType: 1,
+      currencies: [
+        {
+          coinDenom: "sBTC",
+          coinMinimalDenom: "taproot:bitcoinSignet",
+          coinDecimals: 8,
+          coinGeckoId: "bitcoin", // TODO: temporal value for query price test
+          coinImageUrl:
+            "https://cryptologos.cc/logos/bitcoin-btc-logo.png?v=040",
+        },
+      ],
     },
   },
   {
@@ -3282,6 +3314,16 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
       rpc: "",
       rest: "https://explorer.bc-2.jp/api",
       coinType: 1,
+      currencies: [
+        {
+          coinDenom: "sBTC",
+          coinMinimalDenom: "nativeSegwit:bitcoinSignet",
+          coinDecimals: 8,
+          coinGeckoId: "bitcoin",
+          coinImageUrl:
+            "https://cryptologos.cc/logos/bitcoin-btc-logo.png?v=040",
+        },
+      ],
     },
   },
 ];

--- a/apps/extension/src/config.ts
+++ b/apps/extension/src/config.ts
@@ -3216,7 +3216,7 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
       chainId:
         "bip122:000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943",
       rpc: "",
-      rest: "",
+      rest: "https://blockstream.info/testnet/api",
       coinType: 1,
     },
   },
@@ -3232,7 +3232,7 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
       chainId:
         "bip122:000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943",
       rpc: "",
-      rest: "",
+      rest: "https://blockstream.info/testnet/api",
       coinType: 1,
     },
   },
@@ -3264,7 +3264,7 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
       chainId:
         "bip122:00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6",
       rpc: "",
-      rest: "",
+      rest: "https://explorer.bc-2.jp/api",
       coinType: 1,
     },
   },

--- a/apps/extension/src/config.ts
+++ b/apps/extension/src/config.ts
@@ -3186,6 +3186,22 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
       rpc: "",
       rest: "",
       coinType: 0,
+<<<<<<< HEAD
+=======
+      bech32: "bc",
+      messagePrefix: "\x18Bitcoin Signed Message:\n",
+      pubKeyHash: 0x00,
+      currencies: [
+        {
+          coinDenom: "BTC",
+          coinMinimalDenom: "bitcoin-native",
+          coinDecimals: 8,
+          coinGeckoId: "bitcoin",
+          coinImageUrl:
+            "https://cryptologos.cc/logos/bitcoin-btc-logo.png?v=040",
+        },
+      ],
+>>>>>>> 7308bf2b7 (Add currencies field to bitcoin modular chain info)
     },
   },
   {

--- a/apps/extension/src/config.ts
+++ b/apps/extension/src/config.ts
@@ -3286,7 +3286,7 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
       chainId:
         "bip122:00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6",
       rpc: "",
-      rest: "",
+      rest: "https://explorer.bc-2.jp/api",
       coinType: 1,
       currencies: [
         {

--- a/apps/extension/src/pages/main/available.tsx
+++ b/apps/extension/src/pages/main/available.tsx
@@ -106,9 +106,9 @@ export const AvailableTabView: FunctionComponent<{
           (chainInfo) => !chainStore.isEnabledChain(chainInfo.chainId)
         );
 
-      const disabledStarknetChainInfos = chainStore.modularChainInfos.filter(
+      const disabledModularChainInfos = chainStore.modularChainInfos.filter(
         (modularChainInfo) =>
-          "starknet" in modularChainInfo &&
+          ("starknet" in modularChainInfo || "bitcoin" in modularChainInfo) &&
           !chainStore.isEnabledChain(modularChainInfo.chainId) &&
           trimSearch.length >= 3 &&
           (modularChainInfo.chainId.toLowerCase().includes(trimSearch) ||
@@ -117,7 +117,7 @@ export const AvailableTabView: FunctionComponent<{
       );
 
       disabledChainInfos = [
-        ...new Set([...disabledChainInfos, ...disabledStarknetChainInfos]),
+        ...new Set([...disabledChainInfos, ...disabledModularChainInfos]),
       ].sort((a, b) => a.chainName.localeCompare(b.chainName));
 
       return disabledChainInfos.reduce(
@@ -125,10 +125,10 @@ export const AvailableTabView: FunctionComponent<{
           let embedded: boolean | undefined = false;
           let stored: boolean = true;
 
-          const isStarknet = "starknet" in chainInfo;
+          const isModular = "starknet" in chainInfo || "bitcoin" in chainInfo;
 
           try {
-            if (isStarknet) {
+            if (isModular) {
               embedded = true;
             } else {
               const chainInfoInStore = chainStore.getChain(chainInfo.chainId);

--- a/apps/extension/src/pages/main/available.tsx
+++ b/apps/extension/src/pages/main/available.tsx
@@ -106,15 +106,17 @@ export const AvailableTabView: FunctionComponent<{
           (chainInfo) => !chainStore.isEnabledChain(chainInfo.chainId)
         );
 
-      const disabledModularChainInfos = chainStore.modularChainInfos.filter(
-        (modularChainInfo) =>
-          ("starknet" in modularChainInfo || "bitcoin" in modularChainInfo) &&
-          !chainStore.isEnabledChain(modularChainInfo.chainId) &&
-          trimSearch.length >= 3 &&
-          (modularChainInfo.chainId.toLowerCase().includes(trimSearch) ||
-            modularChainInfo.chainName.toLowerCase().includes(trimSearch) ||
-            trimSearch === "eth")
-      );
+      const disabledModularChainInfos =
+        chainStore.groupedModularChainInfos.filter(
+          (modularChainInfo) =>
+            ("starknet" in modularChainInfo || "bitcoin" in modularChainInfo) &&
+            !chainStore.isEnabledChain(modularChainInfo.chainId) &&
+            trimSearch.length >= 3 &&
+            (modularChainInfo.chainId.toLowerCase().includes(trimSearch) ||
+              modularChainInfo.chainName.toLowerCase().includes(trimSearch) ||
+              trimSearch === "eth" ||
+              trimSearch === "btc")
+        );
 
       disabledChainInfos = [
         ...new Set([...disabledChainInfos, ...disabledModularChainInfos]),

--- a/apps/extension/src/pages/main/token-detail/address-chip/index.tsx
+++ b/apps/extension/src/pages/main/token-detail/address-chip/index.tsx
@@ -84,9 +84,14 @@ export const AddressChip: FunctionComponent<{
           navigator.clipboard.writeText(
             isEVMOnlyChain ? account.ethereumHexAddress : account.bech32Address
           );
-        } else {
+        } else if ("starknet" in modularChainInfo) {
           // copy address
           navigator.clipboard.writeText(account.starknetHexAddress);
+        } else if ("bitcoin" in modularChainInfo) {
+          // copy address
+          navigator.clipboard.writeText(
+            account.bitcoinAddress?.bech32Address ?? ""
+          );
         }
         setAnimCheck(true);
       }}
@@ -108,11 +113,17 @@ export const AddressChip: FunctionComponent<{
                     10
                   )}...${account.ethereumHexAddress.slice(32)}`
                 : Bech32Address.shortenAddress(account.bech32Address, 16);
+            } else if ("starknet" in modularChainInfo) {
+              return `${account.starknetHexAddress.slice(
+                0,
+                10
+              )}...${account.starknetHexAddress.slice(56)}`;
+            } else if ("bitcoin" in modularChainInfo) {
+              return Bech32Address.shortenAddress(
+                account.bitcoinAddress?.bech32Address ?? "",
+                16
+              );
             }
-            return `${account.starknetHexAddress.slice(
-              0,
-              10
-            )}...${account.starknetHexAddress.slice(56)}`;
           })()}
         </Body3>
         <Gutter size="0.4rem" />

--- a/apps/extension/src/pages/main/token-detail/modal.tsx
+++ b/apps/extension/src/pages/main/token-detail/modal.tsx
@@ -88,11 +88,11 @@ export const TokenDetailModal: FunctionComponent<{
     // TODO: 일단 cosmos가 아니면 대충에기에다가 force currency 로직을 박아놓는다...
     //       나중에 이런 기능을 chain store 자체에다가 만들어야한다.
     const modularChainInfoImpl = chainStore.getModularChainInfoImpl(chainId);
-    const modularChainInfoImplImpl =
+    const currencies =
       "bitcoin" in modularChainInfo
         ? modularChainInfoImpl.getCurrencies("bitcoin")
         : modularChainInfoImpl.getCurrencies("starknet");
-    const res = modularChainInfoImplImpl.find(
+    const res = currencies.find(
       (cur) => cur.coinMinimalDenom === coinMinimalDenom
     );
     if (res) {

--- a/apps/extension/src/pages/main/token-detail/modal.tsx
+++ b/apps/extension/src/pages/main/token-detail/modal.tsx
@@ -160,7 +160,7 @@ export const TokenDetailModal: FunctionComponent<{
         );
     }
 
-    throw new Error(`Unsupported chain: ${chainId}`);
+    return undefined;
   })();
 
   const price24HChange = (() => {

--- a/apps/extension/src/stores/huge-queries/index.ts
+++ b/apps/extension/src/stores/huge-queries/index.ts
@@ -291,15 +291,7 @@ export class HugeQueriesStore {
         const queries = this.bitcoinQueriesStore.get(modularChainInfo.chainId);
         const currencies = modularChainInfoImpl.getCurrencies("bitcoin");
 
-        // TODO: bitcoin coinMinimalDenom 변경 시 수정 필요
-        const currency = currencies.find(
-          (currency) =>
-            currency.coinMinimalDenom.startsWith("taproot:bitcoin") ||
-            currency.coinMinimalDenom.startsWith("nativeSegwit:bitcoin")
-        );
-        if (!currency) {
-          continue;
-        }
+        const currency = currencies[0];
 
         const queryBalance = queries.queryBitcoinBalance.getBalance(
           modularChainInfo.chainId,

--- a/apps/extension/src/stores/index.tsx
+++ b/apps/extension/src/stores/index.tsx
@@ -62,6 +62,8 @@ export const StoreProvider: FunctionComponent<PropsWithChildren> = ({
             ) {
               stores.accountStore.getAccount(modularChainInfo.chainId).init();
             }
+          } else if ("bitcoin" in modularChainInfo) {
+            // TODO: bitcoin 계정 초기화
           }
         }
       }
@@ -88,6 +90,8 @@ export const StoreProvider: FunctionComponent<PropsWithChildren> = ({
               ) {
                 stores.accountStore.getAccount(modularChainInfo.chainId).init();
               }
+            } else if ("bitcoin" in modularChainInfo) {
+              // TODO: bitcoin 계정 초기화
             }
           }
         }

--- a/apps/extension/src/stores/root.tsx
+++ b/apps/extension/src/stores/root.tsx
@@ -83,7 +83,7 @@ import {
   StarknetAccountStore,
   StarknetQueriesStore,
 } from "@keplr-wallet/stores-starknet";
-
+import { BitcoinQueriesStore } from "@keplr-wallet/stores-bitcoin";
 let _sidePanelWindowId: number | undefined;
 async function getSidePanelWindowId(): Promise<number | undefined> {
   if (_sidePanelWindowId != null) {
@@ -135,6 +135,7 @@ export class RootStore {
   public readonly swapUsageQueries: SwapUsageQueries;
   public readonly skipQueriesStore: SkipQueries;
   public readonly starknetQueriesStore: StarknetQueriesStore;
+  public readonly bitcoinQueriesStore: BitcoinQueriesStore;
   public readonly accountStore: AccountStore<
     [CosmosAccount, CosmwasmAccount, SecretAccount]
   >;
@@ -339,6 +340,11 @@ export class RootStore {
       TokenContractListURL
     );
 
+    this.bitcoinQueriesStore = new BitcoinQueriesStore(
+      this.queriesStore.sharedContext,
+      this.chainStore
+    );
+
     this.accountStore = new AccountStore(
       window,
       this.chainStore,
@@ -503,6 +509,7 @@ export class RootStore {
       this.chainStore,
       this.queriesStore,
       this.starknetQueriesStore,
+      this.bitcoinQueriesStore,
       this.accountStore,
       this.priceStore
     );

--- a/packages/stores-bitcoin/.eslintignore
+++ b/packages/stores-bitcoin/.eslintignore
@@ -1,0 +1,2 @@
+build/*
+.DS_Store

--- a/packages/stores-bitcoin/.prettierignore
+++ b/packages/stores-bitcoin/.prettierignore
@@ -1,0 +1,2 @@
+build/*
+.DS_Store

--- a/packages/stores-bitcoin/jest.config.js
+++ b/packages/stores-bitcoin/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testMatch: ["**/src/**/?(*.)+(spec|test).[jt]s?(x)"],
+};

--- a/packages/stores-bitcoin/package.json
+++ b/packages/stores-bitcoin/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@keplr-wallet/stores-bitcoin",
+  "version": "0.12.190",
+  "main": "build/index.js",
+  "author": "chainapsis",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "clean": "rm -rf node_modules; rm -rf build",
+    "build": "tsc",
+    "dev": "tsc -w",
+    "test": "jest --passWithNoTests",
+    "lint-test": "eslint \"src/**/*\" && prettier --check \"src/**/*\"",
+    "lint-fix": "eslint --fix \"src/**/*\" && prettier --write \"src/**/*\""
+  },
+  "dependencies": {
+    "@keplr-wallet/common": "0.12.190",
+    "@keplr-wallet/simple-fetch": "0.12.190",
+    "@keplr-wallet/stores": "0.12.190",
+    "@keplr-wallet/types": "0.12.190",
+    "@keplr-wallet/unit": "0.12.190",
+    "utility-types": "^3.10.0"
+  },
+  "peerDependencies": {
+    "bitcoinjs-lib": "^6",
+    "mobx": "^6",
+    "mobx-utils": "^6"
+  }
+}

--- a/packages/stores-bitcoin/src/account/base.ts
+++ b/packages/stores-bitcoin/src/account/base.ts
@@ -1,0 +1,25 @@
+import { ChainGetter } from "@keplr-wallet/stores";
+import { Keplr } from "@keplr-wallet/types";
+import { action, makeObservable, observable } from "mobx";
+
+export class BitcoinAccountBase {
+  @observable
+  protected _isSendingTx: boolean = false;
+
+  constructor(
+    protected readonly chainGetter: ChainGetter,
+    protected readonly chainId: string,
+    protected readonly getKeplr: () => Promise<Keplr | undefined>
+  ) {
+    makeObservable(this);
+  }
+
+  @action
+  setIsSendingTx(value: boolean) {
+    this._isSendingTx = value;
+  }
+
+  get isSendingTx(): boolean {
+    return this._isSendingTx;
+  }
+}

--- a/packages/stores-bitcoin/src/account/index.ts
+++ b/packages/stores-bitcoin/src/account/index.ts
@@ -1,0 +1,2 @@
+export * from "./base";
+export * from "./store";

--- a/packages/stores-bitcoin/src/account/store.ts
+++ b/packages/stores-bitcoin/src/account/store.ts
@@ -1,0 +1,22 @@
+import { ChainGetter, HasMapStore } from "@keplr-wallet/stores";
+import { BitcoinAccountBase } from "./base";
+import { Keplr } from "@keplr-wallet/types";
+
+export class BitcoinAccountStore extends HasMapStore<BitcoinAccountBase> {
+  constructor(
+    protected readonly chainGetter: ChainGetter,
+    protected readonly getKeplr: () => Promise<Keplr | undefined>
+  ) {
+    super((chainId: string) => {
+      return new BitcoinAccountBase(chainGetter, chainId, getKeplr);
+    });
+  }
+
+  getAccount(chainId: string): BitcoinAccountBase {
+    const modularChainInfo = this.chainGetter.getModularChain(chainId);
+    if (!("bitcoin" in modularChainInfo)) {
+      throw new Error(`${chainId} is not bitcoin chain`);
+    }
+    return this.get(modularChainInfo.chainId);
+  }
+}

--- a/packages/stores-bitcoin/src/index.ts
+++ b/packages/stores-bitcoin/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./account";

--- a/packages/stores-bitcoin/src/index.ts
+++ b/packages/stores-bitcoin/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./account";
+export * from "./queries";

--- a/packages/stores-bitcoin/src/queries/balance.ts
+++ b/packages/stores-bitcoin/src/queries/balance.ts
@@ -1,0 +1,142 @@
+import {
+  ChainGetter,
+  IObservableQueryBalanceImpl,
+  QuerySharedContext,
+} from "@keplr-wallet/stores";
+import { computed, makeObservable } from "mobx";
+import { AppCurrency } from "@keplr-wallet/types";
+import { DenomHelper } from "@keplr-wallet/common";
+import { CoinPretty, Int } from "@keplr-wallet/unit";
+import { ObservableBitcoinIndexerQuery } from "./bitcoin-indexer";
+import { AddressDetails } from "./types";
+
+export class ObservableQueryBitcoinBalanceImpl
+  extends ObservableBitcoinIndexerQuery<AddressDetails>
+  implements IObservableQueryBalanceImpl
+{
+  constructor(
+    sharedContext: QuerySharedContext,
+    chainId: string,
+    chainGetter: ChainGetter,
+    protected readonly denomHelper: DenomHelper,
+    protected readonly address: string
+  ) {
+    super(sharedContext, chainId, chainGetter, `address/${address}`);
+
+    makeObservable(this);
+  }
+
+  /**
+   * Confirmed balance is the sum of all the confirmed transactions in the chain.
+   */
+  @computed
+  get confirmedBalance(): CoinPretty {
+    if (!this.response || !this.response.data) {
+      return new CoinPretty(this.currency, new Int(0));
+    }
+
+    const data = this.response.data;
+
+    return new CoinPretty(
+      this.currency,
+      new Int(data.chain_stats.funded_txo_sum - data.chain_stats.spent_txo_sum)
+    );
+  }
+
+  /**
+   * Unconfirmed balance is the sum of all the unconfirmed transactions in the mempool.
+   */
+  @computed
+  get unconfirmedBalance(): CoinPretty {
+    if (!this.response || !this.response.data) {
+      return new CoinPretty(this.currency, new Int(0));
+    }
+
+    const data = this.response.data;
+    return new CoinPretty(
+      this.currency,
+      new Int(
+        data.mempool_stats.funded_txo_sum - data.mempool_stats.spent_txo_sum
+      )
+    );
+  }
+
+  /**
+   * balance is the sum of confirmed and unconfirmed balances.
+   */
+  @computed
+  get balance(): CoinPretty {
+    if (!this.response || !this.response.data) {
+      return new CoinPretty(this.currency, new Int(0));
+    }
+
+    const data = this.response.data;
+    return new CoinPretty(
+      this.currency,
+      new Int(
+        data.chain_stats.funded_txo_sum -
+          data.chain_stats.spent_txo_sum +
+          data.mempool_stats.funded_txo_sum -
+          data.mempool_stats.spent_txo_sum
+      )
+    );
+  }
+
+  @computed
+  get currency(): AppCurrency {
+    const denom = this.denomHelper.denom;
+
+    const modularChainInfo = this.chainGetter.getModularChain(this.chainId);
+    if (!("bitcoin" in modularChainInfo)) {
+      throw new Error(`${this.chainId} is not bitcoin chain`);
+    }
+
+    const modularChainInfoImpl = this.chainGetter.getModularChainInfoImpl(
+      this.chainId
+    );
+
+    const currencies = modularChainInfoImpl.getCurrencies("bitcoin");
+    const currency = currencies.find((cur) => cur.coinMinimalDenom === denom);
+
+    if (!currency) {
+      throw new Error(`Unknown currency: ${denom}`);
+    }
+
+    return currency;
+  }
+}
+
+export class ObservableQueryBitcoinBalance {
+  protected map: Map<string, ObservableQueryBitcoinBalanceImpl> = new Map();
+
+  constructor(protected readonly sharedContext: QuerySharedContext) {}
+
+  getBalance(
+    chainId: string,
+    chainGetter: ChainGetter,
+    address: string,
+    minimalDenom: string
+  ): IObservableQueryBalanceImpl | undefined {
+    const key = `${chainId}/${address}/${minimalDenom}`;
+    const prior = this.map.get(key);
+    if (prior) {
+      return prior;
+    }
+
+    const denomHelper = new DenomHelper(minimalDenom);
+    const modularChainInfo = chainGetter.getModularChain(chainId);
+    if (!("bitcoin" in modularChainInfo)) {
+      return;
+    }
+
+    const impl = new ObservableQueryBitcoinBalanceImpl(
+      this.sharedContext,
+      chainId,
+      chainGetter,
+      denomHelper,
+      address
+    );
+    this.map.set(key, impl);
+    return impl;
+  }
+}

--- a/packages/stores-bitcoin/src/queries/balance.ts
+++ b/packages/stores-bitcoin/src/queries/balance.ts
@@ -27,41 +27,6 @@ export class ObservableQueryBitcoinBalanceImpl
   }
 
   /**
-   * Confirmed balance is the sum of all the confirmed transactions in the chain.
-   */
-  @computed
-  get confirmedBalance(): CoinPretty {
-    if (!this.response || !this.response.data) {
-      return new CoinPretty(this.currency, new Int(0));
-    }
-
-    const data = this.response.data;
-
-    return new CoinPretty(
-      this.currency,
-      new Int(data.chain_stats.funded_txo_sum - data.chain_stats.spent_txo_sum)
-    );
-  }
-
-  /**
-   * Unconfirmed balance is the sum of all the unconfirmed transactions in the mempool.
-   */
-  @computed
-  get unconfirmedBalance(): CoinPretty {
-    if (!this.response || !this.response.data) {
-      return new CoinPretty(this.currency, new Int(0));
-    }
-
-    const data = this.response.data;
-    return new CoinPretty(
-      this.currency,
-      new Int(
-        data.mempool_stats.funded_txo_sum - data.mempool_stats.spent_txo_sum
-      )
-    );
-  }
-
-  /**
    * balance is the sum of confirmed and unconfirmed balances.
    */
   @computed

--- a/packages/stores-bitcoin/src/queries/bitcoin-indexer.ts
+++ b/packages/stores-bitcoin/src/queries/bitcoin-indexer.ts
@@ -1,0 +1,48 @@
+import {
+  ChainGetter,
+  ObservableQuery,
+  QueryOptions,
+  QuerySharedContext,
+} from "@keplr-wallet/stores";
+import { GenesisHash } from "@keplr-wallet/types";
+
+export class ObservableBitcoinIndexerQuery<
+  T = unknown,
+  E = unknown
+> extends ObservableQuery<T, E> {
+  // Chain Id should not be changed after creation.
+  protected readonly _chainId: string;
+  protected readonly chainGetter: ChainGetter;
+
+  constructor(
+    sharedContext: QuerySharedContext,
+    chainId: string,
+    chainGetter: ChainGetter,
+    url: string,
+    options?: Partial<QueryOptions>
+  ) {
+    let baseUrl = "";
+    const modularChainInfo = chainGetter.getModularChain(chainId);
+    if ("bitcoin" in modularChainInfo) {
+      baseUrl = modularChainInfo.bitcoin.rest;
+    }
+
+    super(sharedContext, baseUrl, url, options);
+
+    this._chainId = chainId;
+    this.chainGetter = chainGetter;
+  }
+
+  protected override canFetch(): boolean {
+    // TODO: enable for mainnet once indexer setup is done
+    if (this._chainId.startsWith(`bip122:${GenesisHash.MAINNET}`)) {
+      return false;
+    }
+
+    return super.canFetch();
+  }
+
+  get chainId(): string {
+    return this._chainId;
+  }
+}

--- a/packages/stores-bitcoin/src/queries/index.ts
+++ b/packages/stores-bitcoin/src/queries/index.ts
@@ -1,0 +1,37 @@
+import { ChainGetter, QuerySharedContext } from "@keplr-wallet/stores";
+import { DeepReadonly } from "utility-types";
+export class BitcoinQueriesStore {
+  protected map: Map<string, BitcoinQueriesStoreImpl> = new Map();
+
+  constructor(
+    protected readonly sharedContext: QuerySharedContext,
+    protected readonly chainGetter: ChainGetter,
+    protected readonly tokenContractListURL: string
+  ) {}
+
+  public get(chainId: string): DeepReadonly<BitcoinQueriesStoreImpl> {
+    const prior = this.map.get(chainId);
+    if (prior) {
+      return prior;
+    }
+
+    const store = new BitcoinQueriesStoreImpl(
+      this.sharedContext,
+      chainId,
+      this.chainGetter,
+      this.tokenContractListURL
+    );
+    this.map.set(chainId, store);
+
+    return store;
+  }
+}
+
+class BitcoinQueriesStoreImpl {
+  constructor(
+    protected readonly sharedContext: QuerySharedContext,
+    protected readonly chainId: string,
+    protected readonly chainGetter: ChainGetter,
+    protected readonly tokenContractListURL: string
+  ) {}
+}

--- a/packages/stores-bitcoin/src/queries/index.ts
+++ b/packages/stores-bitcoin/src/queries/index.ts
@@ -6,8 +6,7 @@ export class BitcoinQueriesStore {
 
   constructor(
     protected readonly sharedContext: QuerySharedContext,
-    protected readonly chainGetter: ChainGetter,
-    protected readonly tokenContractListURL: string
+    protected readonly chainGetter: ChainGetter
   ) {}
 
   public get(chainId: string): DeepReadonly<BitcoinQueriesStoreImpl> {
@@ -19,8 +18,7 @@ export class BitcoinQueriesStore {
     const store = new BitcoinQueriesStoreImpl(
       this.sharedContext,
       chainId,
-      this.chainGetter,
-      this.tokenContractListURL
+      this.chainGetter
     );
     this.map.set(chainId, store);
 
@@ -34,8 +32,7 @@ class BitcoinQueriesStoreImpl {
   constructor(
     protected readonly sharedContext: QuerySharedContext,
     protected readonly chainId: string,
-    protected readonly chainGetter: ChainGetter,
-    protected readonly tokenContractListURL: string
+    protected readonly chainGetter: ChainGetter
   ) {
     this.queryBitcoinBalance = new ObservableQueryBitcoinBalance(sharedContext);
   }

--- a/packages/stores-bitcoin/src/queries/index.ts
+++ b/packages/stores-bitcoin/src/queries/index.ts
@@ -1,5 +1,6 @@
 import { ChainGetter, QuerySharedContext } from "@keplr-wallet/stores";
 import { DeepReadonly } from "utility-types";
+import { ObservableQueryBitcoinBalance } from "./balance";
 export class BitcoinQueriesStore {
   protected map: Map<string, BitcoinQueriesStoreImpl> = new Map();
 
@@ -28,10 +29,14 @@ export class BitcoinQueriesStore {
 }
 
 class BitcoinQueriesStoreImpl {
+  public readonly queryBitcoinBalance: DeepReadonly<ObservableQueryBitcoinBalance>;
+
   constructor(
     protected readonly sharedContext: QuerySharedContext,
     protected readonly chainId: string,
     protected readonly chainGetter: ChainGetter,
     protected readonly tokenContractListURL: string
-  ) {}
+  ) {
+    this.queryBitcoinBalance = new ObservableQueryBitcoinBalance(sharedContext);
+  }
 }

--- a/packages/stores-bitcoin/src/queries/types.ts
+++ b/packages/stores-bitcoin/src/queries/types.ts
@@ -1,0 +1,13 @@
+export interface TxoStats {
+  funded_txo_count: number;
+  funded_txo_sum: number;
+  spent_txo_count: number;
+  spent_txo_sum: number;
+  tx_count: number;
+}
+
+export interface AddressDetails {
+  address: string;
+  chain_stats: TxoStats;
+  mempool_stats: TxoStats;
+}

--- a/packages/stores-bitcoin/tsconfig.json
+++ b/packages/stores-bitcoin/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "build",
+    "declaration": true,
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/stores/src/chain/base.ts
+++ b/packages/stores/src/chain/base.ts
@@ -533,6 +533,8 @@ export class ModularChainInfoImpl<M extends ModularChainInfo = ModularChainInfo>
   protected registeredCosmosCurrencies: AppCurrency[] = [];
   @observable.shallow
   protected registeredStarkentCurrencies: ERC20Currency[] = [];
+  @observable.shallow
+  protected registeredBitcoinCurrencies: AppCurrency[] = [];
 
   constructor(
     embedded: M,
@@ -546,6 +548,7 @@ export class ModularChainInfoImpl<M extends ModularChainInfo = ModularChainInfo>
 
     keepAlive(this, "cosmosCurrencyMap");
     keepAlive(this, "starknetCurrencyMap");
+    keepAlive(this, "bitcoinCurrencyMap");
   }
 
   get embedded(): M {
@@ -579,6 +582,15 @@ export class ModularChainInfoImpl<M extends ModularChainInfo = ModularChainInfo>
         return this._embedded.starknet.currencies.concat(
           this.registeredStarkentCurrencies
         );
+      case "bitcoin":
+        if (!("bitcoin" in this._embedded)) {
+          throw new Error(`No bitcoin module for this chain: ${this.chainId}`);
+        }
+
+        return this._embedded.bitcoin.currencies.concat(
+          this.registeredBitcoinCurrencies
+        );
+
       default:
         throw new Error(`Unknown module: ${module}`);
     }
@@ -614,6 +626,17 @@ export class ModularChainInfoImpl<M extends ModularChainInfo = ModularChainInfo>
             currency.type === "erc20"
           ) {
             this.registeredStarkentCurrencies.push(currency);
+          }
+        }
+        break;
+      case "bitcoin":
+        if (!("bitcoin" in this._embedded)) {
+          throw new Error(`No bitcoin module for this chain: ${this.chainId}`);
+        }
+
+        for (const currency of currencies) {
+          if (!this.bitcoinCurrencyMap.has(currency.coinMinimalDenom)) {
+            this.registeredBitcoinCurrencies.push(currency);
           }
         }
         break;
@@ -654,6 +677,16 @@ export class ModularChainInfoImpl<M extends ModularChainInfo = ModularChainInfo>
             (currency) => !map.get(currency.coinMinimalDenom)
           );
         break;
+      case "bitcoin":
+        if (!("bitcoin" in this._embedded)) {
+          throw new Error(`No bitcoin module for this chain: ${this.chainId}`);
+        }
+
+        this.registeredBitcoinCurrencies =
+          this.registeredBitcoinCurrencies.filter(
+            (currency) => !map.get(currency.coinMinimalDenom)
+          );
+        break;
       default:
         throw new Error(`Unknown module: ${module}`);
     }
@@ -676,6 +709,18 @@ export class ModularChainInfoImpl<M extends ModularChainInfo = ModularChainInfo>
     const result: Map<string, AppCurrency> = new Map();
     if ("starknet" in this._embedded) {
       for (const currency of this._embedded.starknet.currencies) {
+        result.set(currency.coinMinimalDenom, currency);
+      }
+    }
+
+    return result;
+  }
+
+  @computed
+  protected get bitcoinCurrencyMap(): Map<string, AppCurrency> {
+    const result: Map<string, AppCurrency> = new Map();
+    if ("bitcoin" in this._embedded) {
+      for (const currency of this._embedded.bitcoin.currencies) {
         result.set(currency.coinMinimalDenom, currency);
       }
     }

--- a/packages/types/src/chain-info.ts
+++ b/packages/types/src/chain-info.ts
@@ -76,6 +76,7 @@ export interface BitcoinChainInfo {
   readonly rest: string;
   readonly chainId: string;
   readonly coinType: number;
+  readonly currencies: AppCurrency[];
 }
 
 export type ChainInfoModule = "cosmos" | "starknet" | "bitcoin";

--- a/yarn.lock
+++ b/yarn.lock
@@ -9192,6 +9192,23 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@keplr-wallet/stores-bitcoin@workspace:packages/stores-bitcoin":
+  version: 0.0.0-use.local
+  resolution: "@keplr-wallet/stores-bitcoin@workspace:packages/stores-bitcoin"
+  dependencies:
+    "@keplr-wallet/common": 0.12.190
+    "@keplr-wallet/simple-fetch": 0.12.190
+    "@keplr-wallet/stores": 0.12.190
+    "@keplr-wallet/types": 0.12.190
+    "@keplr-wallet/unit": 0.12.190
+    utility-types: ^3.10.0
+  peerDependencies:
+    bitcoinjs-lib: ^6
+    mobx: ^6
+    mobx-utils: ^6
+  languageName: unknown
+  linkType: soft
+
 "@keplr-wallet/stores-core@0.12.190, @keplr-wallet/stores-core@workspace:packages/stores-core":
   version: 0.0.0-use.local
   resolution: "@keplr-wallet/stores-core@workspace:packages/stores-core"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8801,6 +8801,7 @@ __metadata:
     "@keplr-wallet/router-extension": 0.12.190
     "@keplr-wallet/simple-fetch": 0.12.190
     "@keplr-wallet/stores": 0.12.190
+    "@keplr-wallet/stores-bitcoin": 0.12.190
     "@keplr-wallet/stores-core": 0.12.190
     "@keplr-wallet/stores-etc": 0.12.190
     "@keplr-wallet/stores-eth": 0.12.190
@@ -9192,7 +9193,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@keplr-wallet/stores-bitcoin@workspace:packages/stores-bitcoin":
+"@keplr-wallet/stores-bitcoin@0.12.190, @keplr-wallet/stores-bitcoin@workspace:packages/stores-bitcoin":
   version: 0.0.0-use.local
   resolution: "@keplr-wallet/stores-bitcoin@workspace:packages/stores-bitcoin"
   dependencies:


### PR DESCRIPTION
### 1.  bitcoin chain info

- testnet, signet indexer url 추가
- currencies 필드 추가
 
> coinMinimalDenom은 ibc, erc20 같이 체인 이름 옆에 표시되도록 구성을 해보았는데, 따로 식별자를 추가하는 게 좋을까요?

### 2. `stores-bitcoin` 라이브러리 추가

- `BitcoinAccountStore`는 베이스만 잡아놓았습니다
- `ObservableBitcoinIndexerQuery` 정의
- `ObservableQueryBitcoinBalance` 구현

> balance 값은 우선 mempool에 있는 utxo도 포함하도록 계산했습니다

### 3. `ChainStore` 수정

- bitcoin currencies 등록 가능하게 수정

### 4. available 탭에서 밸런스 보여주기

- `HugeQueriesStore`에 `BitcoinQueriesStore` 추가
- 체인 및 btc 자산도 검색 가능하도록 수정
<img width="363" alt="스크린샷 2025-02-28 오후 2 56 59" src="https://github.com/user-attachments/assets/84ff24ca-661c-4db3-8bac-2d6eb077d2fe" />

### 5. token details 페이지 
<img width="358" alt="스크린샷 2025-02-28 오후 2 58 49" src="https://github.com/user-attachments/assets/714e60a2-99d9-47f1-9af8-5580af50d9d6" />


