### PR TITLE
Add styles for Earn light mode

### DIFF
--- a/apps/extension/src/components/divder/index.tsx
+++ b/apps/extension/src/components/divder/index.tsx
@@ -13,7 +13,7 @@ export const Divider: FunctionComponent<{
     color ??
     (theme.mode === "dark"
       ? ColorPalette["gray-600"]
-      : ColorPalette["gray-500"]);
+      : ColorPalette["gray-50"]);
 
   if (direction === "vertical") {
     return (

--- a/apps/extension/src/components/full-horizontal-silder/index.tsx
+++ b/apps/extension/src/components/full-horizontal-silder/index.tsx
@@ -4,6 +4,7 @@ import { Box } from "../box";
 import { ArrowLeftIcon, ArrowRightIcon } from "../icon";
 import { ColorPalette } from "../../styles";
 import { IconProps } from "../icon/types";
+import { useTheme } from "styled-components";
 
 // Pixel values
 const BUTTON_WIDTH = 312;
@@ -97,6 +98,8 @@ const SliderButton: FunctionComponent<{
   handlePrev?: () => void;
   Icon: React.FunctionComponent<IconProps>;
 }> = ({ handleNext, handlePrev, Icon }) => {
+  const theme = useTheme();
+  const isLightMode = theme.mode === "light";
   const [isHover, setIsHover] = useState(false);
 
   return (
@@ -116,7 +119,7 @@ const SliderButton: FunctionComponent<{
         border: "none",
         cursor: "pointer",
         background: `linear-gradient(${handleNext ? "270deg" : "90deg"}, ${
-          ColorPalette["gray-700"]
+          isLightMode ? ColorPalette["blue-10"] : ColorPalette["gray-700"]
         } 0%, rgba(9, 9, 10, 0.00) 100%)`,
       }}
       height="100%"
@@ -124,16 +127,27 @@ const SliderButton: FunctionComponent<{
     >
       <Box
         opacity={isHover ? 1 : 0}
-        borderColor={ColorPalette["gray-400"]}
-        backgroundColor={ColorPalette["gray-500"]}
+        borderColor={
+          isLightMode ? ColorPalette["gray-100"] : ColorPalette["gray-400"]
+        }
+        backgroundColor={
+          isLightMode ? ColorPalette["gray-10"] : ColorPalette["gray-500"]
+        }
         borderRadius="10rem"
+        borderWidth="1px"
         padding="0.5rem"
         margin={handleNext ? "0 0.5rem 0 0" : "0 0 0 0.5rem"}
         style={{
           transition: "opacity 0.3s ease",
         }}
       >
-        <Icon width="1rem" height="1rem" color={ColorPalette["gray-200"]} />
+        <Icon
+          width="1rem"
+          height="1rem"
+          color={
+            isLightMode ? ColorPalette["gray-300"] : ColorPalette["gray-200"]
+          }
+        />
       </Box>
     </Box>
   );

--- a/apps/extension/src/pages/earn/amount/index.tsx
+++ b/apps/extension/src/pages/earn/amount/index.tsx
@@ -18,10 +18,14 @@ import { Input } from "../components/input";
 import { useNobleEarnAmountConfig } from "@keplr-wallet/hooks-internal";
 import { EmptyAmountError, ZeroAmountError } from "@keplr-wallet/hooks";
 import { NOBLE_CHAIN_ID } from "../../../config.ui";
+import { useTheme } from "styled-components";
 
 const NOBLE_EARN_DEPOSIT_OUT_COIN_MINIMAL_DENOM = "uusdn";
 
 export const EarnAmountPage: FunctionComponent = observer(() => {
+  const theme = useTheme();
+  const isLightMode = theme.mode === "light";
+
   const { accountStore, chainStore, queriesStore } = useStore();
   const intl = useIntl();
   const navigate = useNavigate();
@@ -167,13 +171,25 @@ export const EarnAmountPage: FunctionComponent = observer(() => {
                   paddingX="0.375rem"
                   paddingY="0.25rem"
                   cursor="pointer"
-                  backgroundColor={ColorPalette["gray-550"]}
+                  backgroundColor={
+                    isLightMode
+                      ? ColorPalette["gray-50"]
+                      : ColorPalette["gray-550"]
+                  }
                   onClick={maximizeInput}
                   hover={{
-                    backgroundColor: ColorPalette["gray-500"],
+                    backgroundColor: isLightMode
+                      ? ColorPalette["gray-10"]
+                      : ColorPalette["gray-500"],
                   }}
                 >
-                  <Subtitle3 color={ColorPalette["gray-200"]}>
+                  <Subtitle3
+                    color={
+                      isLightMode
+                        ? ColorPalette["gray-400"]
+                        : ColorPalette["gray-200"]
+                    }
+                  >
                     {balanceQuery?.balance.shrink(true).toString() || "0"}
                   </Subtitle3>
                 </Box>

--- a/apps/extension/src/pages/earn/components/description-modal.tsx
+++ b/apps/extension/src/pages/earn/components/description-modal.tsx
@@ -1,7 +1,7 @@
 import { observer } from "mobx-react-lite";
 import React, { FunctionComponent } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
-import styled from "styled-components";
+import styled, { useTheme } from "styled-components";
 import { XAxis } from "../../../components/axis";
 import { Box } from "../../../components/box";
 import { Button } from "../../../components/button";
@@ -16,6 +16,8 @@ export const DescriptionModal: FunctionComponent<{
   title: string;
   paragraphs: string[];
 }> = observer(({ close, title, paragraphs }) => {
+  const theme = useTheme();
+  const isLightMode = theme.mode === "light";
   const intl = useIntl();
 
   return (
@@ -28,7 +30,9 @@ export const DescriptionModal: FunctionComponent<{
             color={ColorPalette["gray-300"]}
           />
           <Gutter size="0.5rem" />
-          <H4 color={ColorPalette.white}>
+          <H4
+            color={isLightMode ? ColorPalette["gray-700"] : ColorPalette.white}
+          >
             <FormattedMessage id={title} />
           </H4>
         </XAxis>
@@ -37,7 +41,14 @@ export const DescriptionModal: FunctionComponent<{
       <Box paddingX="0.5rem" marginBottom="1.25rem">
         <Stack gutter="0.75rem">
           {paragraphs.map((paragraph) => (
-            <Body2 key={paragraph}>
+            <Body2
+              key={paragraph}
+              color={
+                isLightMode
+                  ? ColorPalette["gray-400"]
+                  : ColorPalette["gray-200"]
+              }
+            >
               <FormattedMessage id={paragraph} />
             </Body2>
           ))}

--- a/apps/extension/src/pages/earn/components/estimation-section.tsx
+++ b/apps/extension/src/pages/earn/components/estimation-section.tsx
@@ -10,18 +10,22 @@ import { ColorPalette } from "../../../styles";
 import { Chip, ApyChip } from "./chip";
 import { LongArrowDownIcon } from "../../../components/icon/long-arrow-down";
 import { NOBLE_CHAIN_ID } from "../../../config.ui";
+import { useTheme } from "styled-components";
 
 export const EstimationSection: FunctionComponent<{
   inAmount: CoinPretty;
   outAmount: CoinPretty;
 }> = ({ inAmount, outAmount }) => {
+  const theme = useTheme();
+  const isLightMode = theme.mode === "light";
+
   const intl = useIntl();
 
   const renderAmount = (amount: CoinPretty) => (
     <Box>
       <XAxis>
         <Gutter size="0.25rem" />
-        <H3 color={ColorPalette.white}>
+        <H3 color={isLightMode ? ColorPalette["gray-700"] : ColorPalette.white}>
           {amount.shrink(true).hideDenom(true).trim(true).toString()}
         </H3>
         <Gutter size="0.25rem" />
@@ -38,7 +42,9 @@ export const EstimationSection: FunctionComponent<{
   return (
     <Box
       padding="1rem"
-      backgroundColor={ColorPalette["gray-650"]}
+      backgroundColor={
+        isLightMode ? ColorPalette.white : ColorPalette["gray-650"]
+      }
       borderRadius="0.75rem"
     >
       <Chip
@@ -55,7 +61,9 @@ export const EstimationSection: FunctionComponent<{
         <LongArrowDownIcon
           width="1.5rem"
           height="1.5rem"
-          color={ColorPalette["gray-400"]}
+          color={
+            isLightMode ? ColorPalette["gray-200"] : ColorPalette["gray-400"]
+          }
         />
       </Box>
 

--- a/apps/extension/src/pages/earn/components/overview-balance-section.tsx
+++ b/apps/extension/src/pages/earn/components/overview-balance-section.tsx
@@ -19,6 +19,7 @@ import { useGetEarnApy } from "../../../hooks/use-get-apy";
 import { useStore } from "../../../stores";
 import { ColorPalette } from "../../../styles";
 import { observer } from "mobx-react-lite";
+import { useTheme } from "styled-components";
 
 export const EarnOverviewBalanceSection: FunctionComponent<{
   chainId: string;
@@ -26,6 +27,9 @@ export const EarnOverviewBalanceSection: FunctionComponent<{
   rewardCurrency?: Currency;
   bech32Address: string;
 }> = observer(({ chainId, holdingCurrency, rewardCurrency, bech32Address }) => {
+  const theme = useTheme();
+  const isLightMode = theme.mode === "light";
+
   const intl = useIntl();
 
   const { queriesStore, priceStore, uiConfigStore } = useStore();
@@ -58,17 +62,27 @@ export const EarnOverviewBalanceSection: FunctionComponent<{
           />
         )}
 
-        <Subtitle3 color={ColorPalette["gray-200"]}>
+        <Subtitle3
+          color={
+            isLightMode ? ColorPalette["gray-400"] : ColorPalette["gray-200"]
+          }
+        >
           {rewardCurrency?.coinDenom}
         </Subtitle3>
 
         <Dot />
 
-        <Subtitle4 color={ColorPalette["green-400"]}>APY {apy}</Subtitle4>
+        <Subtitle4
+          color={
+            isLightMode ? ColorPalette["green-600"] : ColorPalette["green-400"]
+          }
+        >
+          APY {apy}
+        </Subtitle4>
       </XAxis>
       <Gutter size="0.75rem" />
 
-      <H1 color={ColorPalette.white}>
+      <H1 color={isLightMode ? ColorPalette["gray-700"] : ColorPalette.white}>
         {balance?.hideDenom(true).shrink(true).toString() || "0"}
       </H1>
       <Gutter size="0.5rem" />
@@ -108,5 +122,10 @@ export const EarnOverviewBalanceSection: FunctionComponent<{
 });
 
 const Dot: FunctionComponent = () => (
-  <Box width="3px" height="3px" backgroundColor={ColorPalette["gray-400"]} />
+  <Box
+    width="3px"
+    height="3px"
+    backgroundColor={ColorPalette["gray-400"]}
+    style={{ borderRadius: "50%" }}
+  />
 );

--- a/apps/extension/src/pages/earn/components/overview-claim-section.tsx
+++ b/apps/extension/src/pages/earn/components/overview-claim-section.tsx
@@ -10,11 +10,15 @@ import { CoinPretty, Dec, Int } from "@keplr-wallet/unit";
 import { Currency } from "@keplr-wallet/types";
 import { observer } from "mobx-react-lite";
 import { useNavigate } from "react-router";
+import { useTheme } from "styled-components";
 
 export const EarnOverviewClaimSection: FunctionComponent<{
   chainId: string;
   currency: Currency;
 }> = observer(({ chainId, currency }) => {
+  const theme = useTheme();
+  const isLightMode = theme.mode === "light";
+
   const intl = useIntl();
   const navigate = useNavigate();
   const { queriesStore, accountStore } = useStore();
@@ -105,11 +109,21 @@ export const EarnOverviewClaimSection: FunctionComponent<{
         }}
       >
         <Box width="50%">
-          <Subtitle3 color={ColorPalette["gray-200"]}>
+          <Subtitle3
+            color={
+              isLightMode ? ColorPalette["gray-400"] : ColorPalette["gray-200"]
+            }
+          >
             <FormattedMessage id="page.earn.overview.claim-section.claimable-reward" />
           </Subtitle3>
           <Gutter size="0.875rem" />
-          <H4 color={ColorPalette["green-400"]}>
+          <H4
+            color={
+              isLightMode
+                ? ColorPalette["green-600"]
+                : ColorPalette["green-400"]
+            }
+          >
             {new CoinPretty(currency, claimableAmount)
               .hideDenom(true)
               .trim(true)
@@ -117,11 +131,17 @@ export const EarnOverviewClaimSection: FunctionComponent<{
           </H4>
         </Box>
         <Box width="50%">
-          <Subtitle3 color={ColorPalette["gray-200"]}>
+          <Subtitle3
+            color={
+              isLightMode ? ColorPalette["gray-400"] : ColorPalette["gray-200"]
+            }
+          >
             <FormattedMessage id="page.earn.overview.claim-section.total-claimed" />
           </Subtitle3>
           <Gutter size="0.875rem" />
-          <H4 color={ColorPalette.white}>
+          <H4
+            color={isLightMode ? ColorPalette["gray-700"] : ColorPalette.white}
+          >
             {totalYield.shrink(true).hideDenom(true).toString()}
           </H4>
         </Box>

--- a/apps/extension/src/pages/earn/confirm-usdn-estimation/index.tsx
+++ b/apps/extension/src/pages/earn/confirm-usdn-estimation/index.tsx
@@ -21,12 +21,16 @@ import { ExtensionKVStore } from "@keplr-wallet/common";
 import { useGasSimulator, useTxConfigsValidate } from "@keplr-wallet/hooks";
 import { useNobleEarnAmountConfig } from "@keplr-wallet/hooks-internal";
 import { WarningBox } from "../../../components/warning-box";
+import { useTheme } from "styled-components";
 
 const TERM_AGREED_STORAGE_KEY = "nobleTermAgreed";
 const NOBLE_EARN_DEPOSIT_IN_COIN_MINIMAL_DENOM = "uusdc";
 const NOBLE_EARN_DEPOSIT_OUT_COIN_MINIMAL_DENOM = "uusdn";
 
 export const EarnConfirmUsdnEstimationPage: FunctionComponent = observer(() => {
+  const theme = useTheme();
+  const isLightMode = theme.mode === "light";
+
   const [searchParams] = useSearchParams();
   const intl = useIntl();
   const navigate = useNavigate();
@@ -218,7 +222,11 @@ export const EarnConfirmUsdnEstimationPage: FunctionComponent = observer(() => {
           />
         </H2>
         <Gutter size="1rem" />
-        <Body2 color={ColorPalette["gray-200"]}>
+        <Body2
+          color={
+            isLightMode ? ColorPalette["gray-400"] : ColorPalette["gray-200"]
+          }
+        >
           <FormattedMessage
             id="page.earn.estimation-confirm.usdc-to-usdn.paragraph"
             values={{
@@ -265,7 +273,9 @@ export const EarnConfirmUsdnEstimationPage: FunctionComponent = observer(() => {
           </Box>
           <Gutter size="0.5rem" />
           <Body2
-            color={ColorPalette["gray-100"]}
+            color={
+              isLightMode ? ColorPalette["gray-400"] : ColorPalette["gray-200"]
+            }
             onClick={handleCheckboxChange}
             style={{
               cursor: "pointer",
@@ -277,7 +287,11 @@ export const EarnConfirmUsdnEstimationPage: FunctionComponent = observer(() => {
                 link: (texts) => (
                   <Link
                     to="/earn/noble-terms"
-                    style={{ textDecoration: "underline", cursor: "pointer" }}
+                    style={{
+                      textDecoration: "underline",
+                      cursor: "pointer",
+                      color: "inherit",
+                    }}
                   >
                     {texts}
                   </Link>

--- a/apps/extension/src/pages/earn/intro/index.tsx
+++ b/apps/extension/src/pages/earn/intro/index.tsx
@@ -68,7 +68,13 @@ export const EarnIntroPage: FunctionComponent = observer(() => {
         <Gutter size="1rem" />
 
         <Stack gutter="0.25rem">
-          <H1>
+          <H1
+            color={
+              theme.mode === "light"
+                ? ColorPalette["gray-700"]
+                : ColorPalette.white
+            }
+          >
             {intl.formatMessage(
               { id: "page.earn.intro.title" },
               {
@@ -111,7 +117,11 @@ export const EarnIntroPage: FunctionComponent = observer(() => {
         <Gutter size="1rem" />
 
         <Body2
-          color={ColorPalette["gray-100"]}
+          color={
+            theme.mode === "light"
+              ? ColorPalette["gray-500"]
+              : ColorPalette["gray-100"]
+          }
           style={{ lineHeight: "1.225rem" }}
         >
           {intl.formatMessage(
@@ -131,7 +141,14 @@ export const EarnIntroPage: FunctionComponent = observer(() => {
                 color={ColorPalette["green-500"]}
               />
               <Gutter size="0.25rem" />
-              <Body2 key={benefit} color={ColorPalette["gray-100"]}>
+              <Body2
+                key={benefit}
+                color={
+                  theme.mode === "light"
+                    ? ColorPalette["gray-500"]
+                    : ColorPalette["gray-100"]
+                }
+              >
                 {benefit}
               </Body2>
             </XAxis>
@@ -167,13 +184,23 @@ export const EarnIntroPage: FunctionComponent = observer(() => {
           style={{ cursor: "pointer" }}
         >
           <XAxis alignY="center">
-            <Body2 color={ColorPalette["gray-200"]}>
+            <Body2
+              color={
+                theme.mode === "light"
+                  ? ColorPalette["gray-400"]
+                  : ColorPalette["gray-200"]
+              }
+            >
               {intl.formatMessage({ id: "page.earn.intro.learn-more-button" })}
             </Body2>
             <ArrowRightIcon
               width="1rem"
               height="1rem"
-              color={ColorPalette["gray-200"]}
+              color={
+                theme.mode === "light"
+                  ? ColorPalette["gray-500"]
+                  : ColorPalette["gray-200"]
+              }
             />
           </XAxis>
         </Box>

--- a/apps/extension/src/pages/earn/overview/tutorial-modal/earn-claim-content.tsx
+++ b/apps/extension/src/pages/earn/overview/tutorial-modal/earn-claim-content.tsx
@@ -17,17 +17,24 @@ export const EarnClaimContent: FunctionComponent<{
   tokenName: string;
   moveToNext: () => void;
   moveToPrev: () => void;
-}> = ({ tokenName, moveToNext, moveToPrev }) => (
+  isLightMode: boolean;
+}> = ({ tokenName, moveToNext, moveToPrev, isLightMode }) => (
   <Fragment>
     <Box paddingY="1.25rem">
-      <H4 color={ColorPalette.white} style={{ textAlign: "center" }}>
+      <H4
+        color={isLightMode ? ColorPalette["gray-700"] : ColorPalette.white}
+        style={{ textAlign: "center" }}
+      >
         <FormattedMessage
           id="page.earn.overview.tutorial-modal.claim.title"
           values={{ tokenName }}
         />
       </H4>
     </Box>
-    <Body3 color={ColorPalette["gray-200"]} style={{ textAlign: "center" }}>
+    <Body3
+      color={isLightMode ? ColorPalette["gray-400"] : ColorPalette["gray-200"]}
+      style={{ textAlign: "center" }}
+    >
       <FormattedMessage
         id="page.earn.overview.tutorial-modal.claim.paragraph"
         values={{ tokenName }}
@@ -35,7 +42,7 @@ export const EarnClaimContent: FunctionComponent<{
     </Body3>
     <Gutter size="1.125rem" />
 
-    <SampleClaimAllRewardCard />
+    <SampleClaimAllRewardCard isLightMode={isLightMode} />
     <Gutter size="1.5rem" />
 
     <XAxis>
@@ -57,13 +64,22 @@ export const EarnClaimContent: FunctionComponent<{
   </Fragment>
 );
 
-const SampleClaimAllRewardCard: FunctionComponent = () => (
+const SampleClaimAllRewardCard: FunctionComponent<{
+  isLightMode: boolean;
+}> = ({ isLightMode }) => (
   <Box position="relative" style={{ cursor: "default" }}>
     <Box
       zIndex={1}
       paddingX="1rem"
       paddingY="0.75rem"
-      backgroundColor={ColorPalette["gray-650"]}
+      backgroundColor={
+        isLightMode ? ColorPalette.white : ColorPalette["gray-650"]
+      }
+      style={
+        isLightMode
+          ? { boxShadow: "0px 1px 4px 0px rgba(43, 39, 55, 0.10)" }
+          : {}
+      }
       borderRadius="0.5rem"
     >
       <XAxis>
@@ -80,7 +96,7 @@ const SampleClaimAllRewardCard: FunctionComponent = () => (
           style={{
             marginLeft: "auto",
             borderRadius: "0.5rem",
-            border: "5px solid #23242D",
+            border: `5px solid ${isLightMode ? "#E1E5FB" : "#23242D"}`,
             background: ColorPalette["blue-400"],
             boxSizing: "border-box",
             maxHeight: "max-content",

--- a/apps/extension/src/pages/earn/overview/tutorial-modal/index.tsx
+++ b/apps/extension/src/pages/earn/overview/tutorial-modal/index.tsx
@@ -32,12 +32,14 @@ export const EarnOverviewTutorialModal: FunctionComponent<{
       coinImageUrl={holdingCurrency.coinImageUrl ?? ""}
       key="manage-earn"
       onNext={handleNext}
+      isLightMode={theme.mode === "light"}
     />,
     <EarnClaimContent
       tokenName={rewardDenom}
       moveToNext={onClose}
       moveToPrev={handlePrev}
       key="earn-claim"
+      isLightMode={theme.mode === "light"}
     />,
   ];
 

--- a/apps/extension/src/pages/earn/overview/tutorial-modal/manage-earn-content.tsx
+++ b/apps/extension/src/pages/earn/overview/tutorial-modal/manage-earn-content.tsx
@@ -13,17 +13,24 @@ export const ManageEarnContent: FunctionComponent<{
   denom: string;
   coinImageUrl: string;
   onNext: () => void;
-}> = ({ denom, coinImageUrl, onNext }) => (
+  isLightMode: boolean;
+}> = ({ denom, coinImageUrl, onNext, isLightMode }) => (
   <Fragment>
     <Box paddingY="1.25rem">
-      <H4 color={ColorPalette.white} style={{ textAlign: "center" }}>
+      <H4
+        color={isLightMode ? ColorPalette["gray-700"] : ColorPalette.white}
+        style={{ textAlign: "center" }}
+      >
         <FormattedMessage
           id="page.earn.overview.tutorial-modal.manage-earn.title"
           values={{ tokenName: denom }}
         />
       </H4>
     </Box>
-    <Body3 color={ColorPalette["gray-200"]} style={{ textAlign: "center" }}>
+    <Body3
+      color={isLightMode ? ColorPalette["gray-400"] : ColorPalette["gray-200"]}
+      style={{ textAlign: "center" }}
+    >
       <FormattedMessage
         id="page.earn.overview.tutorial-modal.manage-earn.paragraph"
         values={{ tokenName: denom }}
@@ -31,7 +38,11 @@ export const ManageEarnContent: FunctionComponent<{
     </Body3>
     <Gutter size="1.125rem" />
 
-    <SampleTokenItemCard denom={denom} coinImageUrl={coinImageUrl} />
+    <SampleTokenItemCard
+      denom={denom}
+      coinImageUrl={coinImageUrl}
+      isLightMode={isLightMode}
+    />
     <Gutter size="1.625rem" />
 
     <Button
@@ -46,21 +57,32 @@ export const ManageEarnContent: FunctionComponent<{
 const SampleTokenItemCard: FunctionComponent<{
   denom: string;
   coinImageUrl: string;
-}> = ({ denom, coinImageUrl }) => {
-  console.log(denom);
+  isLightMode: boolean;
+}> = ({ denom, coinImageUrl, isLightMode }) => {
   return (
     <Box position="relative" style={{ cursor: "default" }}>
       <Box
         zIndex={2}
         paddingX="1rem"
         paddingY="0.75rem"
-        backgroundColor={ColorPalette["gray-650"]}
+        backgroundColor={
+          isLightMode ? ColorPalette.white : ColorPalette["gray-650"]
+        }
         borderRadius="0.5rem"
+        style={
+          isLightMode
+            ? { boxShadow: "0px 1px 4px 0px rgba(43, 39, 55, 0.10)" }
+            : {}
+        }
       >
         <XAxis alignY="center">
           <Image src={coinImageUrl} width="24px" height="24px" alt={denom} />
           <Gutter size="0.75rem" />
-          <Subtitle4 color={ColorPalette.white}>{denom}</Subtitle4>
+          <Subtitle4
+            color={isLightMode ? ColorPalette["gray-700"] : ColorPalette.white}
+          >
+            {denom}
+          </Subtitle4>
         </XAxis>
       </Box>
       <Box
@@ -72,11 +94,17 @@ const SampleTokenItemCard: FunctionComponent<{
         }}
         paddingTop="0.875rem"
         paddingBottom="0.375rem"
-        backgroundColor={Color(ColorPalette["green-700"]).alpha(0.2).toString()}
+        backgroundColor={
+          isLightMode
+            ? ColorPalette["green-100"]
+            : Color(ColorPalette["green-700"]).alpha(0.2).toString()
+        }
         borderRadius="0 0 0.5rem 0.5rem"
       >
         <Body3
-          color={ColorPalette["green-400"]}
+          color={
+            isLightMode ? ColorPalette["green-600"] : ColorPalette["green-400"]
+          }
           style={{ textAlign: "center" }}
         >
           <FormattedMessage

--- a/apps/extension/src/pages/earn/transfer/amount.tsx
+++ b/apps/extension/src/pages/earn/transfer/amount.tsx
@@ -52,8 +52,12 @@ import { NOBLE_CHAIN_ID } from "../../../config.ui";
 import { DenomHelper, ExtensionKVStore } from "@keplr-wallet/common";
 import { XAxis, YAxis } from "../../../components/axis";
 import { LongArrowDownIcon } from "../../../components/icon/long-arrow-down";
+import { useTheme } from "styled-components";
 
 export const EarnTransferAmountPage: FunctionComponent = observer(() => {
+  const theme = useTheme();
+  const isLightMode = theme.mode === "light";
+
   const {
     accountStore,
     chainStore,
@@ -548,7 +552,9 @@ export const EarnTransferAmountPage: FunctionComponent = observer(() => {
         }}
       >
         <Stack flex={1}>
-          <MobileH3 color={ColorPalette["white"]}>
+          <MobileH3
+            color={isLightMode ? ColorPalette["gray-700"] : ColorPalette.white}
+          >
             {intl.formatMessage(
               { id: "page.earn.transfer.amount.title" },
               {
@@ -576,7 +582,9 @@ export const EarnTransferAmountPage: FunctionComponent = observer(() => {
                 .equals(new Dec("0")) && (
                 <Box
                   padding="0.25rem 0.375rem"
-                  backgroundColor={ColorPalette["gray-550"]}
+                  backgroundColor={
+                    isLightMode ? ColorPalette.white : ColorPalette["gray-550"]
+                  }
                   borderRadius="0.5rem"
                   width="fit-content"
                   cursor="pointer"
@@ -584,7 +592,13 @@ export const EarnTransferAmountPage: FunctionComponent = observer(() => {
                     sendConfigs.amountConfig.setFraction(1);
                   }}
                 >
-                  <Subtitle4 color={ColorPalette["gray-200"]}>
+                  <Subtitle4
+                    color={
+                      isLightMode
+                        ? ColorPalette["gray-400"]
+                        : ColorPalette["gray-200"]
+                    }
+                  >
                     {balance.trim(true).hideIBCMetadata(true).toString()}
                   </Subtitle4>
                 </Box>
@@ -607,7 +621,11 @@ export const EarnTransferAmountPage: FunctionComponent = observer(() => {
                 <LongArrowDownIcon
                   width="1.5rem"
                   height="1.5rem"
-                  color={ColorPalette["gray-400"]}
+                  color={
+                    isLightMode
+                      ? ColorPalette["gray-200"]
+                      : ColorPalette["gray-400"]
+                  }
                 />
               </YAxis>
               <Gutter size="1rem" />

--- a/apps/extension/src/pages/earn/transfer/intro.tsx
+++ b/apps/extension/src/pages/earn/transfer/intro.tsx
@@ -13,8 +13,15 @@ import { Column, Columns } from "../../../components/column";
 import { ColorPalette } from "../../../styles";
 import { Stack } from "../../../components/stack";
 import { NOBLE_CHAIN_ID } from "../../../config.ui";
+import { useTheme } from "styled-components";
 
 export const EarnTransferIntroPage: FunctionComponent = observer(() => {
+  const theme = useTheme();
+  const isLightMode = theme.mode === "light";
+  const textHighColor = isLightMode
+    ? ColorPalette["gray-700"]
+    : ColorPalette.white;
+
   const intl = useIntl();
   const navigate = useNavigate();
 
@@ -43,7 +50,7 @@ export const EarnTransferIntroPage: FunctionComponent = observer(() => {
       }}
     >
       <Box paddingX="1.5rem" paddingTop="2rem">
-        <H2 color={ColorPalette["white"]}>
+        <H2 color={textHighColor}>
           {intl.formatMessage(
             {
               id: "page.earn.transfer.intro.title",
@@ -61,7 +68,11 @@ export const EarnTransferIntroPage: FunctionComponent = observer(() => {
                 width="1.5rem"
                 height="1.5rem"
                 padding="0.25rem"
-                backgroundColor={ColorPalette["gray-600"]}
+                backgroundColor={
+                  isLightMode
+                    ? ColorPalette["gray-100"]
+                    : ColorPalette["gray-600"]
+                }
                 borderRadius="50%"
                 style={{
                   display: "flex",
@@ -69,19 +80,27 @@ export const EarnTransferIntroPage: FunctionComponent = observer(() => {
                   justifyContent: "center",
                 }}
               >
-                <Caption1 color={ColorPalette["white"]}>1</Caption1>
+                <Caption1 color={textHighColor}>1</Caption1>
               </Box>
               <Box
                 width="0.125rem"
                 height="2.125rem"
-                backgroundColor={ColorPalette["gray-500"]}
+                backgroundColor={
+                  isLightMode
+                    ? ColorPalette["gray-100"]
+                    : ColorPalette["gray-500"]
+                }
                 borderRadius="0.125rem"
               />
               <Box
                 width="1.5rem"
                 height="1.5rem"
                 padding="0.25rem"
-                backgroundColor={ColorPalette["gray-600"]}
+                backgroundColor={
+                  isLightMode
+                    ? ColorPalette["gray-100"]
+                    : ColorPalette["gray-600"]
+                }
                 borderRadius="50%"
                 style={{
                   display: "flex",
@@ -89,27 +108,33 @@ export const EarnTransferIntroPage: FunctionComponent = observer(() => {
                   justifyContent: "center",
                 }}
               >
-                <Caption1 color={ColorPalette["white"]}>2</Caption1>
+                <Caption1 color={textHighColor}>2</Caption1>
               </Box>
             </Stack>
           </Column>
           <Column weight={1}>
             <Stack>
               <Box paddingY="0.21875rem">
-                <Body2 color={ColorPalette["white"]}>
+                <Body2 color={textHighColor}>
                   {intl.formatMessage({
                     id: "page.earn.transfer.intro.paragraph.first",
                   })}
                 </Body2>
               </Box>
-              <Body3 color={ColorPalette["gray-200"]}>
+              <Body3
+                color={
+                  isLightMode
+                    ? ColorPalette["gray-400"]
+                    : ColorPalette["gray-200"]
+                }
+              >
                 {intl.formatMessage({
                   id: "page.earn.transfer.intro.paragraph.first.sub-paragraph",
                 })}
               </Body3>
               <Gutter size="2.25rem" />
               <Box paddingY="0.21875rem">
-                <Body2 color={ColorPalette["white"]}>
+                <Body2 color={textHighColor}>
                   {intl.formatMessage({
                     id: "page.earn.transfer.intro.paragraph.second",
                   })}

--- a/apps/extension/src/pages/earn/withdraw/amount.tsx
+++ b/apps/extension/src/pages/earn/withdraw/amount.tsx
@@ -34,13 +34,17 @@ import {
   NobleEarnAmountConfig,
   useNobleEarnAmountConfig,
 } from "@keplr-wallet/hooks-internal";
-import { ApyChip } from "../components/chip";
+import { ApyChip, Chip } from "../components/chip";
 import { ExtensionKVStore } from "@keplr-wallet/common";
 import { WarningBox } from "../../../components/warning-box";
+import { useTheme } from "styled-components";
 
 const NOBLE_EARN_WITHDRAW_OUT_COIN_MINIMAL_DENOM = "uusdc";
 
 export const EarnWithdrawAmountPage: FunctionComponent = observer(() => {
+  const theme = useTheme();
+  const isLightMode = theme.mode === "light";
+
   const { accountStore, chainStore, queriesStore } = useStore();
   const [searchParams] = useSearchParams();
   const intl = useIntl();
@@ -240,7 +244,11 @@ export const EarnWithdrawAmountPage: FunctionComponent = observer(() => {
           }}
         >
           <Stack flex={1}>
-            <MobileH3 color={ColorPalette["white"]}>
+            <MobileH3
+              color={
+                isLightMode ? ColorPalette["gray-700"] : ColorPalette["white"]
+              }
+            >
               {intl.formatMessage(
                 { id: "page.earn.withdraw.amount.title" },
                 {
@@ -268,15 +276,30 @@ export const EarnWithdrawAmountPage: FunctionComponent = observer(() => {
                   .equals(new Dec("0")) && (
                   <Box
                     padding="0.25rem 0.375rem"
-                    backgroundColor={ColorPalette["gray-550"]}
+                    backgroundColor={
+                      isLightMode
+                        ? ColorPalette["gray-50"]
+                        : ColorPalette["gray-550"]
+                    }
                     borderRadius="0.5rem"
                     width="fit-content"
                     cursor="pointer"
                     onClick={() => {
                       nobleEarnAmountConfig.amountConfig.setFraction(1);
                     }}
+                    hover={{
+                      backgroundColor: isLightMode
+                        ? ColorPalette["gray-10"]
+                        : ColorPalette["gray-500"],
+                    }}
                   >
-                    <Subtitle4 color={ColorPalette["gray-200"]}>
+                    <Subtitle4
+                      color={
+                        isLightMode
+                          ? ColorPalette["gray-400"]
+                          : ColorPalette["gray-200"]
+                      }
+                    >
                       {balance.trim(true).toString()}
                     </Subtitle4>
                   </Box>
@@ -301,7 +324,11 @@ export const EarnWithdrawAmountPage: FunctionComponent = observer(() => {
                   <LongArrowDownIcon
                     width="1.5rem"
                     height="1.5rem"
-                    color={ColorPalette["gray-400"]}
+                    color={
+                      isLightMode
+                        ? ColorPalette["gray-200"]
+                        : ColorPalette["gray-400"]
+                    }
                   />
                 </YAxis>
                 <Gutter size="1rem" />
@@ -339,6 +366,9 @@ export const EarnWithdrawAmountPage: FunctionComponent = observer(() => {
 const ConfirmView: FunctionComponent<{
   amountConfig: NobleEarnAmountConfig;
 }> = observer(({ amountConfig }) => {
+  const theme = useTheme();
+  const isLightMode = theme.mode === "light";
+
   const intl = useIntl();
 
   return (
@@ -350,7 +380,9 @@ const ConfirmView: FunctionComponent<{
       }}
     >
       <Stack flex={1}>
-        <MobileH3 color={ColorPalette["white"]}>
+        <MobileH3
+          color={isLightMode ? ColorPalette["gray-700"] : ColorPalette["white"]}
+        >
           {intl.formatMessage(
             { id: "page.earn.withdraw.amount.confirm.title" },
             {
@@ -361,7 +393,11 @@ const ConfirmView: FunctionComponent<{
           )}
         </MobileH3>
         <Gutter size="1rem" />
-        <Body2 color={ColorPalette["gray-200"]}>
+        <Body2
+          color={
+            isLightMode ? ColorPalette["gray-400"] : ColorPalette["gray-200"]
+          }
+        >
           {intl.formatMessage(
             {
               id: "page.earn.withdraw.amount.confirm.description",
@@ -377,12 +413,18 @@ const ConfirmView: FunctionComponent<{
         <Box
           padding="1rem"
           borderRadius="0.75rem"
-          backgroundColor={ColorPalette["gray-650"]}
+          backgroundColor={
+            isLightMode ? ColorPalette.white : ColorPalette["gray-650"]
+          }
         >
           <ApyChip chainId={amountConfig.chainId} colorType="green" />
           <Gutter size="0.75rem" />
           <XAxis alignY="center" gap="0.25rem">
-            <H3 color={ColorPalette["white"]}>
+            <H3
+              color={
+                isLightMode ? ColorPalette["gray-700"] : ColorPalette.white
+              }
+            >
               {amountConfig.amount[0].hideDenom(true).trim(true).toString()}
             </H3>
             <H3 color={ColorPalette["gray-300"]}>
@@ -410,23 +452,21 @@ const ConfirmView: FunctionComponent<{
 
           <Gutter size="0.75rem" />
 
-          <Box
-            padding="0.25rem 0.5rem"
-            backgroundColor={ColorPalette["gray-600"]}
-            borderRadius="0.375rem"
-            width="fit-content"
-          >
-            <Subtitle4 color={ColorPalette["gray-300"]}>
-              {intl.formatMessage({
-                id: "page.earn.withdraw.amount.confirm.norewards",
-              })}
-            </Subtitle4>
-          </Box>
+          <Chip
+            text={intl.formatMessage({
+              id: "page.earn.withdraw.amount.confirm.norewards",
+            })}
+            colorType="gray"
+          />
 
           <Gutter size="0.75rem" />
 
           <XAxis alignY="center" gap="0.25rem">
-            <H3 color={ColorPalette["white"]}>
+            <H3
+              color={
+                isLightMode ? ColorPalette["gray-700"] : ColorPalette.white
+              }
+            >
               {amountConfig.expectedOutAmount
                 .hideDenom(true)
                 .trim(true)

--- a/apps/extension/src/pages/main/components/available-tab-slide-list/index.tsx
+++ b/apps/extension/src/pages/main/components/available-tab-slide-list/index.tsx
@@ -15,9 +15,12 @@ import { useGetEarnApy } from "../../../../hooks/use-get-apy";
 import { observer } from "mobx-react-lite";
 import { NOBLE_CHAIN_ID } from "../../../../config.ui";
 import { Dec } from "@keplr-wallet/unit";
+import { useTheme } from "styled-components";
 
 export const AvailableTabSlideList = observer(() => {
   const navigate = useNavigate();
+  const theme = useTheme();
+
   const { analyticsStore, hugeQueriesStore } = useStore();
   const { apy } = useGetEarnApy(NOBLE_CHAIN_ID);
 
@@ -45,7 +48,11 @@ export const AvailableTabSlideList = observer(() => {
         <PercentageIcon
           width="0.5rem"
           height="0.5rem"
-          color={ColorPalette.white}
+          color={
+            theme.mode === "light"
+              ? ColorPalette["gray-700"]
+              : ColorPalette.white
+          }
         />
       </Box>
       <Gutter size="0.5rem" />

--- a/apps/extension/src/pages/main/components/token/wrapper-with-bottom-tag.tsx
+++ b/apps/extension/src/pages/main/components/token/wrapper-with-bottom-tag.tsx
@@ -9,6 +9,7 @@ import { useGetEarnApy } from "../../../../hooks/use-get-apy";
 import { ColorPalette } from "../../../../styles";
 import { observer } from "mobx-react-lite";
 import { NOBLE_CHAIN_ID } from "../../../../config.ui";
+import { useTheme } from "styled-components";
 
 type BottomTagType = "nudgeEarn" | "showEarnSavings";
 
@@ -25,6 +26,9 @@ export const WrapperwithBottomTag = observer(function ({
   const intl = useIntl();
   const navigate = useNavigate();
   const { apy } = useGetEarnApy(NOBLE_CHAIN_ID);
+
+  const theme = useTheme();
+  const isLightMode = theme.mode === "light";
 
   function onClick() {
     if (isNudgeEarn) {
@@ -67,16 +71,26 @@ export const WrapperwithBottomTag = observer(function ({
         }}
         paddingTop="0.875rem"
         paddingBottom="0.375rem"
-        backgroundColor={Color(ColorPalette["green-600"]).alpha(0.2).toString()}
-        hover={{
-          backgroundColor: Color(ColorPalette["green-600"])
-            .alpha(0.15)
-            .toString(),
-        }}
+        backgroundColor={
+          isLightMode
+            ? ColorPalette["green-100"]
+            : Color(ColorPalette["green-600"]).alpha(0.2).toString()
+        }
+        hover={
+          isLightMode
+            ? {}
+            : {
+                backgroundColor: Color(ColorPalette["green-600"])
+                  .alpha(0.15)
+                  .toString(),
+              }
+        }
         borderRadius="0 0 0.5rem 0.5rem"
       >
         <Body2
-          color={ColorPalette["green-400"]}
+          color={
+            isLightMode ? ColorPalette["green-600"] : ColorPalette["green-400"]
+          }
           style={{ textAlign: "center" }}
         >
           {message}
@@ -84,7 +98,9 @@ export const WrapperwithBottomTag = observer(function ({
         <ArrowRightIcon
           width="1rem"
           height="1rem"
-          color={ColorPalette["green-400"]}
+          color={
+            isLightMode ? ColorPalette["green-600"] : ColorPalette["green-400"]
+          }
         />
       </Box>
     </Box>

--- a/apps/extension/src/pages/main/token-detail/banners/earn-apy-banner.tsx
+++ b/apps/extension/src/pages/main/token-detail/banners/earn-apy-banner.tsx
@@ -1,7 +1,6 @@
 import React, { FunctionComponent } from "react";
 import { Box } from "../../../../components/box";
 import { PercentageIcon } from "../../../../components/icon";
-import { IconInCircle } from "../icon-in-circle";
 import { YAxis } from "../../../../components/axis";
 import { Subtitle3 } from "../../../../components/typography";
 import { useIntl } from "react-intl";
@@ -10,10 +9,13 @@ import { ColorPalette } from "../../../../styles";
 import { Gutter } from "../../../../components/gutter";
 import { ApyChip } from "../../../earn/components/chip";
 import { useNavigate } from "react-router";
+import { useTheme } from "styled-components";
 
 export const EarnApyBanner: FunctionComponent<{
   chainId: string;
 }> = ({ chainId }) => {
+  const theme = useTheme();
+  const isLightMode = theme.mode === "light";
   const intl = useIntl();
   const navigate = useNavigate();
 
@@ -23,19 +25,39 @@ export const EarnApyBanner: FunctionComponent<{
         display: "flex",
         flexDirection: "row",
         alignItems: "center",
+        ...(isLightMode
+          ? { boxShadow: "0px 1px 4px 0px rgba(43, 39, 55, 0.10)" }
+          : {}),
       }}
-      backgroundColor={ColorPalette["gray-650"]}
+      backgroundColor={
+        isLightMode ? ColorPalette.white : ColorPalette["gray-650"]
+      }
       padding="1rem"
       marginX="0.75rem"
       marginTop="19px"
       borderRadius="0.375rem"
     >
-      <IconInCircle
-        icon={<PercentageIcon width="0.75rem" height="0.75rem" />}
-      />
+      <Box
+        width="2.5rem"
+        height="2.5rem"
+        alignX="center"
+        alignY="center"
+        borderRadius="999999px"
+        backgroundColor={
+          isLightMode ? ColorPalette["gray-50"] : ColorPalette["gray-550"]
+        }
+      >
+        <PercentageIcon
+          width="0.75rem"
+          height="0.75rem"
+          color={isLightMode ? ColorPalette["gray-200"] : ColorPalette["white"]}
+        />
+      </Box>
       <Gutter size="0.75rem" />
       <YAxis gap="0.375rem">
-        <Subtitle3>
+        <Subtitle3
+          color={isLightMode ? ColorPalette["gray-700"] : ColorPalette.white}
+        >
           {intl.formatMessage({
             id: "page.token-detail.earn-apy-banner.title",
           })}

--- a/apps/extension/src/pages/send/select-asset/index.tsx
+++ b/apps/extension/src/pages/send/select-asset/index.tsx
@@ -126,7 +126,13 @@ export const SendSelectAssetPage: FunctionComponent = observer(() => {
       <Styles.Container gutter="0.5rem" isNobleEarn={paramIsNobleEarn}>
         {paramIsNobleEarn ? (
           <Box>
-            <H2 color={ColorPalette["white"]}>
+            <H2
+              color={
+                theme.mode === "light"
+                  ? ColorPalette["gray-700"]
+                  : ColorPalette.white
+              }
+            >
               {intl.formatMessage(
                 { id: "page.send.select-asset.earn.title" },
                 {


### PR DESCRIPTION
Home 토큰 목록 아이템의 EARN 뱃지는 제거 예정으로 확인해서 light mode 반영하지 않았습니다. (`EarnBadgeWrapper`)