### PR TITLE
Update get-key.md

### DIFF
--- a/docs/docs/guide/get-key.md
+++ b/docs/docs/guide/get-key.md
@@ -1,6 +1,6 @@
 # Get Address / Public Key
 
-The `getKey` function is used to retrieve addresses and its associated public key. This function is a crucial part of interacting with blockchain accounts, enabling developers to obtain account details securely.
+The `getKey` function is used to retrieve addresses and their associated public key. This function is a crucial part of interacting with blockchain accounts, enabling developers to obtain account details securely.
 
 ---
 
@@ -50,7 +50,7 @@ interface Key {
 
 :::info
 Hardware Wallet Support:
-- Ledger wallets typically use the Amino JSON sign mode due to limited support for Protobuf-based SIGN_MODE_DIRECT. Check more details [here](../use-with/cosmjs#types-of-offline-signers).
+- Ledger wallets typically use the Amino JSON sign mode due to limited support for Protobuf-based SIGN_MODE_DIRECT. For more details, check [here](../use-with/cosmjs#types-of-offline-signers).
 - Use the `isNanoLedger` and `isKeystone` properties to determine the appropriate signing mode for hardware wallets.
 :::
 


### PR DESCRIPTION
Hi,

I suggest two changes for this doc:

First; "addresses and its associated public key": "its" should be "their" because you're referring to multiple items (addresses and public keys),

And second; "Check more details [here]": The sentence structure here is fine, but for clarity, you might want to adjust it to be more direct. "Check more details" sounds a bit informal. Corrected: "For more details, check [here]".

Thanks.