### PR TITLE
fix Main Page Earn features

### DIFF
--- a/apps/extension/src/pages/earn/components/use-earn-bottom-tag.ts
+++ b/apps/extension/src/pages/earn/components/use-earn-bottom-tag.ts
@@ -40,6 +40,17 @@ export function useEarnBottomTag(balances: ViewToken[]) {
       )?.token ??
       null;
 
+    const isUsdcOnTop =
+      isUsdcFromNoble &&
+      (!topUsdcFound.current || topUsdcFound.current === key);
+
+    if (isUsdcOnTop) {
+      topUsdcFound.current = key;
+      if (token.toDec().isZero()) {
+        return {};
+      }
+    }
+
     if (!usdnAsset.current) {
       return {
         bottomTagType: "nudgeEarn",
@@ -50,16 +61,7 @@ export function useEarnBottomTag(balances: ViewToken[]) {
       .calculatePrice(usdnAsset.current)
       ?.toString();
 
-    if (isUsdn) {
-      return {
-        bottomTagType: "showEarnSavings",
-        earnedAssetPrice,
-      };
-    }
-
-    if (!topUsdcFound.current || topUsdcFound.current === key) {
-      topUsdcFound.current = key;
-
+    if (isUsdcOnTop || isUsdn) {
       return {
         bottomTagType: "showEarnSavings",
         earnedAssetPrice,

--- a/apps/extension/src/pages/main/components/token/wrapper-with-bottom-tag.tsx
+++ b/apps/extension/src/pages/main/components/token/wrapper-with-bottom-tag.tsx
@@ -55,13 +55,12 @@ export const WrapperwithBottomTag = observer(function ({
 
   return (
     <Box position="relative" style={{ cursor: "pointer" }}>
-      {children}
+      <Box zIndex={1}>{children}</Box>
       <Box
         onClick={onClick}
-        zIndex={1}
+        zIndex={0}
         position="relative"
         style={{
-          zIndex: -1,
           top: "-0.5rem",
           left: 0,
           display: "flex",


### PR DESCRIPTION
- [Main Page] hid a token item’s bottom banner when USDC balance doesn’t exist
- [Main Page] fixed bottom banners to be clickable