### PR TITLE
Handle bip32 derivation for bitcoin

### DIFF
--- a/apps/extension/src/config.ts
+++ b/apps/extension/src/config.ts
@@ -3183,9 +3183,12 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
     bitcoin: {
       chainId:
         "bip122:000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
-      rpc: "http://37.27.229.203:50001",
-      rest: "http://37.27.229.203:50011",
-      coinType: 0,
+      rpc: "",
+      rest: "https://api-indexer-bitcoin.keplr.app",
+      bip44: {
+        coinType: 0,
+        purpose: 86,
+      },
       currencies: [
         {
           coinDenom: "BTC",
@@ -3209,9 +3212,12 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
     bitcoin: {
       chainId:
         "bip122:000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
-      rpc: "http://37.27.229.203:50001",
-      rest: "http://37.27.229.203:50001",
-      coinType: 0,
+      rpc: "",
+      rest: "https://api-indexer-bitcoin.keplr.app",
+      bip44: {
+        coinType: 0,
+        purpose: 84,
+      },
       currencies: [
         {
           coinDenom: "BTC",
@@ -3237,7 +3243,10 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
         "bip122:000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943",
       rpc: "",
       rest: "https://blockstream.info/testnet/api",
-      coinType: 1,
+      bip44: {
+        coinType: 1,
+        purpose: 86,
+      },
       currencies: [
         {
           coinDenom: "tBTC",
@@ -3262,7 +3271,10 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
         "bip122:000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943",
       rpc: "",
       rest: "https://blockstream.info/testnet/api",
-      coinType: 1,
+      bip44: {
+        coinType: 1,
+        purpose: 84,
+      },
       currencies: [
         {
           coinDenom: "tBTC",
@@ -3287,7 +3299,10 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
         "bip122:00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6",
       rpc: "",
       rest: "https://explorer.bc-2.jp/api",
-      coinType: 1,
+      bip44: {
+        coinType: 1,
+        purpose: 86,
+      },
       currencies: [
         {
           coinDenom: "sBTC",
@@ -3313,7 +3328,10 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
         "bip122:00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6",
       rpc: "",
       rest: "https://explorer.bc-2.jp/api",
-      coinType: 1,
+      bip44: {
+        coinType: 1,
+        purpose: 84,
+      },
       currencies: [
         {
           coinDenom: "sBTC",

--- a/apps/extension/src/hooks/bitcoin/use-bitcoin-network-config.ts
+++ b/apps/extension/src/hooks/bitcoin/use-bitcoin-network-config.ts
@@ -70,7 +70,7 @@ export const useGetBitcoinKeys = (chainId: string) => {
       masterFingerprintHex?: string | undefined;
       derivationPath?: string | undefined;
     }[]
-  >([]);
+  >([]); // TODO: 하드웨어 지갑을 사용하는 경우, 키 정보를 하드웨어 지갑에서 가져오도록 해야 함.
 
   const getBitcoinKeys = useCallback(async () => {
     const modularChainInfo = chainStore.getModularChain(chainId);

--- a/apps/extension/src/hooks/bitcoin/use-get-utxos.ts
+++ b/apps/extension/src/hooks/bitcoin/use-get-utxos.ts
@@ -1,5 +1,4 @@
 import { useStore } from "../../stores";
-import { useBitcoinAddresses } from "./use-bitcoin-network-config";
 import { useGetInscriptionsByAddress } from "./use-get-inscriptions";
 import { useGetRunesOutputsByAddress } from "./use-get-runes-outputs";
 import { CoinPretty, Dec } from "@keplr-wallet/unit";
@@ -127,15 +126,4 @@ export const useGetUTXOs = (
     availableUTXOs,
     availableBalance,
   };
-};
-
-export const useGetNativeSegwitUTXOs = (chainId: string) => {
-  const { nativeSegwitAddress } = useBitcoinAddresses(chainId);
-
-  return useGetUTXOs(chainId, nativeSegwitAddress ?? "", false, true);
-};
-
-export const useGetTaprootUTXOs = (chainId: string) => {
-  const { taprootAddress } = useBitcoinAddresses(chainId);
-  return useGetUTXOs(chainId, taprootAddress ?? "", true, true);
 };

--- a/apps/extension/src/hooks/bitcoin/use-psbt-validate.ts
+++ b/apps/extension/src/hooks/bitcoin/use-psbt-validate.ts
@@ -1,6 +1,6 @@
-import { IFeeConfig } from "@keplr-wallet/hooks-bitcoin";
+import { IFeeConfig, IPsbtSimulator } from "@keplr-wallet/hooks-bitcoin";
 import { Dec } from "@keplr-wallet/unit";
-import { Network, Psbt, Transaction } from "bitcoinjs-lib";
+import { Psbt, Transaction } from "bitcoinjs-lib";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { fromOutputScript } from "bitcoinjs-lib/src/address";
 import { useGetBitcoinKeys } from "./use-bitcoin-network-config";
@@ -62,10 +62,9 @@ export function formatPsbtHex(psbtHex: string) {
 }
 
 export const usePsbtsValidate = (
-  psbtsHexes: string[],
+  interactionData: NonNullable<SignBitcoinTxInteractionStore["waitingData"]>,
   feeConfig: IFeeConfig,
-  chainId: string,
-  networkConfig: Network
+  psbtSimulator: IPsbtSimulator
 ) => {
   const [isInitialized, setIsInitialized] = useState(false);
   const [validatedPsbts, setValidatedPsbts] = useState<ValidatedPsbt[]>([]);
@@ -78,8 +77,12 @@ export const usePsbtsValidate = (
   const psbtsHexes = useMemo(() => {
     return "psbtHex" in interactionData.data
       ? [interactionData.data.psbtHex]
-      : interactionData.data.psbtsHexes;
-  }, [interactionData.data]);
+      : "psbtsHexes" in interactionData.data
+      ? interactionData.data.psbtsHexes
+      : psbtSimulator.psbtHex != null
+      ? [psbtSimulator.psbtHex]
+      : [];
+  }, [interactionData.data, psbtSimulator.psbtHex]);
 
   const bitcoinKeys = useGetBitcoinKeys(chainId);
 

--- a/apps/extension/src/pages/bitcoin/components/input/fee-control/index.tsx
+++ b/apps/extension/src/pages/bitcoin/components/input/fee-control/index.tsx
@@ -20,49 +20,9 @@ import { Box } from "../../../../../components/box";
 import { VerticalResizeTransition } from "../../../../../components/transition";
 import { FormattedMessage, useIntl } from "react-intl";
 import { XAxis, YAxis } from "../../../../../components/axis";
-import { UIConfigStore } from "../../../../../stores/ui-config";
 import { Tooltip } from "../../../../../components/tooltip";
 import { Modal } from "../../../../../components/modal";
 import { TransactionFeeModal } from "../../transaction-fee-modal";
-
-// 기본적으로 `FeeControl` 안에 있는 로직이였지만 `FeeControl` 말고도 다른 UI를 가진 똑같은 기능의 component가
-// 여러개 생기게 되면서 공통적으로 사용하기 위해서 custom hook으로 분리함
-export const useFeeOptionSelectionOnInit = (
-  _uiConfigStore: UIConfigStore,
-  _feeConfig: IFeeConfig,
-  _disableAutomaticFeeSet: boolean | undefined
-) => {
-  // TODO
-  // useLayoutEffect(() => {
-  //   if (disableAutomaticFeeSet) {
-  //     return;
-  //   }
-  //
-  //   if (
-  //     feeConfig.fees.length === 0 &&
-  //     feeConfig.selectableFeeCurrencies.length > 0
-  //   ) {
-  //     if (uiConfigStore.rememberLastFeeOption && uiConfigStore.lastFeeOption) {
-  //       feeConfig.setFee({
-  //         type: uiConfigStore.lastFeeOption,
-  //         currency: feeConfig.selectableFeeCurrencies[0],
-  //       });
-  //     } else {
-  //       feeConfig.setFee({
-  //         type: "average",
-  //         currency: feeConfig.selectableFeeCurrencies[0],
-  //       });
-  //     }
-  //   }
-  // }, [
-  //   disableAutomaticFeeSet,
-  //   feeConfig,
-  //   feeConfig.fees,
-  //   feeConfig.selectableFeeCurrencies,
-  //   uiConfigStore.lastFeeOption,
-  //   uiConfigStore.rememberLastFeeOption,
-  // ]);
-};
 
 export const FeeControl: FunctionComponent<{
   senderConfig: ISenderConfig;
@@ -81,16 +41,10 @@ export const FeeControl: FunctionComponent<{
     disableAutomaticFeeSet,
     disableClick,
   }) => {
-    const { analyticsStore, priceStore, uiConfigStore } = useStore();
+    const { analyticsStore, priceStore } = useStore();
 
     const intl = useIntl();
     const theme = useTheme();
-
-    useFeeOptionSelectionOnInit(
-      uiConfigStore,
-      feeConfig,
-      disableAutomaticFeeSet
-    );
 
     const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -360,7 +314,3 @@ export const FeeControl: FunctionComponent<{
     );
   }
 );
-
-// const noop = (..._args: any[]) => {
-//   // noop
-// };

--- a/apps/extension/src/pages/bitcoin/send/index.tsx
+++ b/apps/extension/src/pages/bitcoin/send/index.tsx
@@ -269,6 +269,10 @@ export const BitcoinSendPage: FunctionComponent = observer(() => {
         const isSendMax = sendConfigs.amountConfig.fraction === 1;
 
         // Prepare BIP32 derivation data based on payment type
+        // hardware wallet을 사용할 때 참고용.
+        // 내부적으로 send 요청을 처리할 때 mnemonic이나 private key를 사용하는 경우에는 사실상 필요가 없다.
+        // 왜냐하면 내부적으로 처리하는 경우에는 주소만으로 서명할 입력을 매칭할 수 있기 때문이다.
+        // 다만 psbt validation할 때는 mnemonic을 사용해 hd키를 생성할 수 있는 경우가 있기 때문에 필요하다.
         const { bip32Derivation, tapBip32Derivation } = (() => {
           if (
             !bitcoinAddress?.masterFingerprintHex ||

--- a/apps/extension/src/pages/bitcoin/sign/tx/view.tsx
+++ b/apps/extension/src/pages/bitcoin/sign/tx/view.tsx
@@ -332,7 +332,11 @@ export const SignBitcoinTxView: FunctionComponent<{
 
       const psbtSignData: {
         psbtHex: string;
-        inputsToSign: number[];
+        inputsToSign: {
+          index: number;
+          address: string;
+          path?: string;
+        }[];
       }[] = [];
 
       for (const psbt of validatedPsbts) {

--- a/apps/extension/src/pages/bitcoin/sign/tx/view.tsx
+++ b/apps/extension/src/pages/bitcoin/sign/tx/view.tsx
@@ -33,7 +33,7 @@ import { ViewDataButton } from "../../../sign/components/view-data-button";
 import { useNavigate } from "react-router";
 import { ApproveIcon, CancelIcon } from "../../../../components/button";
 import { FeeSummary } from "../../components/input/fee-summary";
-import { Psbt, Transaction } from "bitcoinjs-lib";
+import { Transaction } from "bitcoinjs-lib";
 import { CoinPretty, Dec } from "@keplr-wallet/unit";
 import { ChainImageFallback } from "../../../../components/image";
 import { Gutter } from "../../../../components/gutter";
@@ -565,18 +565,18 @@ const InternalSendBitcoinTxReview: FunctionComponent<{
 }> = observer(({ validatedPsbt, chainId }) => {
   const theme = useTheme();
   const { chainStore } = useStore();
-  const { psbt, sumInputAmountByAddress } = validatedPsbt ?? {};
+  const { psbt, sumInputValueByAddress } = validatedPsbt ?? {};
 
   const [isViewData, setIsViewData] = useState(false);
 
-  const sender = sumInputAmountByAddress?.[0].address;
+  const sender = sumInputValueByAddress?.[0].address;
   const recipient = psbt?.txOutputs.find(
     (output) => output.address !== sender
   )?.address;
   const sendToken = new CoinPretty(
     chainStore.getModularChainInfoImpl(chainId).getCurrencies("bitcoin")[0],
-    sumInputAmountByAddress?.reduce((acc, curr) => {
-      return acc.add(curr.amount);
+    sumInputValueByAddress?.reduce((acc, curr) => {
+      return acc.add(curr.value);
     }, new Dec(0)) ?? new Dec(0)
   );
 
@@ -810,7 +810,7 @@ const SinglePsbtView: FunctionComponent<{
 }> = observer(({ validatedPsbt, chainId }) => {
   const theme = useTheme();
   const { networkConfig } = useBitcoinNetworkConfig(chainId);
-  const { psbt, sumInputAmountByAddress } = validatedPsbt ?? {};
+  const { psbt, sumInputValueByAddress } = validatedPsbt ?? {};
 
   const [isViewData, setIsViewData] = useState(false);
 
@@ -887,8 +887,8 @@ const SinglePsbtView: FunctionComponent<{
                     : ColorPalette["gray-50"],
               }}
             >
-              {sumInputAmountByAddress && sumInputAmountByAddress.length > 1
-                ? `${sumInputAmountByAddress.length} Input(s)`
+              {sumInputValueByAddress && sumInputValueByAddress.length > 1
+                ? `${sumInputValueByAddress.length} Input(s)`
                 : `${psbt?.txOutputs.length ?? 0} Output(s)`}
             </H5>
           </XAxis>
@@ -947,11 +947,7 @@ const SinglePsbtView: FunctionComponent<{
 
 const PsbtsView: FunctionComponent<{
   chainId: string;
-  validatedPsbts: {
-    psbt: Psbt;
-    feeAmount: Dec;
-    warnings: string[];
-  }[];
+  validatedPsbts: ValidatedPsbt[];
 }> = observer(({ validatedPsbts, chainId }) => {
   const theme = useTheme();
   const { networkConfig } = useBitcoinNetworkConfig(chainId);

--- a/apps/extension/src/pages/bitcoin/sign/tx/view.tsx
+++ b/apps/extension/src/pages/bitcoin/sign/tx/view.tsx
@@ -261,13 +261,13 @@ export const SignBitcoinTxView: FunctionComponent<{
     }
   );
 
-  // 여러 주소 체계의 utxo를 조합하여 사용하는 경우가 있을 수 있으므로
-  // sender address의 balance를 체크하지 않는다.
+  // sendBitcoin 요청이 들어오는 경우를 제외하고는 balance를 체크하지 않는다.
+  // (여러 주소 체계의 utxo를 조합하여 사용하는 경우가 있을 수 있으므로)
   // 중요한 오류는 usePsbtsValidate 훅에서 처리한다.
-  feeConfig.setDisableBalanceCheck(true);
+  feeConfig.setDisableBalanceCheck(hasPsbtCandidate);
 
   const { isInitialized, validatedPsbts, criticalValidationError } =
-    usePsbtsValidate(interactionData, feeConfig, psbtSimulator);
+    usePsbtsValidate(interactionData, feeConfig, psbtSimulator.psbtHex);
 
   const [unmountPromise] = useState(() => {
     let resolver: () => void;
@@ -326,7 +326,8 @@ export const SignBitcoinTxView: FunctionComponent<{
         inputsToSign: {
           index: number;
           address: string;
-          path?: string;
+          hdPath?: string;
+          tapLeafHashesToSign?: Buffer[];
         }[];
       }[] = [];
 

--- a/packages/background/src/keyring-bitcoin/messages.ts
+++ b/packages/background/src/keyring-bitcoin/messages.ts
@@ -14,6 +14,8 @@ export class GetBitcoinKeyMsg extends Message<{
   address: string;
   paymentType: SupportedPaymentType;
   isNanoLedger: boolean;
+  masterFingerprintHex?: string;
+  derivationPath?: string;
 }> {
   public static type() {
     return "get-bitcoin-key";
@@ -49,6 +51,8 @@ export class GetBitcoinKeysSettledMsg extends Message<
     address: string;
     paymentType: SupportedPaymentType;
     isNanoLedger: boolean;
+    masterFingerprintHex?: string;
+    derivationPath?: string;
   }>
 > {
   public static type() {
@@ -94,6 +98,8 @@ export class GetBitcoinKeysForEachVaultSettledMsg extends Message<
       address: string;
       paymentType: SupportedPaymentType;
       isNanoLedger: boolean;
+      masterFingerprintHex?: string;
+      derivationPath?: string;
     } & {
       vaultId: string;
     }

--- a/packages/background/src/keyring-bitcoin/service.ts
+++ b/packages/background/src/keyring-bitcoin/service.ts
@@ -118,20 +118,7 @@ export class KeyRingBitcoinService {
 
     const network = this.getNetwork(chainId);
 
-    let address: string | undefined;
-
-    if (paymentType === "native-segwit") {
-      const nativeSegwitAddress = bitcoinPubKey.getNativeSegwitAddress(network);
-      if (nativeSegwitAddress) {
-        address = nativeSegwitAddress;
-      }
-    } else {
-      const taprootAddress = bitcoinPubKey.getTaprootAddress(network);
-      if (taprootAddress) {
-        address = taprootAddress;
-      }
-    }
-
+    const address = bitcoinPubKey.getBitcoinAddress(paymentType, network);
     if (!address) {
       throw new KeplrError("keyring", 221, "No payment address found");
     }

--- a/packages/background/src/keyring-bitcoin/service.ts
+++ b/packages/background/src/keyring-bitcoin/service.ts
@@ -108,18 +108,16 @@ export class KeyRingBitcoinService {
     }
 
     const { paymentType } = this.parseChainId(chainId);
-
-    // TODO: Ledger support
-    // const isLedger = vault.insensitive["keyRingType"] === "ledger";
+    const network = this.getNetwork(chainId);
 
     const bitcoinPubKey = await this.keyRingService.getPubKeyBitcoin(
       chainId,
-      vaultId
+      vaultId,
+      network
     );
 
-    const network = this.getNetwork(chainId);
+    const address = bitcoinPubKey.getBitcoinAddress(paymentType);
 
-    const address = bitcoinPubKey.getBitcoinAddress(paymentType, network);
     if (!address) {
       throw new KeplrError("keyring", 221, "No payment address found");
     }

--- a/packages/background/src/keyring-bitcoin/service.ts
+++ b/packages/background/src/keyring-bitcoin/service.ts
@@ -16,7 +16,7 @@ import {
   CHAIN_TYPE_TO_GENESIS_HASH,
 } from "@keplr-wallet/types";
 import { Env, KeplrError } from "@keplr-wallet/router";
-import { Psbt, payments, networks } from "bitcoinjs-lib";
+import { Psbt, payments } from "bitcoinjs-lib";
 import { encodeLegacyMessage, encodeLegacySignature } from "./helper";
 import { toXOnly } from "@keplr-wallet/crypto";
 import { BIP322 } from "./bip322";
@@ -25,6 +25,7 @@ import { BackgroundTxService } from "../tx";
 import validate, {
   Network as BitcoinNetwork,
 } from "bitcoin-address-validation";
+import { mainnet, signet, testnet } from "./constants";
 
 const DUST_THRESHOLD = 546;
 export class KeyRingBitcoinService {
@@ -430,11 +431,11 @@ export class KeyRingBitcoinService {
 
     switch (network) {
       case Network.MAINNET:
-        return networks.bitcoin;
+        return mainnet;
       case Network.TESTNET:
-        return networks.testnet;
+        return testnet;
       case Network.SIGNET:
-        return networks.testnet;
+        return signet;
     }
   }
 
@@ -730,7 +731,11 @@ export class KeyRingBitcoinService {
               async (res: {
                 psbtSignData: {
                   psbtHex: string;
-                  inputsToSign: number[];
+                  inputsToSign: {
+                    index: number;
+                    address: string;
+                    path?: string;
+                  }[];
                 }[];
                 signedPsbtsHexes: string[];
               }) => {
@@ -750,7 +755,8 @@ export class KeyRingBitcoinService {
                   currentChainId,
                   vaultId,
                   psbt,
-                  res.psbtSignData[0].inputsToSign
+                  res.psbtSignData[0].inputsToSign,
+                  network
                 );
 
                 return signedPsbt.toHex();

--- a/packages/background/src/keyring-bitcoin/service.ts
+++ b/packages/background/src/keyring-bitcoin/service.ts
@@ -201,7 +201,8 @@ export class KeyRingBitcoinService {
           inputsToSign: {
             index: number;
             address: string;
-            path?: string;
+            hdPath?: string;
+            tapLeafHashesToSign?: Buffer[];
           }[];
         }[];
         signedPsbtsHexes: string[];
@@ -264,7 +265,8 @@ export class KeyRingBitcoinService {
           inputsToSign: {
             index: number;
             address: string;
-            path?: string;
+            hdPath?: string;
+            tapLeafHashesToSign?: Buffer[];
           }[];
         }[];
         signedPsbtsHexes: string[];
@@ -734,7 +736,8 @@ export class KeyRingBitcoinService {
                   inputsToSign: {
                     index: number;
                     address: string;
-                    path?: string;
+                    hdPath?: string;
+                    tapLeafHashesToSign?: Buffer[];
                   }[];
                 }[];
                 signedPsbtsHexes: string[];

--- a/packages/background/src/keyring-bitcoin/service.ts
+++ b/packages/background/src/keyring-bitcoin/service.ts
@@ -111,11 +111,10 @@ export class KeyRingBitcoinService {
     // TODO: Ledger support
     // const isLedger = vault.insensitive["keyRingType"] === "ledger";
 
-    const pubKey = await this.keyRingService.getPubKeyBitcoin(chainId, vaultId);
-    const bitcoinPubKey =
-      typeof pubKey === "object" && "toBitcoinPubKey" in pubKey
-        ? pubKey.toBitcoinPubKey()
-        : pubKey;
+    const bitcoinPubKey = await this.keyRingService.getPubKeyBitcoin(
+      chainId,
+      vaultId
+    );
 
     const network = this.getNetwork(chainId);
 

--- a/packages/background/src/keyring-bitcoin/service.ts
+++ b/packages/background/src/keyring-bitcoin/service.ts
@@ -210,7 +210,11 @@ export class KeyRingBitcoinService {
       async (res: {
         psbtSignData: {
           psbtHex: string;
-          inputsToSign: number[];
+          inputsToSign: {
+            index: number;
+            address: string;
+            path?: string;
+          }[];
         }[];
         signedPsbtsHexes: string[];
       }) => {
@@ -224,7 +228,8 @@ export class KeyRingBitcoinService {
               chainId,
               vaultId,
               Psbt.fromHex(psbtSignData.psbtHex),
-              psbtSignData.inputsToSign
+              psbtSignData.inputsToSign,
+              network
             )
           )
         );
@@ -268,7 +273,11 @@ export class KeyRingBitcoinService {
       async (res: {
         psbtSignData: {
           psbtHex: string;
-          inputsToSign: number[];
+          inputsToSign: {
+            index: number;
+            address: string;
+            path?: string;
+          }[];
         }[];
         signedPsbtsHexes: string[];
       }) => {
@@ -286,7 +295,8 @@ export class KeyRingBitcoinService {
           chainId,
           vaultId,
           psbt,
-          res.psbtSignData[0].inputsToSign
+          res.psbtSignData[0].inputsToSign,
+          network
         );
 
         return signedPsbt.toHex();
@@ -392,7 +402,12 @@ export class KeyRingBitcoinService {
           chainId,
           vaultId,
           txToSign,
-          Array.from({ length: txToSign.data.inputs.length }, (_, i) => i)
+          Array.from({ length: txToSign.data.inputs.length }, (_, i) => ({
+            index: i,
+            address: bitcoinPubKey.address,
+            path: bitcoinPubKey.derivationPath,
+          })),
+          network
         );
 
         return BIP322.encodeWitness(signedPsbt);

--- a/packages/background/src/keyring-cosmos/service.ts
+++ b/packages/background/src/keyring-cosmos/service.ts
@@ -1,5 +1,5 @@
 import { ChainsService } from "../chains";
-import { KeyRingService } from "../keyring";
+import { KeyRingService, DEFAULT_BIP44_PURPOSE } from "../keyring";
 import {
   AminoSignResponse,
   ChainInfo,
@@ -170,6 +170,7 @@ export class KeyRingCosmosService {
         pubKey = await this.keyRingService.getPubKeyWithNotFinalizedCoinType(
           chainId,
           vaultId,
+          DEFAULT_BIP44_PURPOSE,
           coinType
         );
       } catch (e) {

--- a/packages/background/src/keyring-keystone/service.ts
+++ b/packages/background/src/keyring-keystone/service.ts
@@ -38,15 +38,17 @@ export class KeyRingKeystoneService {
     });
   }
 
-  getPubKey(vault: Vault, coinType: number): PubKeySecp256k1 {
+  getPubKey(vault: Vault, purpose: number, coinType: number): PubKeySecp256k1 {
     let bytes;
     if (vault.insensitive["keys"]) {
       const path = Object.keys(vault.insensitive["keys"]).find((path) => {
         const result = KeyRingService.parseBIP44Path(path);
-        return result.coinType === coinType;
+        return result.purpose === purpose && result.coinType === coinType;
       });
       if (!path) {
-        throw new Error(`CoinType ${coinType} is not supported.`);
+        throw new Error(
+          `Purpose ${purpose} and CoinType ${coinType} is not supported.`
+        );
       }
       bytes = Buffer.from(
         ((vault.insensitive["keys"] as PlainObject)[path] as PlainObject)[

--- a/packages/background/src/keyring-ledger/service.ts
+++ b/packages/background/src/keyring-ledger/service.ts
@@ -39,6 +39,7 @@ export class KeyRingLedgerService {
 
   getPubKey(
     vault: Vault,
+    _purpose: number,
     _coinType: number,
     modularChainInfo: ModularChainInfo
   ): PubKeySecp256k1 {

--- a/packages/background/src/keyring-mnemonic/service.ts
+++ b/packages/background/src/keyring-mnemonic/service.ts
@@ -162,7 +162,8 @@ export class KeyRingMnemonicService {
     inputsToSign: {
       index: number;
       address: string;
-      path?: string;
+      hdPath?: string;
+      tapLeafHashesToSign?: NodeBuffer[];
     }[]
   ): Promise<Psbt> {
     const bitcoinPubkey = this.getPrivKey(
@@ -174,7 +175,7 @@ export class KeyRingMnemonicService {
     const masterSeed = this.getMasterSeedFromVault(vault);
 
     // Must consider partially signed psbt.
-    for (const { index, path } of inputsToSign) {
+    for (const { index, hdPath } of inputsToSign) {
       const input = psbt.data.inputs[index];
 
       const privKey = this.findSignerForInput(
@@ -182,7 +183,7 @@ export class KeyRingMnemonicService {
         index,
         masterSeed,
         masterFingerprint,
-        path
+        hdPath
       );
       if (!privKey) {
         throw new Error(`No signer found for input ${index}`);

--- a/packages/background/src/keyring-private-key/service.ts
+++ b/packages/background/src/keyring-private-key/service.ts
@@ -7,7 +7,7 @@ import {
   PubKeySecp256k1,
   toXOnly,
 } from "@keplr-wallet/crypto";
-import { Psbt, payments, Network as BitcoinJSNetwork } from "bitcoinjs-lib";
+import { Psbt, payments, Network as BitcoinNetwork } from "bitcoinjs-lib";
 import { taggedHash } from "bitcoinjs-lib/src/crypto";
 
 export class KeyRingPrivateKeyService {
@@ -100,7 +100,7 @@ export class KeyRingPrivateKeyService {
       hdPath?: string;
       tapLeafHashesToSign?: NodeBuffer[];
     }[],
-    network: BitcoinJSNetwork
+    network: BitcoinNetwork
   ): Promise<Psbt> {
     const privateKeyText = this.vaultService.decrypt(vault.sensitive)[
       "privateKey"

--- a/packages/background/src/keyring-private-key/service.ts
+++ b/packages/background/src/keyring-private-key/service.ts
@@ -97,7 +97,8 @@ export class KeyRingPrivateKeyService {
     inputsToSign: {
       index: number;
       address: string;
-      path?: string;
+      hdPath?: string;
+      tapLeafHashesToSign?: NodeBuffer[];
     }[],
     network: BitcoinJSNetwork
   ): Promise<Psbt> {

--- a/packages/background/src/keyring-private-key/service.ts
+++ b/packages/background/src/keyring-private-key/service.ts
@@ -54,6 +54,7 @@ export class KeyRingPrivateKeyService {
 
   sign(
     vault: Vault,
+    _purpose: number,
     _coinType: number,
     data: Uint8Array,
     digestMethod: "sha256" | "keccak256" | "hash256" | "noop"

--- a/packages/background/src/keyring-private-key/service.ts
+++ b/packages/background/src/keyring-private-key/service.ts
@@ -107,8 +107,11 @@ export class KeyRingPrivateKeyService {
     const privateKey = new PrivKeySecp256k1(Buffer.from(privateKeyText, "hex"));
     const bitcoinPubkey = privateKey.getBitcoinPubKey();
 
-    const nativeSegwitAddress = bitcoinPubkey.getNativeSegwitAddress(network);
-    const taprootAddress = bitcoinPubkey.getTaprootAddress(network);
+    const nativeSegwitAddress = bitcoinPubkey.getBitcoinAddress(
+      "native-segwit",
+      network
+    );
+    const taprootAddress = bitcoinPubkey.getBitcoinAddress("taproot", network);
 
     // private key를 사용하는 경우는 HD키 파생이 불가능하므로,
     // derivation path를 별도로 검증하지 않고 주소가 일치하는 경우에만 서명할 수 있도록 한다.
@@ -140,8 +143,6 @@ export class KeyRingPrivateKeyService {
       }
       return false;
     };
-
-    console.log(nativeSegwitAddress, taprootAddress, inputsToSign);
 
     // Must consider partially signed psbt.
     // If the input is already signed, skip signing. (in case input index is not in inputsToSign)

--- a/packages/background/src/keyring-starknet/service.ts
+++ b/packages/background/src/keyring-starknet/service.ts
@@ -1,6 +1,6 @@
 import { Env } from "@keplr-wallet/router";
 import { ChainsService } from "../chains";
-import { KeyRingService } from "../keyring";
+import { KeyRingService, DEFAULT_BIP44_PURPOSE } from "../keyring";
 import { Buffer } from "buffer/";
 import { TokenERC20Service } from "../token-erc20";
 import { WatchAssetParameters } from "@keplr-wallet/types";
@@ -190,6 +190,7 @@ export class KeyRingStarknetService {
       } else {
         const sig = await this.keyRingService.signWithVault(
           vault,
+          DEFAULT_BIP44_PURPOSE,
           9004,
           Buffer.from("starknet_key_salt"),
           "sha256",

--- a/packages/background/src/keyring/constants.ts
+++ b/packages/background/src/keyring/constants.ts
@@ -1,1 +1,2 @@
 export const ROUTE = "keyring-v2";
+export const DEFAULT_BIP44_PURPOSE = 44;

--- a/packages/background/src/keyring/index.ts
+++ b/packages/background/src/keyring/index.ts
@@ -1,4 +1,5 @@
 export * from "./types";
 export * from "./messages";
 export * from "./service";
+export * from "./constants";
 export * as KeyRingLegacy from "./legacy";

--- a/packages/background/src/keyring/service.ts
+++ b/packages/background/src/keyring/service.ts
@@ -25,7 +25,7 @@ import { MultiAccounts } from "../keyring-keystone";
 import { AnalyticsService } from "../analytics";
 import { Primitive } from "utility-types";
 import { runIfOnlyAppStart } from "../utils";
-import { Network as BitcoinJSNetwork, Psbt } from "bitcoinjs-lib";
+import { Network as BitcoinNetwork, Psbt } from "bitcoinjs-lib";
 import { DEFAULT_BIP44_PURPOSE } from "./constants";
 import { Buffer as NodeBuffer } from "buffer";
 
@@ -1290,7 +1290,7 @@ export class KeyRingService {
       hdPath?: string;
       tapLeafHashesToSign?: NodeBuffer[];
     }[],
-    network: BitcoinJSNetwork
+    network: BitcoinNetwork
   ) {
     if (this.vaultService.isLocked) {
       throw new Error("KeyRing is locked");
@@ -1434,7 +1434,7 @@ export class KeyRingService {
       hdPath?: string;
       tapLeafHashesToSign?: NodeBuffer[];
     }[],
-    network: BitcoinJSNetwork,
+    network: BitcoinNetwork,
     modularChainInfo: ModularChainInfo
   ) {
     if (this.vaultService.isLocked) {

--- a/packages/background/src/keyring/service.ts
+++ b/packages/background/src/keyring/service.ts
@@ -1105,7 +1105,8 @@ export class KeyRingService {
 
   getPubKeyBitcoin(
     chainId: string,
-    vaultId: string
+    vaultId: string,
+    network: BitcoinNetwork
   ): Promise<PubKeyBitcoinCompatible> {
     if (this.vaultService.isLocked) {
       throw new Error("KeyRing is locked");
@@ -1146,6 +1147,7 @@ export class KeyRingService {
       vault,
       purpose,
       coinType,
+      network,
       modularChainInfo
     );
   }
@@ -1374,6 +1376,7 @@ export class KeyRingService {
     vault: Vault,
     purpose: number,
     coinType: number,
+    network: BitcoinNetwork,
     modularChainInfo: ModularChainInfo
   ): Promise<PubKeyBitcoinCompatible> {
     if (this.vaultService.isLocked) {
@@ -1383,15 +1386,19 @@ export class KeyRingService {
     const keyRing = this.getVaultKeyRing(vault);
 
     if (typeof keyRing.getPubKeyBitcoin !== "function") {
+      console.log("getPubKeyBitcoin using getPubKey");
+
       return Promise.resolve(
         (async () =>
           (
             await keyRing.getPubKey(vault, purpose, coinType, modularChainInfo)
-          ).toBitcoinPubKey())()
+          ).toBitcoinPubKey(network))()
       );
     }
 
-    return Promise.resolve(keyRing.getPubKeyBitcoin(vault, purpose, coinType));
+    return Promise.resolve(
+      keyRing.getPubKeyBitcoin(vault, purpose, coinType, network)
+    );
   }
   signWithVault(
     vault: Vault,

--- a/packages/background/src/keyring/service.ts
+++ b/packages/background/src/keyring/service.ts
@@ -27,6 +27,7 @@ import { Primitive } from "utility-types";
 import { runIfOnlyAppStart } from "../utils";
 import { Network as BitcoinJSNetwork, Psbt } from "bitcoinjs-lib";
 import { DEFAULT_BIP44_PURPOSE } from "./constants";
+import { Buffer as NodeBuffer } from "buffer";
 
 export class KeyRingService {
   protected _needMigration = false;
@@ -1286,7 +1287,8 @@ export class KeyRingService {
     inputsToSign: {
       index: number;
       address: string;
-      path?: string;
+      hdPath?: string;
+      tapLeafHashesToSign?: NodeBuffer[];
     }[],
     network: BitcoinJSNetwork
   ) {
@@ -1429,7 +1431,8 @@ export class KeyRingService {
     inputsToSign: {
       index: number;
       address: string;
-      path?: string;
+      hdPath?: string;
+      tapLeafHashesToSign?: NodeBuffer[];
     }[],
     network: BitcoinJSNetwork,
     modularChainInfo: ModularChainInfo

--- a/packages/background/src/keyring/service.ts
+++ b/packages/background/src/keyring/service.ts
@@ -1105,7 +1105,7 @@ export class KeyRingService {
   getPubKeyBitcoin(
     chainId: string,
     vaultId: string
-  ): Promise<PubKeyBitcoinCompatible | PubKeySecp256k1> {
+  ): Promise<PubKeyBitcoinCompatible> {
     if (this.vaultService.isLocked) {
       throw new Error("KeyRing is locked");
     }
@@ -1359,7 +1359,7 @@ export class KeyRingService {
     purpose: number,
     coinType: number,
     modularChainInfo: ModularChainInfo
-  ): Promise<PubKeyBitcoinCompatible | PubKeySecp256k1> {
+  ): Promise<PubKeyBitcoinCompatible> {
     if (this.vaultService.isLocked) {
       throw new Error("KeyRing is locked");
     }
@@ -1368,7 +1368,10 @@ export class KeyRingService {
 
     if (typeof keyRing.getPubKeyBitcoin !== "function") {
       return Promise.resolve(
-        keyRing.getPubKey(vault, purpose, coinType, modularChainInfo)
+        (async () =>
+          (
+            await keyRing.getPubKey(vault, purpose, coinType, modularChainInfo)
+          ).toBitcoinPubKey())()
       );
     }
 

--- a/packages/background/src/keyring/types.ts
+++ b/packages/background/src/keyring/types.ts
@@ -5,7 +5,7 @@ import {
   PubKeyStarknet,
 } from "@keplr-wallet/crypto";
 import { ModularChainInfo } from "@keplr-wallet/types";
-import { Psbt } from "bitcoinjs-lib";
+import { Psbt, Network as BitcoinJSNetwork } from "bitcoinjs-lib";
 
 export type KeyRingStatus = "empty" | "locked" | "unlocked";
 
@@ -65,9 +65,15 @@ export interface KeyRing {
       }>;
   signPsbt?(
     vault: Vault,
+    purpose: number,
     coinType: number,
     psbt: Psbt,
-    inputsToSign: number[],
+    inputsToSign: {
+      index: number;
+      address: string;
+      path?: string;
+    }[],
+    network: BitcoinJSNetwork,
     modularChainInfo: ModularChainInfo
   ): Promise<Psbt>;
 }

--- a/packages/background/src/keyring/types.ts
+++ b/packages/background/src/keyring/types.ts
@@ -71,7 +71,8 @@ export interface KeyRing {
     inputsToSign: {
       index: number;
       address: string;
-      path?: string;
+      hdPath?: string;
+      tapLeafHashesToSign?: Buffer[];
     }[],
     network: BitcoinJSNetwork,
     modularChainInfo: ModularChainInfo

--- a/packages/background/src/keyring/types.ts
+++ b/packages/background/src/keyring/types.ts
@@ -43,7 +43,8 @@ export interface KeyRing {
   getPubKeyBitcoin?(
     vault: Vault,
     purpose: number,
-    coinType: number
+    coinType: number,
+    network: BitcoinNetwork
   ): PubKeyBitcoinCompatible | Promise<PubKeyBitcoinCompatible>;
   sign(
     vault: Vault,

--- a/packages/background/src/keyring/types.ts
+++ b/packages/background/src/keyring/types.ts
@@ -27,6 +27,7 @@ export interface KeyRing {
   }>;
   getPubKey(
     vault: Vault,
+    purpose: number,
     coinType: number,
     modularChainInfo: ModularChainInfo
   ): PubKeySecp256k1 | Promise<PubKeySecp256k1>;
@@ -37,6 +38,7 @@ export interface KeyRing {
   ): PubKeyStarknet | Promise<PubKeyStarknet>;
   sign(
     vault: Vault,
+    purpose: number,
     coinType: number,
     data: Uint8Array,
     digestMethod: "sha256" | "keccak256" | "hash256" | "noop",

--- a/packages/background/src/keyring/types.ts
+++ b/packages/background/src/keyring/types.ts
@@ -1,5 +1,9 @@
 import { PlainObject, Vault } from "../vault";
-import { PubKeySecp256k1, PubKeyStarknet } from "@keplr-wallet/crypto";
+import {
+  PubKeyBitcoinCompatible,
+  PubKeySecp256k1,
+  PubKeyStarknet,
+} from "@keplr-wallet/crypto";
 import { ModularChainInfo } from "@keplr-wallet/types";
 import { Psbt } from "bitcoinjs-lib";
 
@@ -36,6 +40,11 @@ export interface KeyRing {
     vault: Vault,
     modularChainInfo: ModularChainInfo
   ): PubKeyStarknet | Promise<PubKeyStarknet>;
+  getPubKeyBitcoin?(
+    vault: Vault,
+    purpose: number,
+    coinType: number
+  ): PubKeyBitcoinCompatible | Promise<PubKeyBitcoinCompatible>;
   sign(
     vault: Vault,
     purpose: number,

--- a/packages/background/src/keyring/types.ts
+++ b/packages/background/src/keyring/types.ts
@@ -5,7 +5,7 @@ import {
   PubKeyStarknet,
 } from "@keplr-wallet/crypto";
 import { ModularChainInfo } from "@keplr-wallet/types";
-import { Psbt, Network as BitcoinJSNetwork } from "bitcoinjs-lib";
+import { Psbt, Network as BitcoinNetwork } from "bitcoinjs-lib";
 
 export type KeyRingStatus = "empty" | "locked" | "unlocked";
 
@@ -74,7 +74,7 @@ export interface KeyRing {
       hdPath?: string;
       tapLeafHashesToSign?: Buffer[];
     }[],
-    network: BitcoinJSNetwork,
+    network: BitcoinNetwork,
     modularChainInfo: ModularChainInfo
   ): Promise<Psbt>;
 }

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -18,9 +18,9 @@
   "dependencies": {
     "@noble/curves": "^1.4.2",
     "@noble/hashes": "^1.4.0",
-    "bip32": "^2.0.6",
-    "bip39": "^3.0.3",
-    "bs58check": "^2.1.2",
+    "bip32": "^4.0.0",
+    "bip39": "^3.1.0",
+    "bs58check": "^4.0.0",
     "buffer": "^6.0.3",
     "ecpair": "^2.1.0"
   },

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -18,9 +18,9 @@
   "dependencies": {
     "@noble/curves": "^1.4.2",
     "@noble/hashes": "^1.4.0",
-    "bip32": "^4.0.0",
-    "bip39": "^3.1.0",
-    "bs58check": "^4.0.0",
+    "bip32": "^2.0.6",
+    "bip39": "^3.0.3",
+    "bs58check": "^2.1.2",
     "buffer": "^6.0.3",
     "ecpair": "^2.1.0"
   },

--- a/packages/crypto/src/ecc-adapter.ts
+++ b/packages/crypto/src/ecc-adapter.ts
@@ -207,6 +207,22 @@ export function pointCompress(p: Uint8Array, compressed?: boolean): Uint8Array {
   return fromHex(p).toRawBytes(assumeCompression(compressed, p));
 }
 
+export function pointAddScalar(
+  p: Uint8Array,
+  tweak: Uint8Array,
+  compressed?: boolean
+): Uint8Array | null {
+  if (!isPoint(p)) {
+    throw new Error(THROW_BAD_POINT);
+  }
+  if (!isTweak(tweak)) {
+    throw new Error(THROW_BAD_TWEAK);
+  }
+  return throwToNull(() =>
+    _pointAddScalar(p, tweak, assumeCompression(compressed, p))
+  );
+}
+
 export function privateAdd(
   d: Uint8Array,
   tweak: Uint8Array

--- a/packages/crypto/src/key.spec.ts
+++ b/packages/crypto/src/key.spec.ts
@@ -195,8 +195,6 @@ describe("Test priv key", () => {
       Mnemonic.generateWalletFromMnemonic(mnemonic)
     );
 
-    const dogecoinPubKey = privKey.getBitcoinPubKey();
-
     const dogecoinMainnet = {
       messagePrefix: "\x19Dogecoin Signed Message:\n",
       bech32: "doge",
@@ -209,10 +207,9 @@ describe("Test priv key", () => {
       wif: 0x9e, // 158
     };
 
-    const legacyAddress = dogecoinPubKey.getBitcoinAddress(
-      "legacy",
-      dogecoinMainnet
-    );
+    const dogecoinPubKey = privKey.getBitcoinPubKey(dogecoinMainnet);
+
+    const legacyAddress = dogecoinPubKey.getBitcoinAddress("legacy");
 
     expect(legacyAddress).not.toBeUndefined();
     expect(legacyAddress?.startsWith("D")).toBe(true);

--- a/packages/crypto/src/key.spec.ts
+++ b/packages/crypto/src/key.spec.ts
@@ -135,25 +135,32 @@ describe("Test priv key", () => {
   it("test bitcoin address", () => {
     const mnemonic =
       "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    const path = `m/44'/118'/0'/0/0`;
 
-    const privKey = new PrivKeySecp256k1(
-      Mnemonic.generateWalletFromMnemonic(mnemonic)
-    );
+    const { privateKey, masterFingerprint } =
+      Mnemonic.generatePrivateKeyFromMasterSeed(
+        Mnemonic.generateMasterSeedFromMnemonic(mnemonic),
+        path
+      );
+
+    const privKey = new PrivKeySecp256k1(privateKey, masterFingerprint, path);
 
     const bitcoinPubKey = privKey.getBitcoinPubKey();
 
-    const legacyAddressUncompressed = bitcoinPubKey.getLegacyAddress(true);
+    expect(bitcoinPubKey.getMasterFingerprint()).not.toBeUndefined();
+    expect(bitcoinPubKey.getMasterFingerprint()).toBe(masterFingerprint);
 
-    expect(legacyAddressUncompressed).not.toBeUndefined();
-    expect(legacyAddressUncompressed?.startsWith("1")).toBe(true);
-    expect(legacyAddressUncompressed).toBe("1z5bFTcS7zfCHHKk3kXjvBNr6hMMNQYjh");
-    const legacyAddressCompressed = bitcoinPubKey.getLegacyAddress(false);
+    expect(bitcoinPubKey.getPath()).not.toBeUndefined();
+    expect(bitcoinPubKey.getPath()).toBe(path);
 
-    expect(legacyAddressCompressed).not.toBeUndefined();
-    expect(legacyAddressCompressed?.startsWith("1")).toBe(true);
-    expect(legacyAddressCompressed).toBe("14jmwUEdEZ7Bn3ksbhceZryVdkbbdSCsMU");
+    const legacyAddress = bitcoinPubKey.getBitcoinAddress("legacy");
 
-    const nativeSegwitAddress = bitcoinPubKey.getNativeSegwitAddress();
+    expect(legacyAddress).not.toBeUndefined();
+    expect(legacyAddress?.startsWith("1")).toBe(true);
+    expect(legacyAddress).toBe("14jmwUEdEZ7Bn3ksbhceZryVdkbbdSCsMU");
+
+    const nativeSegwitAddress =
+      bitcoinPubKey.getBitcoinAddress("native-segwit");
 
     expect(nativeSegwitAddress).not.toBeUndefined();
     expect(nativeSegwitAddress?.startsWith("bc1q")).toBe(true);
@@ -161,13 +168,23 @@ describe("Test priv key", () => {
       "bc1q9rl4cm2hmr8afy4kldpxz3fka4jguq0a26nkmc"
     );
 
-    const taprootAddress = bitcoinPubKey.getTaprootAddress();
+    const taprootAddress = bitcoinPubKey.getBitcoinAddress("taproot");
 
     expect(taprootAddress).not.toBeUndefined();
     expect(taprootAddress?.startsWith("bc1p")).toBe(true);
     expect(taprootAddress).toBe(
       "bc1ps0m23ua63lejktfq0vf9dp603q4h7l4tkcc4n644uph5ccjkjs8suu99pl"
     );
+
+    const defaultAddress = bitcoinPubKey.getBitcoinAddress(); // 44 for legacy
+
+    expect(defaultAddress).not.toBeUndefined();
+    expect(defaultAddress?.startsWith("1")).toBe(true);
+    expect(defaultAddress).toBe("14jmwUEdEZ7Bn3ksbhceZryVdkbbdSCsMU");
+
+    const noDefaultAddressPubKey = privKey.getPubKey().toBitcoinPubKey();
+
+    expect(noDefaultAddressPubKey.getBitcoinAddress()).toBeUndefined();
   });
 
   it("test dogecoin address", () => {
@@ -192,24 +209,13 @@ describe("Test priv key", () => {
       wif: 0x9e, // 158
     };
 
-    const legacyAddressUncompressed = dogecoinPubKey.getLegacyAddress(
-      true,
+    const legacyAddress = dogecoinPubKey.getBitcoinAddress(
+      "legacy",
       dogecoinMainnet
     );
 
-    expect(legacyAddressUncompressed).not.toBeUndefined();
-    expect(legacyAddressUncompressed?.startsWith("D")).toBe(true);
-    expect(legacyAddressUncompressed).toBe(
-      "D68B8WQFjXtwjHTvUdk6HgLyjERecjVEYX"
-    );
-
-    const legacyAddressCompressed = dogecoinPubKey.getLegacyAddress(
-      false,
-      dogecoinMainnet
-    );
-
-    expect(legacyAddressCompressed).not.toBeUndefined();
-    expect(legacyAddressCompressed?.startsWith("D")).toBe(true);
-    expect(legacyAddressCompressed).toBe("D8ssUjBGXy1UK3wULHcD7d96WtKtus5My3");
+    expect(legacyAddress).not.toBeUndefined();
+    expect(legacyAddress?.startsWith("D")).toBe(true);
+    expect(legacyAddress).toBe("D8ssUjBGXy1UK3wULHcD7d96WtKtus5My3");
   });
 });

--- a/packages/crypto/src/key.ts
+++ b/packages/crypto/src/key.ts
@@ -17,7 +17,11 @@ export class PrivKeySecp256k1 {
     return new PrivKeySecp256k1(secp256k1.utils.randomPrivateKey());
   }
 
-  constructor(protected readonly privKey: Uint8Array) {}
+  constructor(
+    protected readonly privKey: Uint8Array,
+    protected readonly masterFingerprint?: string,
+    protected readonly path?: string
+  ) {}
 
   toBytes(): Uint8Array {
     return new Uint8Array(this.privKey);
@@ -33,7 +37,12 @@ export class PrivKeySecp256k1 {
 
   getBitcoinPubKey(): PubKeyBitcoinCompatible {
     const pubKey = secp256k1.getPublicKey(this.toBytes(), false);
-    return new PubKeyBitcoinCompatible(pubKey);
+
+    return new PubKeyBitcoinCompatible(
+      pubKey,
+      this.masterFingerprint,
+      this.path
+    );
   }
 
   signDigest32(digest: Uint8Array): {
@@ -232,6 +241,22 @@ export class PubKeySecp256k1 {
 }
 
 export class PubKeyBitcoinCompatible extends PubKeySecp256k1 {
+  constructor(
+    protected override readonly pubKey: Uint8Array,
+    protected readonly masterFingerprint?: string,
+    protected readonly path?: string
+  ) {
+    super(pubKey);
+  }
+
+  getMasterFingerprint(): string | undefined {
+    return this.masterFingerprint;
+  }
+
+  getPath(): string | undefined {
+    return this.path;
+  }
+
   /**
    * returns the legacy address of the public key compatible with Bitcoin.
    * both compressed and uncompressed are supported.

--- a/packages/crypto/src/key.ts
+++ b/packages/crypto/src/key.ts
@@ -7,7 +7,7 @@ import { Buffer as NodeBuffer } from "buffer";
 import { Hash } from "./hash";
 import { hash as starknetHash } from "starknet";
 import { ECPairInterface, ECPairFactory } from "ecpair";
-import { Network as BitcoinJSNetwork, payments } from "bitcoinjs-lib";
+import { Network as BitcoinNetwork, payments } from "bitcoinjs-lib";
 import * as ecc from "./ecc-adapter";
 import * as bitcoin from "bitcoinjs-lib";
 
@@ -276,7 +276,7 @@ export class PubKeyBitcoinCompatible {
 
   getBitcoinAddress(
     paymentType?: "legacy" | "native-segwit" | "taproot",
-    network?: BitcoinJSNetwork
+    network?: BitcoinNetwork
   ): string | undefined {
     const pubKey = this.toBytes(false);
 

--- a/packages/crypto/src/mnemonic.spec.ts
+++ b/packages/crypto/src/mnemonic.spec.ts
@@ -15,13 +15,15 @@ describe("Test gen key from mnemonic", () => {
     );
 
     const masterSeed = Mnemonic.generateMasterSeedFromMnemonic(mnemonic);
-    privKey = new PrivKeySecp256k1(
-      Mnemonic.generatePrivateKeyFromMasterSeed(masterSeed)
-    );
+    const { privateKey, masterFingerprint } =
+      Mnemonic.generatePrivateKeyFromMasterSeed(masterSeed);
+    privKey = new PrivKeySecp256k1(privateKey);
     pubKey = privKey.getPubKey();
+
     expect(Buffer.from(pubKey.toBytes()).toString("hex")).toBe(
       "02394bc53633366a2ab9b5d697a94c8c0121cc5e3f0d554a63167edb318ceae8bc"
     );
+    expect(masterFingerprint).toBe("a92e593f");
   });
 
   it("mnemonic should generate proper priv key 2", () => {
@@ -31,18 +33,24 @@ describe("Test gen key from mnemonic", () => {
     let privKey = new PrivKeySecp256k1(
       Mnemonic.generateWalletFromMnemonic(mnemonic, "m/44'/118'/1'/0/0")
     );
+
     let pubKey = privKey.getPubKey();
     expect(Buffer.from(pubKey.toBytes()).toString("hex")).toBe(
       "03270e75d7e43f57643cd661bc1a0a3b939b786bbcdec1b82b718fd628e947eec1"
     );
 
     const masterSeed = Mnemonic.generateMasterSeedFromMnemonic(mnemonic);
-    privKey = new PrivKeySecp256k1(
-      Mnemonic.generatePrivateKeyFromMasterSeed(masterSeed, "m/44'/118'/1'/0/0")
-    );
+    const { privateKey, masterFingerprint } =
+      Mnemonic.generatePrivateKeyFromMasterSeed(
+        masterSeed,
+        "m/44'/118'/1'/0/0"
+      );
+
+    privKey = new PrivKeySecp256k1(privateKey);
     pubKey = privKey.getPubKey();
     expect(Buffer.from(pubKey.toBytes()).toString("hex")).toBe(
       "03270e75d7e43f57643cd661bc1a0a3b939b786bbcdec1b82b718fd628e947eec1"
     );
+    expect(masterFingerprint).toBe("a92e593f");
   });
 });

--- a/packages/crypto/src/mnemonic.ts
+++ b/packages/crypto/src/mnemonic.ts
@@ -85,7 +85,10 @@ export class Mnemonic {
   static generatePrivateKeyFromMasterSeed(
     seed: Uint8Array,
     path: string = `m/44'/118'/0'/0/0`
-  ): Uint8Array {
+  ): {
+    privateKey: Uint8Array;
+    masterFingerprint: string;
+  } {
     const masterSeed = bip32Factory.fromBase58(bs58check.encode(seed));
     const hd = masterSeed.derivePath(path);
 
@@ -93,6 +96,9 @@ export class Mnemonic {
     if (!privateKey) {
       throw new Error("null hd key");
     }
-    return privateKey;
+    return {
+      privateKey,
+      masterFingerprint: masterSeed.fingerprint.toString("hex"),
+    };
   }
 }

--- a/packages/crypto/src/mnemonic.ts
+++ b/packages/crypto/src/mnemonic.ts
@@ -1,11 +1,10 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const bip39 = require("bip39");
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const bip32 = require("bip32");
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const bs58check = require("bs58check");
-
+import * as bip32 from "bip32";
+import * as bip39 from "bip39";
+import bs58check from "bs58check";
+import * as ecc from "./ecc-adapter";
 import { Buffer } from "buffer/";
+
+const bip32Factory = bip32.BIP32Factory(ecc);
 
 export type RNG = <
   T extends
@@ -63,7 +62,7 @@ export class Mnemonic {
     password: string = ""
   ): Uint8Array {
     const seed = bip39.mnemonicToSeedSync(mnemonic, password);
-    const masterSeed = bip32.fromSeed(seed);
+    const masterSeed = bip32Factory.fromSeed(seed);
     const hd = masterSeed.derivePath(path);
 
     const privateKey = hd.privateKey;
@@ -78,7 +77,7 @@ export class Mnemonic {
     password: string = ""
   ): Uint8Array {
     const seed = bip39.mnemonicToSeedSync(mnemonic, password);
-    const masterKey = bip32.fromSeed(seed);
+    const masterKey = bip32Factory.fromSeed(seed);
 
     return Buffer.from(bs58check.decode(masterKey.toBase58()));
   }
@@ -87,7 +86,7 @@ export class Mnemonic {
     seed: Uint8Array,
     path: string = `m/44'/118'/0'/0/0`
   ): Uint8Array {
-    const masterSeed = bip32.fromBase58(bs58check.encode(seed));
+    const masterSeed = bip32Factory.fromBase58(bs58check.encode(seed));
     const hd = masterSeed.derivePath(path);
 
     const privateKey = hd.privateKey;

--- a/packages/crypto/src/mnemonic.ts
+++ b/packages/crypto/src/mnemonic.ts
@@ -1,10 +1,10 @@
-import * as bip32 from "bip32";
-import * as bip39 from "bip39";
-import bs58check from "bs58check";
-import * as ecc from "./ecc-adapter";
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const bip39 = require("bip39");
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const bip32 = require("bip32");
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const bs58check = require("bs58check");
 import { Buffer } from "buffer/";
-
-const bip32Factory = bip32.BIP32Factory(ecc);
 
 export type RNG = <
   T extends
@@ -62,7 +62,7 @@ export class Mnemonic {
     password: string = ""
   ): Uint8Array {
     const seed = bip39.mnemonicToSeedSync(mnemonic, password);
-    const masterSeed = bip32Factory.fromSeed(seed);
+    const masterSeed = bip32.fromSeed(seed);
     const hd = masterSeed.derivePath(path);
 
     const privateKey = hd.privateKey;
@@ -77,7 +77,7 @@ export class Mnemonic {
     password: string = ""
   ): Uint8Array {
     const seed = bip39.mnemonicToSeedSync(mnemonic, password);
-    const masterKey = bip32Factory.fromSeed(seed);
+    const masterKey = bip32.fromSeed(seed);
 
     return Buffer.from(bs58check.decode(masterKey.toBase58()));
   }
@@ -89,7 +89,7 @@ export class Mnemonic {
     privateKey: Uint8Array;
     masterFingerprint: string;
   } {
-    const masterSeed = bip32Factory.fromBase58(bs58check.encode(seed));
+    const masterSeed = bip32.fromBase58(bs58check.encode(seed));
     const hd = masterSeed.derivePath(path);
 
     const privateKey = hd.privateKey;

--- a/packages/hooks-bitcoin/src/tx/fee-rate.ts
+++ b/packages/hooks-bitcoin/src/tx/fee-rate.ts
@@ -4,6 +4,9 @@ import { ChainGetter } from "@keplr-wallet/stores";
 import { action, computed, makeObservable, observable } from "mobx";
 import { useState } from "react";
 import { BitcoinQueriesStore } from "@keplr-wallet/stores-bitcoin";
+
+const DEFAULT_MAXIMUM_FEE_RATE = 1000;
+
 export class FeeRateConfig extends TxChainSetter implements IFeeRateConfig {
   // average by default as initialFeeRate is not reliable at the first time
   @observable
@@ -73,7 +76,7 @@ export class FeeRateConfig extends TxChainSetter implements IFeeRateConfig {
         return 0;
       }
 
-      return num;
+      return Math.floor(num * 1000) / 1000;
     }
 
     const feeRate = this.queriesStore.get(this.chainId).queryBitcoinFeeEstimates
@@ -103,6 +106,12 @@ export class FeeRateConfig extends TxChainSetter implements IFeeRateConfig {
     if (Number.isNaN(parsed)) {
       return {
         error: new Error("Fee rate is not valid number"),
+      };
+    }
+
+    if (parsed > DEFAULT_MAXIMUM_FEE_RATE) {
+      return {
+        error: new Error("Maximum fee rate is 1000"),
       };
     }
 

--- a/packages/stores-bitcoin/src/account/base.ts
+++ b/packages/stores-bitcoin/src/account/base.ts
@@ -20,6 +20,8 @@ import {
   SelectUTXOsParams,
   SelectionResult,
   UTXOSelection,
+  IPsbtInput,
+  IPsbtOutput,
 } from "./types";
 import { BRANCH_AND_BOUND_TIMEOUT_MS, DUST_THRESHOLD } from "./constant";
 
@@ -52,9 +54,9 @@ export class BitcoinAccountBase {
    * Select UTXOs for transaction targets
    * @param senderAddress Address of the sender
    * @param utxos UTXOs associated with the sender's address (must be of the same payment type - p2wpkh, p2tr)
-   * @param recipients Recipients of the transaction with amount and address
+   * @param recipients Recipients of the transaction with value and address
    * @param feeRate Transaction fee rate in sat/vB
-   * @param isSendMax Whether to send max amount, do not calculate change output
+   * @param isSendMax Whether to send max value, do not calculate change output
    * @returns {selectedUtxos, txSize, hasChange} Selected UTXOs and transaction size, whether there is change output
    */
   selectUTXOs({
@@ -69,7 +71,7 @@ export class BitcoinAccountBase {
       throw new Error("Invalid parameters");
     }
 
-    // 2. Get network config
+    // 2. Get network config and validate addresses
     const [, genesisHash, paymentType] = this.chainId.split(":");
     const network = GENESIS_HASH_TO_NETWORK[genesisHash as GenesisHash];
     if (
@@ -79,10 +81,6 @@ export class BitcoinAccountBase {
       throw new Error("Invalid chain id");
     }
 
-    // 3. Sort UTXOs by descending order
-    const sortedUtxos = utxos.sort((a, b) => b.value - a.value);
-
-    // 4. Validate addresses
     const senderAddressInfo = this.validateAndGetAddressInfo(
       senderAddress,
       network as unknown as Network
@@ -100,23 +98,15 @@ export class BitcoinAccountBase {
       throw new Error("Invalid recipients");
     }
 
-    // 5. Calculate output parameters
-    const outputParams: Record<string, number> = {};
-    recipientAddressInfos.forEach((info) => {
-      const key = `${info.type}_output_count`;
-      outputParams[key] = (outputParams[key] || 0) + 1;
-    });
-
-    // 6. Calculate target amount
-    const targetAmount = recipients.reduce(
-      (sum, recipient) => sum.add(new Dec(recipient.amount)),
+    // 3. Calculate output parameters and target value
+    const outputParams = this.calculateOutputParams(recipientAddressInfos);
+    const targetValue = recipients.reduce(
+      (sum, recipient) => sum.add(new Dec(recipient.value)),
       new Dec(0)
     );
-
-    // 7. Initialize constants and helpers
     const DUST = new Dec(DUST_THRESHOLD);
 
-    // Helper functions
+    // 4. Setup helper functions
     const calculateTxSize = (
       inputCount: number,
       outputParams: Record<string, number>,
@@ -131,83 +121,32 @@ export class BitcoinAccountBase {
     };
 
     const calculateFee = (size: number) => new Dec(Math.ceil(size * feeRate));
+    const isDust = (value: Dec) => value.lt(DUST);
 
-    const isDust = (amount: Dec) => amount.lt(DUST);
-
-    // Helper to calculate tx configuration for a given set of UTXOs
-    const calculateTxConfig = (
-      selectedUtxoIds: Set<string>,
-      withChange: boolean
-    ) => {
-      const selectedCount = selectedUtxoIds.size;
-      const txSize = calculateTxSize(selectedCount, outputParams, withChange);
-      const fee = calculateFee(txSize.txVBytes);
-
-      const selectedAmount = utxos
-        .filter((utxo) => selectedUtxoIds.has(`${utxo.txid}:${utxo.vout}`))
-        .reduce((sum, utxo) => sum.add(new Dec(utxo.value)), new Dec(0));
-
-      const remainder = selectedAmount.sub(targetAmount).sub(fee);
-
-      return {
-        selectedUtxoIds,
-        selectedAmount,
-        txSize,
-        fee,
-        remainder,
-        hasChange: withChange && remainder.gte(DUST),
-      };
-    };
-
-    // 8. If send max is true, return all UTXOs and estimated fee
-    // This is for simulation of build psbt when amount fraction is 1
+    // 5. Handle send max case
     if (isSendMax) {
       const txSize = calculateTxSize(utxos.length, outputParams, false);
-
-      return {
-        selectedUtxos: utxos,
-        txSize,
-        hasChange: false,
-      };
+      return { selectedUtxos: utxos, txSize, hasChange: false };
     }
 
-    // 9. Check if a single UTXO can satisfy the transaction
-    // Try each UTXO in descending order of value
-    for (const utxo of sortedUtxos) {
-      const utxoId = `${utxo.txid}:${utxo.vout}`;
-      const singleUtxoIds = new Set([utxoId]);
-
-      // Calculate with change first
-      const withChangeConfig = calculateTxConfig(singleUtxoIds, true);
-
-      // If this UTXO can cover the target amount plus fee and has non-dust change
-      if (withChangeConfig.remainder.gte(DUST)) {
-        return {
-          selectedUtxos: [utxo],
-          txSize: withChangeConfig.txSize,
-          hasChange: true,
-        };
-      }
-
-      // If this UTXO can cover the target amount plus fee with no change (or dust change)
-      const withoutChangeConfig = calculateTxConfig(singleUtxoIds, false);
-      if (withoutChangeConfig.remainder.gte(new Dec(0))) {
-        return {
-          selectedUtxos: [utxo],
-          txSize: withoutChangeConfig.txSize,
-          hasChange: false,
-        };
-      }
-    }
-
-    let selectedUtxoIds: Set<string>;
-
-    // 10. Select UTXOs using branch and bound algorithm if no single UTXO is sufficient
-    // Always try to avoid dust change by setting discardDustChange to false
-    // This will make the algorithm prioritize selections that result in non-dust change
-    const branchAndBoundResult = this.branchAndBoundSelection({
+    // 6. Try single UTXO selection first
+    const sortedUtxos = utxos.sort((a, b) => b.value - a.value);
+    const singleUtxoResult = this.trySingleUtxoSelection({
       utxos: sortedUtxos,
-      targetAmount,
+      targetValue,
+      calculateTxSize,
+      calculateFee,
+      isDust,
+      outputParams,
+    });
+    if (singleUtxoResult) {
+      return singleUtxoResult;
+    }
+
+    // 7. Use branch and bound or greedy selection for multiple UTXOs
+    const selectedUtxoIds = this.selectMultipleUtxos({
+      utxos: sortedUtxos,
+      targetValue,
       calculateTxSize,
       calculateFee,
       isDust,
@@ -215,241 +154,313 @@ export class BitcoinAccountBase {
       timeoutMs: BRANCH_AND_BOUND_TIMEOUT_MS,
     });
 
-    if (!branchAndBoundResult) {
-      // If branch and bound algorithm fails, use greedy selection
-      // Also prioritize non-dust change
-      selectedUtxoIds = this.greedySelection({
-        utxos: sortedUtxos,
-        targetAmount,
-        calculateTxSize,
-        calculateFee,
-        isDust,
-        outputParams,
-      });
-    } else {
-      selectedUtxoIds = branchAndBoundResult;
-    }
-
-    // If no UTXOs are selected, return null
-    if (selectedUtxoIds.size === 0) {
+    if (!selectedUtxoIds || selectedUtxoIds.size === 0) {
       return null;
     }
 
-    // 11. Calculate final tx configuration
-    const withChangeConfig = calculateTxConfig(selectedUtxoIds, true);
+    // 8. Calculate final configuration
+    const selectedUtxos = utxos.filter((utxo) =>
+      selectedUtxoIds.has(`${utxo.txid}:${utxo.vout}`)
+    );
+    const txSize = calculateTxSize(selectedUtxos.length, outputParams, true);
+    const fee = calculateFee(txSize.txVBytes);
+    const totalValue = selectedUtxos.reduce(
+      (sum, utxo) => sum.add(new Dec(utxo.value)),
+      new Dec(0)
+    );
+    const remainder = totalValue.sub(targetValue).sub(fee);
+    const hasChange = remainder.gte(DUST);
 
-    // Only include change if it's above dust threshold
-    const hasChange = withChangeConfig.remainder.gte(DUST);
+    return { selectedUtxos, txSize, hasChange };
+  }
 
-    // Final calculations based on whether we have change
-    const finalConfig = calculateTxConfig(selectedUtxoIds, hasChange);
+  private calculateOutputParams(
+    addressInfos: AddressInfo[]
+  ): Record<string, number> {
+    const outputParams: Record<string, number> = {};
+    addressInfos.forEach((info) => {
+      const key = `${info.type}_output_count`;
+      outputParams[key] = (outputParams[key] || 0) + 1;
+    });
+    return outputParams;
+  }
 
-    // 12. Return the selection
-    return {
-      selectedUtxos: utxos.filter((utxo) =>
-        selectedUtxoIds.has(`${utxo.txid}:${utxo.vout}`)
-      ),
-      txSize: finalConfig.txSize,
-      hasChange,
-    };
+  private trySingleUtxoSelection({
+    utxos,
+    targetValue,
+    calculateTxSize,
+    calculateFee,
+    outputParams,
+  }: SelectionParams): UTXOSelection | null {
+    for (const utxo of utxos) {
+      const utxoValue = new Dec(utxo.value);
+
+      // Try with change first
+      const withChangeTxSize = calculateTxSize(1, outputParams, true);
+      const withChangeFee = calculateFee(withChangeTxSize.txVBytes);
+      const withChangeRemainder = utxoValue.sub(targetValue).sub(withChangeFee);
+
+      if (withChangeRemainder.gte(new Dec(DUST_THRESHOLD))) {
+        return {
+          selectedUtxos: [utxo],
+          txSize: withChangeTxSize,
+          hasChange: true,
+        };
+      }
+
+      // Try without change
+      const withoutChangeTxSize = calculateTxSize(1, outputParams, false);
+      const withoutChangeFee = calculateFee(withoutChangeTxSize.txVBytes);
+      const withoutChangeRemainder = utxoValue
+        .sub(targetValue)
+        .sub(withoutChangeFee);
+
+      if (withoutChangeRemainder.gte(new Dec(0))) {
+        return {
+          selectedUtxos: [utxo],
+          txSize: withoutChangeTxSize,
+          hasChange: false,
+        };
+      }
+    }
+    return null;
+  }
+
+  private selectMultipleUtxos(params: SelectionParams): Set<string> | null {
+    const branchAndBoundResult = this.branchAndBoundSelection(params);
+    if (branchAndBoundResult) {
+      return branchAndBoundResult;
+    }
+    return this.greedySelection(params);
   }
 
   /**
    * Build PSBT for transaction
-   * @param utxos UTXOs to be used for the transaction
-   * @param senderAddress Address of the sender
-   * @param xonlyPubKey Internal public key of the sender for taproot (optional)
-   * @param recipients Recipients of the transaction with amount and address
-   * @param estimatedFee Estimated fee for the transaction
+   * @param inputs UTXOs to be used for the transaction
+   * @param outputs Recipients of the transaction with value and address
+   * @param changeAddress Address of the sender to receive change
+   * @param feeRate Transaction fee rate in sat/vB
+   * @param maximumFeeRate Maximum fee rate in sat/vB
+   * @param isSendMax Whether to send max value, do not calculate change output
    * @param hasChange Whether to include a change output
    */
   buildPsbt({
-    utxos,
-    senderAddress,
-    xonlyPubKey,
-    recipients,
+    inputs,
+    outputs,
+    changeAddress,
     feeRate,
+    maximumFeeRate = 1000,
     isSendMax = false,
     hasChange = false,
   }: BuildPsbtParams): string {
     // 1. Basic validation
-    if (!utxos.length) {
-      throw new Error("No UTXOs provided for transaction");
+    if (!inputs.length) {
+      throw new Error(
+        "No inputs provided for transaction, at least one input is required"
+      );
     }
 
-    if (!senderAddress) {
-      throw new Error("Sender address is required");
+    if (hasChange && !changeAddress) {
+      throw new Error("Change address is required when change is enabled");
     }
 
-    if (!recipients.length) {
-      throw new Error("Recipients are required");
+    if (feeRate <= 0 || feeRate > maximumFeeRate) {
+      throw new Error(
+        `Invalid fee rate: ${feeRate}, must be between 0 and ${maximumFeeRate}`
+      );
     }
 
-    if (feeRate <= 0) {
-      throw new Error("Invalid fee rate");
-    }
-
-    // 2. Parse and validate chain configuration
-    const [, genesisHash, paymentType] = this.chainId.split(":");
+    // 2. Get network config and validate addresses
+    const [, genesisHash] = this.chainId.split(":");
     const network = GENESIS_HASH_TO_NETWORK[genesisHash as GenesisHash];
     if (!network) {
       throw new Error(`Unsupported network: ${genesisHash}`);
     }
 
-    if (paymentType !== "native-segwit" && paymentType !== "taproot") {
-      throw new Error(`Unsupported payment type: ${paymentType}`);
-    }
-
-    if (
-      paymentType === "taproot" &&
-      (!xonlyPubKey || xonlyPubKey.length !== 32)
-    ) {
-      throw new Error("Taproot PSBT requires internal pubkey of 32 bytes");
-    }
-
     // 3. Validate transaction economics
-    const totalInputAmount = utxos.reduce(
-      (sum, utxo) => sum.add(new Dec(utxo.value)),
-      new Dec(0)
+    const { remainderValue } = this.validateTransactionEconomics(
+      inputs,
+      outputs,
+      isSendMax
     );
 
-    const totalOutputAmount = recipients.reduce(
-      (sum, recipient) => sum.add(new Dec(recipient.amount)),
+    // 4. Process addresses and get network config
+    const { inputsWithAddressInfo, outputsWithAddressInfo } =
+      this.processAddresses(
+        inputs,
+        outputs,
+        changeAddress,
+        hasChange,
+        network,
+        remainderValue,
+        feeRate
+      );
+
+    // 5. Build PSBT
+    return this.createPsbt(
+      inputsWithAddressInfo,
+      outputsWithAddressInfo,
+      network
+    );
+  }
+
+  private validateTransactionEconomics(
+    inputs: IPsbtInput[],
+    outputs: IPsbtOutput[],
+    isSendMax: boolean
+  ) {
+    const totalInputValue = inputs.reduce(
+      (sum, input) => sum.add(new Dec(input.value)),
       new Dec(0)
     );
+    const totalOutputValue = outputs.reduce(
+      (sum, output) => sum.add(new Dec(output.value)),
+      new Dec(0)
+    );
+    const remainderValue = totalInputValue.sub(totalOutputValue);
 
-    const remainderValue = totalInputAmount.sub(totalOutputAmount);
-    const zeroValue = new Dec(0);
-
-    // If send max is true, it's allowed to simulate build psbt with negative remainder value
-    if (!isSendMax && remainderValue.lt(zeroValue)) {
+    if (!isSendMax && remainderValue.lt(new Dec(0))) {
       throw new Error("Insufficient balance");
     }
 
-    const senderAddressInfo = this.validateAndGetAddressInfo(
-      senderAddress,
-      network as unknown as Network
-    );
+    return { totalInputValue, totalOutputValue, remainderValue };
+  }
 
-    if (!senderAddressInfo) {
+  private processAddresses(
+    inputs: IPsbtInput[],
+    outputs: IPsbtOutput[],
+    changeAddress: string | undefined,
+    hasChange: boolean,
+    network: string,
+    remainderValue: Dec,
+    feeRate: number
+  ) {
+    const inputAddressSet = new Set(inputs.map(({ address }) => address));
+    const inputAddressInfos = Array.from(inputAddressSet)
+      .map((address) =>
+        this.validateAndGetAddressInfo(address, network as unknown as Network)
+      )
+      .filter(Boolean) as AddressInfo[];
+
+    if (!inputAddressInfos.length) {
       throw new Error("Invalid sender address");
     }
 
-    const recipientAddressInfos = recipients
+    const inputsWithAddressInfo = inputs.map((input) => {
+      const addressInfo = inputAddressInfos.find(
+        (info) => info.address === input.address
+      );
+      if (!addressInfo) {
+        throw new Error("Invalid sender address");
+      }
+      return { ...input, addressInfo };
+    });
+
+    const outputAddressInfos = outputs
       .map(({ address }) =>
         this.validateAndGetAddressInfo(address, network as unknown as Network)
       )
       .filter(Boolean) as AddressInfo[];
-    if (!recipientAddressInfos.length) {
-      throw new Error("Invalid recipients");
-    }
 
-    // 5. Calculate output parameters
-    const outputParams: Record<string, number> = {};
-    recipientAddressInfos.forEach((info) => {
-      const key = `${info.type}_output_count`;
-      outputParams[key] = (outputParams[key] || 0) + 1;
+    const outputsWithAddressInfo = outputs.map((output) => {
+      const addressInfo = outputAddressInfos.find(
+        (info) => info.address === output.address
+      );
+      if (!addressInfo) {
+        throw new Error("Invalid recipient address");
+      }
+      return { ...output, addressInfo };
     });
 
-    // Helper functions
-    const calculateTxSize = (
-      inputCount: number,
-      outputParams: Record<string, number>,
-      includeChange: boolean
-    ) => {
-      return this.calculateTxSize(
-        senderAddressInfo.type,
-        inputCount,
-        outputParams,
-        includeChange
+    if (hasChange && changeAddress) {
+      const changeAddressInfo = this.validateAndGetAddressInfo(
+        changeAddress,
+        network as unknown as Network
       );
-    };
+      if (!changeAddressInfo) {
+        throw new Error("Invalid change address");
+      }
 
-    const calculateFee = (size: number) => new Dec(Math.ceil(size * feeRate));
-
-    const DUST = new Dec(DUST_THRESHOLD);
-
-    const allRecipients = [...recipients];
-
-    // 4. Handle change output if needed
-    if (hasChange) {
-      const txSize = calculateTxSize(utxos.length, outputParams, true);
-      const fee = calculateFee(txSize.txVBytes);
-
-      const changeAmount = remainderValue.sub(fee);
-
-      // if change amount is greater than or equal to dust threshold
-      if (changeAmount.gte(DUST)) {
-        // add change output address
-        allRecipients.push({
-          address: senderAddress,
-          amount: changeAmount.truncate().toBigNumber().toJSNumber(),
+      const changeValue = this.calculateChangeValue(
+        remainderValue,
+        feeRate,
+        inputAddressInfos,
+        outputAddressInfos
+      );
+      if (changeValue.gte(new Dec(DUST_THRESHOLD))) {
+        outputsWithAddressInfo.push({
+          address: changeAddress,
+          value: changeValue.truncate().toBigNumber().toJSNumber(),
+          addressInfo: changeAddressInfo,
         });
       } else {
-        // hasChange is true but change amount is less than dust threshold, log warning
         console.warn("Change amount is less than dust threshold");
       }
     }
 
-    // 5. Get network params
-    const networkParams = (() => {
-      switch (network) {
-        case "mainnet":
-          return networks.bitcoin;
-        case "testnet":
-        case "signet":
-          return networks.testnet;
-        default:
-          throw new Error(`Invalid network: ${network}`);
-      }
-    })();
+    return { inputsWithAddressInfo, outputsWithAddressInfo };
+  }
 
-    // 6. Validate recipients
-    allRecipients.forEach((recipient) =>
-      validate(recipient.address, network as unknown as Network)
+  private calculateChangeValue(
+    remainderValue: Dec,
+    feeRate: number,
+    inputAddressInfos: AddressInfo[],
+    outputAddressInfos: AddressInfo[]
+  ): Dec {
+    const outputParams: Record<string, number> = {};
+    outputAddressInfos.forEach((info) => {
+      const key = `${info.type}_output_count`;
+      outputParams[key] = (outputParams[key] || 0) + 1;
+    });
+
+    // Get initial transaction size estimation with a single p2wpkh input
+    const { txVBytes } = this.calculateTxSize(
+      AddressType.p2wpkh,
+      1,
+      outputParams,
+      true
     );
 
-    // 7. Build PSBT
+    let adjustedTxVBytes = txVBytes;
+
+    // Adjust transaction size by replacing the default p2wpkh input size
+    // with the actual input sizes based on their types
+    for (const info of inputAddressInfos) {
+      const inputSize = this._txSizeEstimator.getSizeBasedOnInputType({
+        input_script: info.type,
+      });
+      adjustedTxVBytes += inputSize.inputWitnessSize;
+    }
+
+    // Subtract the default p2wpkh input size that was included in initial estimation
+    adjustedTxVBytes -= this._txSizeEstimator.getSizeBasedOnInputType({
+      input_script: AddressType.p2wpkh,
+    }).inputWitnessSize;
+
+    const fee = new Dec(Math.ceil(adjustedTxVBytes * feeRate));
+
+    return remainderValue.sub(fee);
+  }
+
+  private createPsbt(
+    inputsWithAddressInfo: (IPsbtInput & { addressInfo: AddressInfo })[],
+    outputsWithAddressInfo: (IPsbtOutput & { addressInfo: AddressInfo })[],
+    network: string
+  ): string {
+    const networkConfig =
+      network === "mainnet" ? networks.bitcoin : networks.testnet;
+
     try {
-      const psbt = new Psbt({ network: networkParams });
+      const psbt = new Psbt({ network: networkConfig });
 
-      // 7.1. Process sender address and script
-      const senderOutputScript = address.toOutputScript(
-        senderAddress,
-        networkParams
-      );
-      const internalPubkey = xonlyPubKey ? Buffer.from(xonlyPubKey) : undefined;
-
-      // 7.2. Add sender UTXOs as inputs (RBF enabled)
-      for (const utxo of utxos) {
-        if (paymentType === "taproot") {
-          psbt.addInput({
-            hash: utxo.txid,
-            index: utxo.vout,
-            witnessUtxo: {
-              script: senderOutputScript,
-              value: utxo.value,
-            },
-            tapInternalKey: internalPubkey,
-            sequence: 0xfffffffd,
-          });
-        }
-
-        if (paymentType === "native-segwit") {
-          psbt.addInput({
-            hash: utxo.txid,
-            index: utxo.vout,
-            witnessUtxo: { script: senderOutputScript, value: utxo.value },
-            sequence: 0xfffffffd,
-          });
-        }
+      for (const input of inputsWithAddressInfo) {
+        this.addInputToPsbt(psbt, input, networkConfig);
       }
 
-      // 7.3. Add all outputs (recipients + change if applicable)
-      for (const recipient of allRecipients) {
+      for (const output of outputsWithAddressInfo) {
         psbt.addOutput({
-          address: recipient.address,
-          value: recipient.amount,
+          address: output.address,
+          value: output.value,
         });
       }
 
@@ -460,6 +471,51 @@ export class BitcoinAccountBase {
         throw new Error(`Failed to build PSBT: ${error.message}`);
       }
       throw new Error("Failed to build PSBT: Unknown error");
+    }
+  }
+
+  private addInputToPsbt(
+    psbt: Psbt,
+    input: IPsbtInput & { addressInfo: AddressInfo },
+    networkConfig: networks.Network
+  ) {
+    const txInput = {
+      hash: input.txid,
+      index: input.vout,
+      sequence: 0xfffffffd,
+    };
+
+    if (input.addressInfo.type === "p2pkh") {
+      if (!input.nonWitnessUtxo) {
+        throw new Error("Non-witness UTXO is required for p2pkh inputs");
+      }
+      psbt.addInput({
+        ...txInput,
+        bip32Derivation: input.bip32Derivation,
+        nonWitnessUtxo: input.nonWitnessUtxo,
+      });
+    } else if (input.addressInfo.type === "p2wpkh") {
+      psbt.addInput({
+        ...txInput,
+        witnessUtxo: {
+          script: address.toOutputScript(input.address, networkConfig),
+          value: input.value,
+        },
+        bip32Derivation: input.bip32Derivation,
+      });
+    } else if (input.addressInfo.type === "p2tr") {
+      if (!input.tapInternalKey) {
+        throw new Error("Tap internal key is required for p2tr inputs");
+      }
+      psbt.addInput({
+        ...txInput,
+        witnessUtxo: {
+          script: address.toOutputScript(input.address, networkConfig),
+          value: input.value,
+        },
+        tapInternalKey: input.tapInternalKey,
+        tapBip32Derivation: input.tapBip32Derivation,
+      });
     }
   }
 
@@ -515,7 +571,7 @@ export class BitcoinAccountBase {
 
   private branchAndBoundSelection({
     utxos,
-    targetAmount,
+    targetValue,
     calculateTxSize,
     calculateFee,
     isDust,
@@ -526,14 +582,14 @@ export class BitcoinAccountBase {
     const TIMEOUT = timeoutMs ?? BRANCH_AND_BOUND_TIMEOUT_MS;
     const startTime = Date.now();
 
-    // Calculate total available amount of all UTXOs
+    // Calculate total available value of all UTXOs
     const totalAvailable = utxos.reduce(
       (sum, utxo) => sum.add(new Dec(utxo.value)),
       new Dec(0)
     );
 
-    // If target amount is greater than total available amount, return null
-    if (targetAmount.gt(totalAvailable)) {
+    // If target value is greater than total available value, return null
+    if (targetValue.gt(totalAvailable)) {
       return null;
     }
 
@@ -566,9 +622,9 @@ export class BitcoinAccountBase {
 
       let currentBest: SelectionResult | null = null;
 
-      // If target amount is satisfied, consider current selection as the best candidate
-      if (effectiveValueWithChange.gte(targetAmount)) {
-        const remainder = effectiveValueWithChange.sub(targetAmount);
+      // If target value is satisfied, consider current selection as the best candidate
+      if (effectiveValueWithChange.gte(targetValue)) {
+        const remainder = effectiveValueWithChange.sub(targetValue);
 
         const isDustRemainder = isDust(remainder);
 
@@ -602,16 +658,16 @@ export class BitcoinAccountBase {
       const utxoId = `${utxo.txid}:${utxo.vout}`;
       const utxoValue = new Dec(utxo.value);
 
-      // Bounding: If adding all remaining UTXOs still cannot reach target amount, return current best
-      if (effectiveValueWithChange.add(remainingValue).lt(targetAmount)) {
+      // Bounding: If adding all remaining UTXOs still cannot reach target value, return current best
+      if (effectiveValueWithChange.add(remainingValue).lt(targetValue)) {
         return currentBest;
       }
 
       // If already exceeds target amount and current best is better, return current best
       if (
         currentBest &&
-        effectiveValueWithChange.gte(targetAmount) &&
-        effectiveValueWithChange.sub(targetAmount).lt(currentBest.wastage)
+        effectiveValueWithChange.gte(targetValue) &&
+        effectiveValueWithChange.sub(targetValue).lt(currentBest.wastage)
       ) {
         return currentBest;
       }
@@ -663,32 +719,32 @@ export class BitcoinAccountBase {
 
   private greedySelection({
     utxos,
-    targetAmount,
+    targetValue,
     calculateTxSize,
     calculateFee,
     isDust,
     outputParams,
   }: Omit<SelectionParams, "timeoutMs">): Set<string> {
     const selectedUtxoIds = new Set<string>();
-    let selectedAmount = new Dec(0);
+    let selectedValue = new Dec(0);
 
-    // 1. Select UTXOs to satisfy target amount
+    // 1. Select UTXOs to satisfy target value
     for (const utxo of utxos) {
       const utxoId = `${utxo.txid}:${utxo.vout}`;
       selectedUtxoIds.add(utxoId);
-      selectedAmount = selectedAmount.add(new Dec(utxo.value));
+      selectedValue = selectedValue.add(new Dec(utxo.value));
 
       // Calculate fee
       const txSize = calculateTxSize(selectedUtxoIds.size, outputParams, true);
       const fee = calculateFee(txSize.txVBytes);
 
       // Calculate remainder
-      const remainder = selectedAmount.sub(targetAmount).sub(fee);
+      const remainder = selectedValue.sub(targetValue).sub(fee);
       const isDustRemainder = isDust(remainder);
 
-      // If target amount is satisfied and remainder is not dust, stop
+      // If target value is satisfied and remainder is not dust, stop
       // This prioritizes non-dust change outputs
-      if (selectedAmount.gte(targetAmount) && !isDustRemainder) {
+      if (selectedValue.gte(targetValue) && !isDustRemainder) {
         break;
       }
     }
@@ -696,7 +752,7 @@ export class BitcoinAccountBase {
     // 2. Select additional UTXOs to cover fee
     let txSize = calculateTxSize(selectedUtxoIds.size, outputParams, true);
     let fee = calculateFee(txSize.txVBytes);
-    let remainder = selectedAmount.sub(targetAmount).sub(fee);
+    let remainder = selectedValue.sub(targetValue).sub(fee);
 
     if (remainder.lt(new Dec(0))) {
       for (const utxo of utxos) {
@@ -704,11 +760,11 @@ export class BitcoinAccountBase {
         if (selectedUtxoIds.has(utxoId)) continue;
 
         selectedUtxoIds.add(utxoId);
-        selectedAmount = selectedAmount.add(new Dec(utxo.value));
+        selectedValue = selectedValue.add(new Dec(utxo.value));
 
         txSize = calculateTxSize(selectedUtxoIds.size, outputParams, true);
         fee = calculateFee(txSize.txVBytes);
-        remainder = selectedAmount.sub(targetAmount).sub(fee);
+        remainder = selectedValue.sub(targetValue).sub(fee);
 
         if (remainder.gte(new Dec(0))) {
           break;
@@ -726,7 +782,7 @@ export class BitcoinAccountBase {
 
         // Add this UTXO
         selectedUtxoIds.add(utxoId);
-        const newAmount = selectedAmount.add(new Dec(utxo.value));
+        const newValue = selectedValue.add(new Dec(utxo.value));
 
         // Calculate new fee and remainder
         const newTxSize = calculateTxSize(
@@ -735,11 +791,11 @@ export class BitcoinAccountBase {
           true
         );
         const newFee = calculateFee(newTxSize.txVBytes);
-        const newRemainder = newAmount.sub(targetAmount).sub(newFee);
+        const newRemainder = newValue.sub(targetValue).sub(newFee);
 
         // If the new remainder is not dust, keep this UTXO
         if (!isDust(newRemainder) && newRemainder.gt(new Dec(0))) {
-          selectedAmount = newAmount;
+          selectedValue = newValue;
           break;
         }
 

--- a/packages/stores-bitcoin/src/account/tx-size-estimator.ts
+++ b/packages/stores-bitcoin/src/account/tx-size-estimator.ts
@@ -238,12 +238,12 @@ export class BitcoinTxSizeEstimator {
     );
   }
 
-  getSizeBasedOnInputType() {
+  getSizeBasedOnInputType(params?: Partial<TxSizerParams>) {
     // In most cases the input size is predictable. For multisig inputs we need to perform a detailed calculation
     let inputSize = 0; // in virtual bytes
     let inputWitnessSize = 0;
     let redeemScriptSize;
-    switch (this.params.input_script) {
+    switch (params?.input_script || this.params.input_script) {
       case "p2pkh":
         inputSize = this.P2PKH_IN_SIZE;
         break;
@@ -262,13 +262,13 @@ export class BitcoinTxSizeEstimator {
       case "p2sh":
         redeemScriptSize =
           1 + // OP_M
-          this.params.input_n * (1 + this.PUBKEY_SIZE) + // OP_PUSH33 <pubkey>
+          (params?.input_n || this.params.input_n) * (1 + this.PUBKEY_SIZE) + // OP_PUSH33 <pubkey>
           1 + // OP_N
           1; // OP_CHECKMULTISIG
         // eslint-disable-next-line no-case-declarations
         const scriptSigSize =
           1 + // size(0)
-          this.params.input_m * (1 + this.SIGNATURE_SIZE) + // size(SIGNATURE_SIZE) + signature
+          (params?.input_m || this.params.input_m) * (1 + this.SIGNATURE_SIZE) + // size(SIGNATURE_SIZE) + signature
           this.getSizeOfScriptLengthElement(redeemScriptSize) +
           redeemScriptSize;
         inputSize =
@@ -278,12 +278,12 @@ export class BitcoinTxSizeEstimator {
       case "p2wsh":
         redeemScriptSize =
           1 + // OP_M
-          this.params.input_n * (1 + this.PUBKEY_SIZE) + // OP_PUSH33 <pubkey>
+          (params?.input_n || this.params.input_n) * (1 + this.PUBKEY_SIZE) + // OP_PUSH33 <pubkey>
           1 + // OP_N
           1; // OP_CHECKMULTISIG
         inputWitnessSize =
           1 + // size(0)
-          this.params.input_m * (1 + this.SIGNATURE_SIZE) + // size(SIGNATURE_SIZE) + signature
+          (params?.input_m || this.params.input_m) * (1 + this.SIGNATURE_SIZE) + // size(SIGNATURE_SIZE) + signature
           this.getSizeOfScriptLengthElement(redeemScriptSize) +
           redeemScriptSize;
         inputSize =

--- a/packages/stores-bitcoin/src/account/tx-size-estimator.ts
+++ b/packages/stores-bitcoin/src/account/tx-size-estimator.ts
@@ -238,12 +238,12 @@ export class BitcoinTxSizeEstimator {
     );
   }
 
-  getSizeBasedOnInputType(params?: Partial<TxSizerParams>) {
+  getSizeBasedOnInputType() {
     // In most cases the input size is predictable. For multisig inputs we need to perform a detailed calculation
     let inputSize = 0; // in virtual bytes
     let inputWitnessSize = 0;
     let redeemScriptSize;
-    switch (params?.input_script || this.params.input_script) {
+    switch (this.params.input_script) {
       case "p2pkh":
         inputSize = this.P2PKH_IN_SIZE;
         break;
@@ -262,13 +262,13 @@ export class BitcoinTxSizeEstimator {
       case "p2sh":
         redeemScriptSize =
           1 + // OP_M
-          (params?.input_n || this.params.input_n) * (1 + this.PUBKEY_SIZE) + // OP_PUSH33 <pubkey>
+          this.params.input_n * (1 + this.PUBKEY_SIZE) + // OP_PUSH33 <pubkey>
           1 + // OP_N
           1; // OP_CHECKMULTISIG
         // eslint-disable-next-line no-case-declarations
         const scriptSigSize =
           1 + // size(0)
-          (params?.input_m || this.params.input_m) * (1 + this.SIGNATURE_SIZE) + // size(SIGNATURE_SIZE) + signature
+          this.params.input_m * (1 + this.SIGNATURE_SIZE) + // size(SIGNATURE_SIZE) + signature
           this.getSizeOfScriptLengthElement(redeemScriptSize) +
           redeemScriptSize;
         inputSize =
@@ -278,12 +278,12 @@ export class BitcoinTxSizeEstimator {
       case "p2wsh":
         redeemScriptSize =
           1 + // OP_M
-          (params?.input_n || this.params.input_n) * (1 + this.PUBKEY_SIZE) + // OP_PUSH33 <pubkey>
+          this.params.input_n * (1 + this.PUBKEY_SIZE) + // OP_PUSH33 <pubkey>
           1 + // OP_N
           1; // OP_CHECKMULTISIG
         inputWitnessSize =
           1 + // size(0)
-          (params?.input_m || this.params.input_m) * (1 + this.SIGNATURE_SIZE) + // size(SIGNATURE_SIZE) + signature
+          this.params.input_m * (1 + this.SIGNATURE_SIZE) + // size(SIGNATURE_SIZE) + signature
           this.getSizeOfScriptLengthElement(redeemScriptSize) +
           redeemScriptSize;
         inputSize =

--- a/packages/stores-bitcoin/src/account/types.ts
+++ b/packages/stores-bitcoin/src/account/types.ts
@@ -3,14 +3,14 @@ import { Dec } from "@keplr-wallet/unit";
 export interface SelectUTXOsParams {
   senderAddress: string;
   utxos: UTXO[];
-  recipients: UTXOSelectionRecipient[];
+  recipients: IPsbtOutput[];
   feeRate: number;
   isSendMax?: boolean;
 }
 
 export interface SelectionParams {
   utxos: UTXO[];
-  targetAmount: Dec;
+  targetValue: Dec;
   calculateTxSize: (
     inputCount: number,
     outputParams: Record<string, number>,
@@ -21,17 +21,17 @@ export interface SelectionParams {
     txWeight: number;
   };
   calculateFee: (size: number) => Dec;
-  isDust: (amount: Dec) => boolean;
+  isDust: (value: Dec) => boolean;
   outputParams: Record<string, number>;
   timeoutMs?: number;
 }
 
 export interface BuildPsbtParams {
-  utxos: UTXO[];
-  senderAddress: string;
-  recipients: UTXOSelectionRecipient[];
+  inputs: IPsbtInput[];
+  outputs: IPsbtOutput[];
   feeRate: number;
-  xonlyPubKey?: Uint8Array;
+  maximumFeeRate?: number;
+  changeAddress?: string;
   isSendMax?: boolean;
   hasChange?: boolean;
 }
@@ -65,7 +65,29 @@ export interface UTXO {
   value: number;
 }
 
-export interface UTXOSelectionRecipient {
-  amount: number;
+export interface Bip32Derivation {
+  masterFingerprint: Buffer;
+  pubkey: Buffer;
+  path: string;
+}
+
+export interface TapBip32Derivation extends Bip32Derivation {
+  leafHashes: Buffer[];
+}
+
+export interface IPsbtInput {
+  txid: string;
+  vout: number;
+  value: number;
   address: string;
+  nonWitnessUtxo?: Buffer;
+  tapInternalKey?: Buffer;
+  bip32Derivation?: Bip32Derivation[];
+  tapBip32Derivation?: TapBip32Derivation[];
+  // no script related fields as of now, we don't support multisig
+}
+
+export interface IPsbtOutput {
+  address: string;
+  value: number;
 }

--- a/packages/stores-bitcoin/src/queries/bitcoin-indexer.ts
+++ b/packages/stores-bitcoin/src/queries/bitcoin-indexer.ts
@@ -4,7 +4,6 @@ import {
   QueryOptions,
   QuerySharedContext,
 } from "@keplr-wallet/stores";
-import { GenesisHash } from "@keplr-wallet/types";
 
 export class ObservableBitcoinIndexerQuery<
   T = unknown,
@@ -31,15 +30,6 @@ export class ObservableBitcoinIndexerQuery<
 
     this._chainId = chainId;
     this.chainGetter = chainGetter;
-  }
-
-  protected override canFetch(): boolean {
-    // TODO: enable for mainnet once indexer setup is done
-    if (this._chainId.startsWith(`bip122:${GenesisHash.MAINNET}`)) {
-      return false;
-    }
-
-    return super.canFetch();
   }
 
   get chainId(): string {

--- a/packages/stores-core/src/core/interaction/bitcoin-sign-tx.ts
+++ b/packages/stores-core/src/core/interaction/bitcoin-sign-tx.ts
@@ -55,7 +55,11 @@ export class SignBitcoinTxInteractionStore {
     id: string,
     psbtSignData: {
       psbtHex: string;
-      inputsToSign: number[];
+      inputsToSign: {
+        index: number;
+        address: string;
+        path?: string;
+      }[];
     }[],
     signedPsbtsHexes: string[],
     afterFn: (proceedNext: boolean) => void | Promise<void>,

--- a/packages/stores-core/src/core/interaction/bitcoin-sign-tx.ts
+++ b/packages/stores-core/src/core/interaction/bitcoin-sign-tx.ts
@@ -58,7 +58,8 @@ export class SignBitcoinTxInteractionStore {
       inputsToSign: {
         index: number;
         address: string;
-        path?: string;
+        hdPath?: string;
+        tapLeafHashesToSign?: Buffer[];
       }[];
     }[],
     signedPsbtsHexes: string[],

--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -51,6 +51,8 @@ export class AccountSetBase {
     | {
         bech32Address: string;
         paymentType: SupportedPaymentType;
+        masterFingerprintHex?: string;
+        derivationPath?: string;
       }
     | undefined = undefined;
   @observable
@@ -199,6 +201,8 @@ export class AccountSetBase {
             this._bitcoinAddress = {
               bech32Address: key.address,
               paymentType: key.paymentType,
+              masterFingerprintHex: key.masterFingerprintHex,
+              derivationPath: key.derivationPath,
             };
             this._isNanoLedger = key.isNanoLedger;
             this._isKeystone = false;
@@ -362,6 +366,8 @@ export class AccountSetBase {
     | {
         bech32Address: string;
         paymentType: SupportedPaymentType;
+        masterFingerprintHex?: string;
+        derivationPath?: string;
       }
     | undefined {
     return this._bitcoinAddress;

--- a/packages/stores/src/account/context.ts
+++ b/packages/stores/src/account/context.ts
@@ -267,6 +267,8 @@ export class AccountSharedContext {
             address: string;
             paymentType: SupportedPaymentType;
             isNanoLedger: boolean;
+            masterFingerprintHex?: string;
+            derivationPath?: string;
           }
       >
     ) => void

--- a/packages/types/src/bip44.ts
+++ b/packages/types/src/bip44.ts
@@ -1,3 +1,4 @@
 export interface BIP44 {
   readonly coinType: number;
+  readonly purpose?: number;
 }

--- a/packages/types/src/chain-info.ts
+++ b/packages/types/src/chain-info.ts
@@ -75,7 +75,7 @@ export interface BitcoinChainInfo {
   readonly rpc: string;
   readonly rest: string;
   readonly chainId: string;
-  readonly coinType: number;
+  readonly bip44: BIP44;
   readonly currencies: AppCurrency[];
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8761,9 +8761,9 @@ __metadata:
   dependencies:
     "@noble/curves": ^1.4.2
     "@noble/hashes": ^1.4.0
-    bip32: ^2.0.6
-    bip39: ^3.0.3
-    bs58check: ^2.1.2
+    bip32: ^4.0.0
+    bip39: ^3.1.0
+    bs58check: ^4.0.0
     buffer: ^6.0.3
     ecpair: ^2.1.0
   peerDependencies:
@@ -12888,6 +12888,13 @@ __metadata:
   version: 1.3.2
   resolution: "@remix-run/router@npm:1.3.2"
   checksum: ee2108b87d4a1241cdea137dd7e1741ee679228bd33fd81e22a6bb2940f81186cefe9a85e26d60cc49bbcc1bdbc57d1954b7d4d62f8a51ef69feddfc899f55fa
+  languageName: node
+  linkType: hard
+
+"@scure/base@npm:^1.1.1":
+  version: 1.2.4
+  resolution: "@scure/base@npm:1.2.4"
+  checksum: db554eb550a1bd17684af9282e1ad751050a13d4add0e83ad61cc496680d7d1c1c1120ca780e72935a293bb59721c20a006a53a5eec6f6b5bdcd702cf27c8cae
   languageName: node
   linkType: hard
 
@@ -18234,6 +18241,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"base-x@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "base-x@npm:5.0.1"
+  checksum: 6e4f847ef842e0a71c6b6020a6ec482a2a5e727f5a98534dbfd5d5a4e8afbc0d1bdf1fd57174b3f0455d107f10a932c3c7710bec07e2878f80178607f8f605c8
+  languageName: node
+  linkType: hard
+
 "base58-js@npm:^3.0.2":
   version: 3.0.2
   resolution: "base58-js@npm:3.0.2"
@@ -18414,7 +18428,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bip32@npm:2.0.6, bip32@npm:^2.0.6":
+"bip32@npm:2.0.6":
   version: 2.0.6
   resolution: "bip32@npm:2.0.6"
   dependencies:
@@ -18426,6 +18440,18 @@ __metadata:
     typeforce: ^1.11.5
     wif: ^2.0.6
   checksum: 1c654a93836d8ed0bf5aa18a9b7b8dc3fe65e6a607a736d2acdb7927276c03db4bf8068324b9907e362759f9307d8b2b61c2547c282a2bc5198305f5654ed554
+  languageName: node
+  linkType: hard
+
+"bip32@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "bip32@npm:4.0.0"
+  dependencies:
+    "@noble/hashes": ^1.2.0
+    "@scure/base": ^1.1.1
+    typeforce: ^1.11.5
+    wif: ^2.0.6
+  checksum: a36253ac164db50a25e88effce84aec1eaba2ec2fbd7a19bc1f836f9b1c934fa148c3a01ddece7f136596330074d98c6b2a441e51914c302d130f56f0f893d0d
   languageName: node
   linkType: hard
 
@@ -18441,7 +18467,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bip39@npm:^3.0.2, bip39@npm:^3.0.3":
+"bip39@npm:^3.0.2":
   version: 3.0.3
   resolution: "bip39@npm:3.0.3"
   dependencies:
@@ -18450,6 +18476,15 @@ __metadata:
     pbkdf2: ^3.0.9
     randombytes: ^2.0.1
   checksum: 72c8372d503799b14fda6cf14e173ffd75f58a633b86e98eb339e6ad14d9ecda2058bb2853d1d8aff60ded502a8fae7c940b480daeffe5189387f0f3f63e132a
+  languageName: node
+  linkType: hard
+
+"bip39@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "bip39@npm:3.1.0"
+  dependencies:
+    "@noble/hashes": ^1.2.0
+  checksum: 1224e763ffc6b097052ed8abd57f0e521ad6d31f1645be0d0a15f4417c13f8461f00e47e9cf7c8c784bd533f4fb1ee3ab020f258c7df45ee5dc722b4b0336cfc
   languageName: node
   linkType: hard
 
@@ -19061,6 +19096,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bs58@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "bs58@npm:6.0.0"
+  dependencies:
+    base-x: ^5.0.0
+  checksum: 820334f9513bba6195136dfc9dfbd1f5aded6c7864639f3ee7b63c2d9d6f9f2813b9949b1f6beb9c161237be2a461097444c2ff587c8c3b824fe18878fa22448
+  languageName: node
+  linkType: hard
+
 "bs58check@npm:<3.0.0, bs58check@npm:^2.1.1, bs58check@npm:^2.1.2":
   version: 2.1.2
   resolution: "bs58check@npm:2.1.2"
@@ -19079,6 +19123,16 @@ __metadata:
     "@noble/hashes": ^1.2.0
     bs58: ^5.0.0
   checksum: dbbecc7a09f3836e821149266c864c4bbd545539cea43c35f23f4c3c46b54c86c52b65d224b9ea2e916fa6d93bd2ce9fac5b6c6bfcf19621a9c209a5602f71c8
+  languageName: node
+  linkType: hard
+
+"bs58check@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "bs58check@npm:4.0.0"
+  dependencies:
+    "@noble/hashes": ^1.2.0
+    bs58: ^6.0.0
+  checksum: 416131b647563e9c7daf5d18222862b40dfd39110f8635e9e1d19805d624e96cc12ba03c8e6fdc1f9c0e364dd2918877fb8a02671caeef0de9beeb33c1fb0ed4
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8761,9 +8761,9 @@ __metadata:
   dependencies:
     "@noble/curves": ^1.4.2
     "@noble/hashes": ^1.4.0
-    bip32: ^4.0.0
-    bip39: ^3.1.0
-    bs58check: ^4.0.0
+    bip32: ^2.0.6
+    bip39: ^3.0.3
+    bs58check: ^2.1.2
     buffer: ^6.0.3
     ecpair: ^2.1.0
   peerDependencies:
@@ -12888,13 +12888,6 @@ __metadata:
   version: 1.3.2
   resolution: "@remix-run/router@npm:1.3.2"
   checksum: ee2108b87d4a1241cdea137dd7e1741ee679228bd33fd81e22a6bb2940f81186cefe9a85e26d60cc49bbcc1bdbc57d1954b7d4d62f8a51ef69feddfc899f55fa
-  languageName: node
-  linkType: hard
-
-"@scure/base@npm:^1.1.1":
-  version: 1.2.4
-  resolution: "@scure/base@npm:1.2.4"
-  checksum: db554eb550a1bd17684af9282e1ad751050a13d4add0e83ad61cc496680d7d1c1c1120ca780e72935a293bb59721c20a006a53a5eec6f6b5bdcd702cf27c8cae
   languageName: node
   linkType: hard
 
@@ -18241,13 +18234,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base-x@npm:^5.0.0":
-  version: 5.0.1
-  resolution: "base-x@npm:5.0.1"
-  checksum: 6e4f847ef842e0a71c6b6020a6ec482a2a5e727f5a98534dbfd5d5a4e8afbc0d1bdf1fd57174b3f0455d107f10a932c3c7710bec07e2878f80178607f8f605c8
-  languageName: node
-  linkType: hard
-
 "base58-js@npm:^3.0.2":
   version: 3.0.2
   resolution: "base58-js@npm:3.0.2"
@@ -18428,7 +18414,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bip32@npm:2.0.6":
+"bip32@npm:2.0.6, bip32@npm:^2.0.6":
   version: 2.0.6
   resolution: "bip32@npm:2.0.6"
   dependencies:
@@ -18440,18 +18426,6 @@ __metadata:
     typeforce: ^1.11.5
     wif: ^2.0.6
   checksum: 1c654a93836d8ed0bf5aa18a9b7b8dc3fe65e6a607a736d2acdb7927276c03db4bf8068324b9907e362759f9307d8b2b61c2547c282a2bc5198305f5654ed554
-  languageName: node
-  linkType: hard
-
-"bip32@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "bip32@npm:4.0.0"
-  dependencies:
-    "@noble/hashes": ^1.2.0
-    "@scure/base": ^1.1.1
-    typeforce: ^1.11.5
-    wif: ^2.0.6
-  checksum: a36253ac164db50a25e88effce84aec1eaba2ec2fbd7a19bc1f836f9b1c934fa148c3a01ddece7f136596330074d98c6b2a441e51914c302d130f56f0f893d0d
   languageName: node
   linkType: hard
 
@@ -18479,7 +18453,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bip39@npm:^3.1.0":
+"bip39@npm:^3.0.3":
   version: 3.1.0
   resolution: "bip39@npm:3.1.0"
   dependencies:
@@ -19096,15 +19070,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bs58@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "bs58@npm:6.0.0"
-  dependencies:
-    base-x: ^5.0.0
-  checksum: 820334f9513bba6195136dfc9dfbd1f5aded6c7864639f3ee7b63c2d9d6f9f2813b9949b1f6beb9c161237be2a461097444c2ff587c8c3b824fe18878fa22448
-  languageName: node
-  linkType: hard
-
 "bs58check@npm:<3.0.0, bs58check@npm:^2.1.1, bs58check@npm:^2.1.2":
   version: 2.1.2
   resolution: "bs58check@npm:2.1.2"
@@ -19123,16 +19088,6 @@ __metadata:
     "@noble/hashes": ^1.2.0
     bs58: ^5.0.0
   checksum: dbbecc7a09f3836e821149266c864c4bbd545539cea43c35f23f4c3c46b54c86c52b65d224b9ea2e916fa6d93bd2ce9fac5b6c6bfcf19621a9c209a5602f71c8
-  languageName: node
-  linkType: hard
-
-"bs58check@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "bs58check@npm:4.0.0"
-  dependencies:
-    "@noble/hashes": ^1.2.0
-    bs58: ^6.0.0
-  checksum: 416131b647563e9c7daf5d18222862b40dfd39110f8635e9e1d19805d624e96cc12ba03c8e6fdc1f9c0e364dd2918877fb8a02671caeef0de9beeb33c1fb0ed4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 변경사항

### 1. `BIP44` 타입에 `purpose` 필드 추가

- `purpose` 값이 undefined인 경우, 기본값으로 44를 사용하고, bitcoin modular chaininfo에는 native segwit인 경우 84, taproot인 경우 86을 사용하도록 명시

### 2. `Bip32Derivation`

```typescript
export interface Bip32Derivation {
  masterFingerprint: Buffer;
  pubkey: Buffer;
  path: string;
}
```

1. master seed로 생성된 master node의 fingerprint와 masterFingerprint 값이 일치해야 함
2. master node에서 path로 파생된 child node의 pubkey가 bip32 derivation의 pubkey와 일치해야 함 (taproot의 경우 xonly pubkey를 비교)
3. 1, 2가 유효하면 child node의 private key를 사용해 서명

### 3. `@keplr-wallet/crypto`

- mnemonic을 생성할 때 `masterFingerprint`를 함께 반환하도록 추가
- `PubKeyBitcoinCompatible` 인스턴스를 생성할 때, 생성자에서 `network`, `masterFingerprint`와 `path`를 선택적으로 받도록 추가
- `PubKeyBitcoinCompatible`의 각 주소 생성 메서드를 `getBitcoinAddress` 메서드로 통합

### 4. `@keplr-wallet/background`

- `keyring`: bip44 경로 purpose 처리 추가
- `keyring-mnemonic`: `getPubKeyBitcoin` 메서드를 추가해 `masterFingerprint`와 `path`를 포함한 `PubKeyBitcoinCompatible` 인스턴스를 반환하도록 추가, `signPsbt` 메서드에서 master seed 기반으로 파생 키를 생성하여 서명할 수 있도록 수정
- `keyring-private-key`: private key로는 HD 키를 생성할 수 없으므로 주소만 비교하여 서명할 수 있도록 `signPsbt` 메서드 수정
- `keyring-bitcoin`: key 요청에 대해 `masterFingerprintHex`와 `path`를 포함하여 반환하도록 수정

### 5. `@keplr-wallet/stores-bitcoin`

- 비트코인 맥락상 `amount` -> `value`로 통일
- 작은 금액 (< $10)을 보내는데 여러 개의 입력을 사용하는 경우, selectUTXOs에서 계산된 수수료와 buildPsbt에서 계산된 수수료의 차이가 큰 문제가 있어서 해당 부분 수정
- buildPsbt 메서드의 파라미터로 utxo 대신 Input을 받아서 더 복잡한 트랜잭션을 구성할 수 있도록 수정
- 전체 코드 리팩토링

### 6. `usePsbtsValidate`

- inscription, runes 포함 여부 확인 로직 제거
- `isMine` 함수를 통해서 명시적인 키 파생경로를 파악하고 `inputsToSign`에 추가 (multisig는 우선 고려하지 않기로 햇으므로 경로 배열로 반환하지 않음)
    - private key: address만 비교
    - mnemonic: address, master fingerprint 비교
    - hardware wallet(TODO): address, master fingerprint + 파생된 키가 유효한지 확인
- readable format으로 사용자에게 보여줄 decoded psbt data를 반환하도록 추가

### 7. 스크립트 경로 지출에 대한 처리

- 탭루트 서명 방식에는 키 경로 지출, 스크립트 경로 지출 두 종류가 있는데 바빌론 스테이킹의 스크립트 경로 지출에 대한 처리가 필요하여 이를 추가하였습니다.
    - staking 트랜잭션은 키 경로 지출 방식 (일반적인 트랜잭션 서명, Tweaked key 필요)
    - withdraw, unbonding 트랜잭션의 경우 스크립트 경로 지출 방식 (탭트리에 들어있는 스크립트에 서명, tweaked key 불필요)

### 8. https://github.com/chainapsis/keplr-wallet/pull/1381 리뷰사항

1. bip44 경로 처리하는 방식 변경되면서 백그라운드에서 키를 가져오는 방식으로 변경
2. 혹시나 utxo 목록하고 최신 트랜잭션 목록하고 동기화가 안된 부분이 있을지도 몰라서 최신 트랜잭션 목록도 가져와서 사용한 utxo 필터링하도록 했는데 지나친 걱정인 것 같아서 제거했습니다.
3. availableBalance를 useMemo로 감싼 상태랑 아닌 상태랑 계산하는 횟수는 비슷해서 그대로 놔뒀습니다.
4. bitcoin fee control 컴포넌트에서 불필요한 코드 제거했습니다.
5. replaceQueryParams는 inscription, runes 쿼리를 pagination query로 구현하는 과정에서 커서방식으로 동작하지 않고 limit, offset을 재설정해줘야 해서 기존 쿼리 파라미터를 대체하게 하려고 추가했습니다.

### 8. fee 계산 관련

- 현재 send page에서 단순하게 feeRate * txSize로 계산된 수수료를 보여주고 있는데
- 전체 입력의 합에서 보내는 금액과 수수료를 뺀 나머지가 546 sat보다 작은 경우에는 잔돈으로 추가할 수 없기 때문에
- 이 잔돈으로 들어가지 못하는 나머지 금액을 수수료랑 같이 합산해서 보여줘야 합니다. (sign page에서는 정상적으로 반영)
- 이부분은 remainder hook을 따로 만들어서 처리를 할지, txSize나 fee hook에 필드를 추가하는게 좋을지 의견 주시면 다음 pr에서 수정해오겠습니다. 