### PR TITLE
Fix starknet erc20 symbol hex decoding

### DIFF
--- a/packages/stores-starknet/src/queries/erc20-contract-info.ts
+++ b/packages/stores-starknet/src/queries/erc20-contract-info.ts
@@ -40,7 +40,22 @@ export class ObservableQueryStarknetERC20MetadataSymbol extends ObservableStarkn
     }
 
     try {
-      return shortString.decodeShortString(this.response.data[0]);
+      let data = this.response.data[0];
+      if (this.response.data.length > 1) {
+        data =
+          "0x" +
+          this.response.data
+            .map((d) => {
+              const hexWithoutPrefix = d.slice(2);
+              if (hexWithoutPrefix.length % 2 === 1) {
+                return "0" + hexWithoutPrefix;
+              }
+              return hexWithoutPrefix;
+            })
+            .join("");
+      }
+
+      return shortString.decodeShortString(data);
     } catch (e) {
       console.log(e);
     }


### PR DESCRIPTION
- `0x01c8c5847ae848eabf909515338e74dadbc724f54c7735851c57ecfdf1319143` 이 토큰의 경우 응답값이 다음과 같이 반환되어서 익스텐션에서 토큰을 추가할 때 0으로 뜨는 문제가 있었습니다.
```
{
    "result": [
        "0x00",
        "0x444f47",
        "0x03"
    ]
}
```
- 16진수 문자열을 연결하여 디코딩할 수 있게 수정하였습니다.