### PR TITLE
Fix an issue that tooltip is hidden on asset list

### DIFF
--- a/apps/extension/src/pages/main/components/token/index.tsx
+++ b/apps/extension/src/pages/main/components/token/index.tsx
@@ -54,7 +54,6 @@ const Styles = {
     disableHoverStyle?: boolean;
     isNotReady?: boolean;
   }>`
-    z-index: 2;
     background-color: ${(props) =>
       props.theme.mode === "light"
         ? props.isNotReady


### PR DESCRIPTION
AS-IS
<img width="356" alt="Screenshot 2025-03-24 at 4 49 17 PM" src="https://github.com/user-attachments/assets/0a016a34-82f7-4898-b979-c807795706cd" />


TO-BE
<img width="351" alt="Screenshot 2025-03-24 at 4 49 45 PM" src="https://github.com/user-attachments/assets/acfe393c-8e3e-4d2c-a2b3-7b7ad59fd307" />

