### PR TITLE
Reduce space between earn amount and denom

### DIFF
--- a/apps/extension/src/pages/earn/amount/index.tsx
+++ b/apps/extension/src/pages/earn/amount/index.tsx
@@ -143,7 +143,7 @@ export const EarnAmountPage: FunctionComponent = observer(() => {
 
         <Gutter size="1.75rem" />
         <Input
-          type="number"
+          type="text"
           placeholder={`0 ${currency?.coinDenom ?? ""}`}
           value={amountInput}
           warning={amountError != null}

--- a/apps/extension/src/pages/earn/amount/index.tsx
+++ b/apps/extension/src/pages/earn/amount/index.tsx
@@ -143,7 +143,7 @@ export const EarnAmountPage: FunctionComponent = observer(() => {
 
         <Gutter size="1.75rem" />
         <Input
-          type="text"
+          type="number"
           placeholder={`0 ${currency?.coinDenom ?? ""}`}
           value={amountInput}
           warning={amountError != null}

--- a/apps/extension/src/pages/earn/components/input.tsx
+++ b/apps/extension/src/pages/earn/components/input.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import { ColorPalette } from "../../../styles";
-import React, { FunctionComponent } from "react";
+import React, { FunctionComponent, useEffect, useRef, useState } from "react";
 import Color from "color";
 
 export const Input: FunctionComponent<
@@ -9,26 +9,137 @@ export const Input: FunctionComponent<
     suffix?: string;
   }
 > = ({ warning, suffix, value, ...props }) => {
+  if (!value) {
+    suffix = undefined;
+  }
+  if (suffix) {
+    suffix = " " + suffix;
+  }
+
+  const widthCheckRef = useRef<HTMLSpanElement | null>(null);
+  const [textWidth, setTextWidth] = useState<number | null>(null);
+  useEffect(() => {
+    if (widthCheckRef.current) {
+      const resizeObserver = new ResizeObserver((entries) => {
+        if (entries.length > 0) {
+          const entry = entries[0];
+          const boxSize = Array.isArray(entry.borderBoxSize)
+            ? entry.borderBoxSize[0]
+            : entry.borderBoxSize;
+
+          const width = boxSize.inlineSize;
+          setTextWidth(width);
+        }
+      });
+      resizeObserver.observe(widthCheckRef.current);
+      return () => resizeObserver.disconnect();
+    }
+  }, []);
+  const inputWidthCheckRef = useRef<HTMLInputElement | null>(null);
+  const [textInputWidth, setTextInputWidth] = useState<number | null>(null);
+  useEffect(() => {
+    if (inputWidthCheckRef.current) {
+      const resizeObserver = new ResizeObserver((entries) => {
+        if (entries.length > 0) {
+          const entry = entries[0];
+          const boxSize = Array.isArray(entry.contentBoxSize)
+            ? entry.contentBoxSize[0]
+            : entry.contentBoxSize;
+
+          const width = boxSize.inlineSize;
+          setTextInputWidth(width);
+        }
+      });
+      resizeObserver.observe(inputWidthCheckRef.current);
+      return () => resizeObserver.disconnect();
+    }
+  }, []);
+  const suffixWidthCheckRef = useRef<HTMLDivElement | null>(null);
+  const [suffixTextWidth, setSuffixTextWidth] = useState<number | null>(null);
+  useEffect(() => {
+    if (suffixWidthCheckRef.current) {
+      const resizeObserver = new ResizeObserver((entries) => {
+        if (entries.length > 0) {
+          const entry = entries[0];
+          const boxSize = Array.isArray(entry.borderBoxSize)
+            ? entry.borderBoxSize[0]
+            : entry.borderBoxSize;
+
+          const width = boxSize.inlineSize;
+          setSuffixTextWidth(width);
+        }
+      });
+      resizeObserver.observe(suffixWidthCheckRef.current);
+      return () => resizeObserver.disconnect();
+    }
+  }, []);
+
   return (
     <InputContainer>
-      <StyledInput warning={warning} value={value ?? ""} {...props} />
-      {suffix && value && <Suffix isWarning={!!warning}>{suffix}</Suffix>}
+      <div
+        style={{
+          position: "relative",
+          opacity: 0,
+          visibility: "hidden",
+        }}
+      >
+        <TextInputWidthChecker ref={widthCheckRef}>
+          {value}
+        </TextInputWidthChecker>
+      </div>
+      <div
+        style={{
+          position: "relative",
+          display: "flex",
+        }}
+      >
+        <StyledInput ref={inputWidthCheckRef} warning={warning} {...props} />
+        <div
+          style={(() => {
+            if (suffixTextWidth == null || !suffix) {
+              return {
+                width: 0,
+                opacity: 0,
+              };
+            }
+            return {
+              width: suffixTextWidth + "px",
+              // 옆의 마진이 왜 필요한지 모른다...
+              // 어쨋든 실행시켜서 살펴보면 이 요소는 의도보다 오른쪽으로 치우져진다
+              // 사실 24px도 정확한 값은 아닌데... 원인을 못 찾았으므로 일단 대강 처리
+              marginRight: "24px",
+            };
+          })()}
+        />
+        <Suffix
+          ref={suffixWidthCheckRef}
+          isWarning={!!warning}
+          textWidth={(() => {
+            if (textWidth != null && textInputWidth != null) {
+              return Math.min(textWidth, textInputWidth);
+            }
+            if (textWidth != null) {
+              return textWidth;
+            }
+            if (textInputWidth != null) {
+              return textInputWidth;
+            }
+
+            return 0;
+          })()}
+        >
+          {suffix}
+        </Suffix>
+      </div>
     </InputContainer>
   );
 };
 
 const StyledInput = styled.input<{ warning?: boolean }>`
+  width: 100%;
   font-weight: 700;
   font-size: 1.75rem;
   line-height: 2.25rem;
-
-  width: ${(props) =>
-    props.value?.toString().length
-      ? `${
-          props.value.toString().length +
-          (props.value.toString().includes(".") ? 0.2 : 0.5)
-        }ch`
-      : "100%"};
 
   background: none;
 
@@ -61,7 +172,19 @@ const StyledInput = styled.input<{ warning?: boolean }>`
   }
 `;
 
+const TextInputWidthChecker = styled.span`
+  position: fixed;
+  visibility: hidden;
+  opacity: 0;
+  font-weight: 700;
+  font-size: 1.75rem;
+  line-height: 2.25rem;
+  white-space: pre;
+`;
+
 const InputContainer = styled.div`
+  position: relative;
+
   overflow: scroll;
   width: 100%;
 
@@ -80,7 +203,13 @@ const InputContainer = styled.div`
         : Color(ColorPalette["gray-300"]).alpha(0.5).toString()};
 `;
 
-const Suffix = styled.span<{ isWarning?: boolean }>`
+const Suffix = styled.span<{ isWarning?: boolean; textWidth?: number }>`
+  position: absolute;
+  white-space: pre;
+  top: 50%;
+  transform: translateY(-50%);
+  left: ${({ textWidth }) => (textWidth ? `${textWidth + 2}px` : 0)};
+
   font-weight: 700;
   font-size: 1.75rem;
   line-height: 2.25rem;

--- a/apps/extension/src/pages/earn/components/input.tsx
+++ b/apps/extension/src/pages/earn/components/input.tsx
@@ -93,7 +93,12 @@ export const Input: FunctionComponent<
           display: "flex",
         }}
       >
-        <StyledInput ref={inputWidthCheckRef} warning={warning} {...props} />
+        <StyledInput
+          ref={inputWidthCheckRef}
+          value={value}
+          warning={warning}
+          {...props}
+        />
         <div
           style={(() => {
             if (suffixTextWidth == null || !suffix) {

--- a/apps/extension/src/pages/earn/components/input.tsx
+++ b/apps/extension/src/pages/earn/components/input.tsx
@@ -24,7 +24,10 @@ const StyledInput = styled.input<{ warning?: boolean }>`
 
   width: ${(props) =>
     props.value?.toString().length
-      ? `${props.value.toString().length + 1}ch`
+      ? `${
+          props.value.toString().length +
+          (props.value.toString().includes(".") ? 0.2 : 0.5)
+        }ch`
       : "100%"};
 
   background: none;

--- a/apps/extension/src/pages/earn/components/input.tsx
+++ b/apps/extension/src/pages/earn/components/input.tsx
@@ -198,7 +198,7 @@ const InputContainer = styled.div`
   align-items: center;
 
   margin: 0;
-  padding: 0.25rem;
+  padding: 0.25rem 0.125rem;
   padding-bottom: 0.75rem;
 
   border-bottom: 1px solid

--- a/apps/extension/src/pages/earn/transfer/amount.tsx
+++ b/apps/extension/src/pages/earn/transfer/amount.tsx
@@ -565,7 +565,7 @@ export const EarnTransferAmountPage: FunctionComponent = observer(() => {
 
           <Gutter size="2rem" />
           <Input
-            type="text"
+            type="number"
             placeholder={balance.trim(true).hideIBCMetadata(true).toString()}
             value={sendConfigs.amountConfig.value}
             warning={error != null}

--- a/apps/extension/src/pages/earn/transfer/amount.tsx
+++ b/apps/extension/src/pages/earn/transfer/amount.tsx
@@ -565,7 +565,7 @@ export const EarnTransferAmountPage: FunctionComponent = observer(() => {
 
           <Gutter size="2rem" />
           <Input
-            type="number"
+            type="text"
             placeholder={balance.trim(true).hideIBCMetadata(true).toString()}
             value={sendConfigs.amountConfig.value}
             warning={error != null}

--- a/apps/extension/src/pages/earn/withdraw/amount.tsx
+++ b/apps/extension/src/pages/earn/withdraw/amount.tsx
@@ -269,7 +269,7 @@ export const EarnWithdrawAmountPage: FunctionComponent = observer(() => {
 
             <Gutter size="2rem" />
             <Input
-              type="number"
+              type="text"
               placeholder={balance.trim(true).toString()}
               value={nobleEarnAmountConfig.amountConfig.value}
               warning={error != null}

--- a/apps/extension/src/pages/earn/withdraw/amount.tsx
+++ b/apps/extension/src/pages/earn/withdraw/amount.tsx
@@ -269,7 +269,7 @@ export const EarnWithdrawAmountPage: FunctionComponent = observer(() => {
 
             <Gutter size="2rem" />
             <Input
-              type="text"
+              type="number"
               placeholder={balance.trim(true).toString()}
               value={nobleEarnAmountConfig.amountConfig.value}
               warning={error != null}


### PR DESCRIPTION

변경 전
<img width="346" alt="스크린샷 2025-03-04 오후 8 18 27" src="https://github.com/user-attachments/assets/8b334a3e-710b-4ccd-b7f0-53ce6671db28" />
<img width="346" alt="스크린샷 2025-03-04 오후 8 17 27" src="https://github.com/user-attachments/assets/ac2d4cd8-95bd-407f-b893-0951fca3d787" />

변경 후
<img width="346" alt="스크린샷 2025-03-04 오후 8 08 31" src="https://github.com/user-attachments/assets/fc3f2ed1-675b-4711-93a5-80123af183b3" />
<img width="346" alt="스크린샷 2025-03-04 오후 8 08 38" src="https://github.com/user-attachments/assets/174a0249-6304-4dce-86e8-4185762ffe62" />

변경 전은 number여서 decimal point(`.`)를 length로 인식 못함 -> input value.length에서 글자 길이를 받을 때 포함되지 않음