### PR TITLE
외부 서명 요청이 연속적으로 들어올 때 간헐적으로 reject 되는 현상

### DIFF
--- a/apps/extension/src/stores/root.tsx
+++ b/apps/extension/src/stores/root.tsx
@@ -82,7 +82,10 @@ import {
   SwapUsageQueries,
 } from "@keplr-wallet/stores-internal";
 import { setInteractionDataHref } from "../utils";
-import { InteractionPingMsg } from "@keplr-wallet/background";
+import {
+  InteractionIdPingMsg,
+  InteractionPingMsg,
+} from "@keplr-wallet/background";
 import {
   StarknetAccountStore,
   StarknetQueriesStore,
@@ -197,7 +200,7 @@ export class RootStore {
 
       // popup 상태일때 interaction에 대한 ping이 있을때
       // 해당 interaction id를 가지고 있지 않으면 응답 자체를 안해야한다.
-      if (msg instanceof InteractionPingMsg && msg.interactionId != null) {
+      if (msg instanceof InteractionIdPingMsg) {
         const interaction = this.interactionStore.getData(msg.interactionId);
         if (!interaction) {
           return true;
@@ -258,11 +261,7 @@ export class RootStore {
           setInteractionDataHref(fresh[0]);
         }
       },
-      async (
-        windowId: number | undefined,
-        interactionId: string | undefined,
-        ignoreWindowIdAndForcePing
-      ) => {
+      async (windowId: number | undefined, ignoreWindowIdAndForcePing) => {
         const url = new URL(window.location.href);
         // popup 또는 side panel에서만 interaction을 처리할 수 있다...
         // interaction을 처리할 수 있는 UI가 존재하는 경우
@@ -270,12 +269,6 @@ export class RootStore {
         // XXX: register.html 등에서는 interaction을 처리할 수 없기 때문에
         //      이러한 경우를 막기 위해서 여기서 pathname을 확실하게 확인해야한다.
         if (url.pathname === "/popup.html") {
-          if (interactionId != null) {
-            const interaction = this.interactionStore.getData(interactionId);
-            if (!interaction) {
-              return false;
-            }
-          }
           return true;
         }
         if (url.pathname === "/sidePanel.html") {
@@ -288,6 +281,10 @@ export class RootStore {
         }
 
         return false;
+      },
+      async (interactionId: string) => {
+        const interaction = this.interactionStore.getData(interactionId);
+        return !!interaction;
       }
     );
 

--- a/apps/extension/src/stores/root.tsx
+++ b/apps/extension/src/stores/root.tsx
@@ -195,6 +195,15 @@ export class RootStore {
         }
       }
 
+      // popup 상태일때 interaction에 대한 ping이 있을때
+      // 해당 interaction id를 가지고 있지 않으면 응답 자체를 안해야한다.
+      if (msg instanceof InteractionPingMsg && msg.interactionId != null) {
+        const interaction = this.interactionStore.getData(msg.interactionId);
+        if (!interaction) {
+          return true;
+        }
+      }
+
       return false;
     });
     router.addGuard(ContentScriptGuards.checkMessageIsInternal);
@@ -249,7 +258,11 @@ export class RootStore {
           setInteractionDataHref(fresh[0]);
         }
       },
-      async (windowId: number | undefined, ignoreWindowIdAndForcePing) => {
+      async (
+        windowId: number | undefined,
+        interactionId: string | undefined,
+        ignoreWindowIdAndForcePing
+      ) => {
         const url = new URL(window.location.href);
         // popup 또는 side panel에서만 interaction을 처리할 수 있다...
         // interaction을 처리할 수 있는 UI가 존재하는 경우
@@ -257,6 +270,12 @@ export class RootStore {
         // XXX: register.html 등에서는 interaction을 처리할 수 없기 때문에
         //      이러한 경우를 막기 위해서 여기서 pathname을 확실하게 확인해야한다.
         if (url.pathname === "/popup.html") {
+          if (interactionId != null) {
+            const interaction = this.interactionStore.getData(interactionId);
+            if (!interaction) {
+              return false;
+            }
+          }
           return true;
         }
         if (url.pathname === "/sidePanel.html") {

--- a/packages/background/src/interaction/foreground/handler.ts
+++ b/packages/background/src/interaction/foreground/handler.ts
@@ -6,6 +6,7 @@ import {
   Message,
 } from "@keplr-wallet/router";
 import {
+  InteractionIdPingMsg,
   InteractionPingMsg,
   PushEventDataMsg,
   PushInteractionDataMsg,
@@ -26,6 +27,11 @@ export const getHandler: (service: InteractionForegroundService) => Handler = (
         return handlePushEventDataMsg(service)(env, msg as PushEventDataMsg);
       case InteractionPingMsg:
         return handleInteractionPing(service)(env, msg as InteractionPingMsg);
+      case InteractionIdPingMsg:
+        return handleInteractionIdPing(service)(
+          env,
+          msg as InteractionIdPingMsg
+        );
       default:
         throw new KeplrError("interaction", 110, "Unknown msg type");
     }
@@ -55,10 +61,17 @@ const handleInteractionPing: (
     if (!service.pingHandler) {
       return false;
     }
-    return service.pingHandler(
-      msg.windowId,
-      msg.interactionId,
-      msg.ignoreWindowIdAndForcePing
-    );
+    return service.pingHandler(msg.windowId, msg.ignoreWindowIdAndForcePing);
+  };
+};
+
+const handleInteractionIdPing: (
+  service: InteractionForegroundService
+) => InternalHandler<InteractionIdPingMsg> = (service) => {
+  return (_env, msg) => {
+    if (!service.interactionIdPingHandler) {
+      return false;
+    }
+    return service.interactionIdPingHandler(msg.interactionId);
   };
 };

--- a/packages/background/src/interaction/foreground/handler.ts
+++ b/packages/background/src/interaction/foreground/handler.ts
@@ -55,6 +55,10 @@ const handleInteractionPing: (
     if (!service.pingHandler) {
       return false;
     }
-    return service.pingHandler(msg.windowId, msg.ignoreWindowIdAndForcePing);
+    return service.pingHandler(
+      msg.windowId,
+      msg.interactionId,
+      msg.ignoreWindowIdAndForcePing
+    );
   };
 };

--- a/packages/background/src/interaction/foreground/init.ts
+++ b/packages/background/src/interaction/foreground/init.ts
@@ -3,6 +3,7 @@ import {
   PushInteractionDataMsg,
   PushEventDataMsg,
   InteractionPingMsg,
+  InteractionIdPingMsg,
 } from "./messages";
 import { ROUTE } from "./constants";
 import { getHandler } from "./handler";
@@ -15,6 +16,7 @@ export function interactionForegroundInit(
   router.registerMessage(PushInteractionDataMsg);
   router.registerMessage(PushEventDataMsg);
   router.registerMessage(InteractionPingMsg);
+  router.registerMessage(InteractionIdPingMsg);
 
   router.addHandler(ROUTE, getHandler(service));
 }

--- a/packages/background/src/interaction/foreground/messages.ts
+++ b/packages/background/src/interaction/foreground/messages.ts
@@ -9,7 +9,6 @@ export class InteractionPingMsg extends Message<boolean> {
 
   constructor(
     public readonly windowId: number | undefined,
-    public readonly interactionId: string | undefined,
     public readonly ignoreWindowIdAndForcePing: boolean
   ) {
     super();
@@ -25,6 +24,28 @@ export class InteractionPingMsg extends Message<boolean> {
 
   type(): string {
     return InteractionPingMsg.type();
+  }
+}
+
+export class InteractionIdPingMsg extends Message<boolean> {
+  public static type() {
+    return "interaction-ping-id";
+  }
+
+  constructor(public readonly interactionId: string) {
+    super();
+  }
+
+  validateBasic(): void {
+    // noop
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return InteractionIdPingMsg.type();
   }
 }
 

--- a/packages/background/src/interaction/foreground/messages.ts
+++ b/packages/background/src/interaction/foreground/messages.ts
@@ -9,6 +9,7 @@ export class InteractionPingMsg extends Message<boolean> {
 
   constructor(
     public readonly windowId: number | undefined,
+    public readonly interactionId: string | undefined,
     public readonly ignoreWindowIdAndForcePing: boolean
   ) {
     super();

--- a/packages/background/src/interaction/foreground/service.ts
+++ b/packages/background/src/interaction/foreground/service.ts
@@ -6,6 +6,7 @@ export class InteractionForegroundService {
     protected handler: InteractionForegroundHandler,
     public readonly pingHandler?: (
       windowId: number | undefined,
+      interactionId: string | undefined,
       ignoreWindowIdAndForcePing: boolean
     ) => Promise<boolean>
   ) {}

--- a/packages/background/src/interaction/foreground/service.ts
+++ b/packages/background/src/interaction/foreground/service.ts
@@ -6,8 +6,10 @@ export class InteractionForegroundService {
     protected handler: InteractionForegroundHandler,
     public readonly pingHandler?: (
       windowId: number | undefined,
-      interactionId: string | undefined,
       ignoreWindowIdAndForcePing: boolean
+    ) => Promise<boolean>,
+    public readonly interactionIdPingHandler?: (
+      interactionId: string
     ) => Promise<boolean>
   ) {}
 

--- a/packages/background/src/interaction/service.ts
+++ b/packages/background/src/interaction/service.ts
@@ -7,6 +7,7 @@ import {
   MessageRequester,
 } from "@keplr-wallet/router";
 import {
+  InteractionIdPingMsg,
   InteractionPingMsg,
   PushEventDataMsg,
   PushInteractionDataMsg,
@@ -363,7 +364,6 @@ export class InteractionService {
             // XXX: popup에서는 위에 로직에서 window id를 -1로 대충 처리 했었다.
             new InteractionPingMsg(
               windowId === -1 ? undefined : windowId,
-              undefined,
               false
             )
           );
@@ -408,7 +408,7 @@ export class InteractionService {
       try {
         const res = await this.extensionMessageRequesterToUI!.sendMessage(
           APP_PORT,
-          new InteractionPingMsg(0, interactionId, true)
+          new InteractionIdPingMsg(interactionId)
         );
         if (res) {
           succeeded = true;
@@ -487,7 +487,7 @@ export class InteractionService {
       // 그 부분에 trick이 들어가 있다.
       return await this.extensionMessageRequesterToUI.sendMessage(
         APP_PORT,
-        new InteractionPingMsg(tab.windowId, undefined, false)
+        new InteractionPingMsg(tab.windowId, false)
       );
     } catch {
       return false;

--- a/packages/background/src/interaction/service.ts
+++ b/packages/background/src/interaction/service.ts
@@ -431,6 +431,11 @@ export class InteractionService {
         wasPingSucceeded = true;
       }
 
+      const data = this.waitingMap.get(interactionId);
+      if (!data) {
+        break;
+      }
+
       i++;
     }
   }

--- a/packages/stores-core/src/core/interaction/interaction.ts
+++ b/packages/stores-core/src/core/interaction/interaction.ts
@@ -60,6 +60,7 @@ export class InteractionStore implements InteractionForegroundHandler {
     ) => void,
     protected readonly pingHandler?: (
       windowId: number | undefined,
+      interactionId: string | undefined,
       ignoreWindowIdAndForcePing: boolean
     ) => Promise<boolean>
   ) {

--- a/packages/stores-core/src/core/interaction/interaction.ts
+++ b/packages/stores-core/src/core/interaction/interaction.ts
@@ -60,13 +60,19 @@ export class InteractionStore implements InteractionForegroundHandler {
     ) => void,
     protected readonly pingHandler?: (
       windowId: number | undefined,
-      interactionId: string | undefined,
       ignoreWindowIdAndForcePing: boolean
+    ) => Promise<boolean>,
+    protected readonly interactionIdPingHandler?: (
+      interactionId: string
     ) => Promise<boolean>
   ) {
     makeObservable(this);
 
-    const service = new InteractionForegroundService(this, pingHandler);
+    const service = new InteractionForegroundService(
+      this,
+      pingHandler,
+      interactionIdPingHandler
+    );
     interactionForegroundInit(router, service);
 
     this.init();


### PR DESCRIPTION
원인
- startCheckPingOnUI
   - interaction service에서 startCheckPingOnUI라는 메소드가 있는데 이 메소드는 interaction이 요청되었지만 popup 또는 side panel이 다 닫혀서 더 이상 처리할 수가 없는데 여러가지 이유로 interaction이 reject되지 않았을 경우 백그라운드에서 자동으로 reject 시키는 기능임
   - 하지만 interaction이 연속적으로 요청되었을때 첫번째 interaction으로 popup이 열리고 유저가 approve를 눌렀을때 즉시 두번째 interaction이 요청되면 유저가 approve를 눌러서 팝업이 닫혔지만 startCheckPingOnUI에서 더 이상 인터렉션을  처리할 ui가 없다고 판단하고 두번째 interaction을 rejectAll 시켜버리는 문제가 있음
   - 그래서 startCheckPingOnUI를 global하게 모든 interaction에 대해서 처리하는게 아니라 각각의 interaction id에 대해서 처리하도록 수정
- openPopupWindow
   - 이름 그대로 popup을 여는 기능인데 팝업을 create를 시도하고 이미 팝업이 있으면 기존 팝업의 url을 업데이트하는 기능임
   - 근데 테스트 해본 결과 연속적인 요청이 들어왔을때 create가 실제로 작동하지 않아도 오류를 throw하지 않음...
   - env의 unstableOnClose 기능도 create가 실제로는 이루어지지 않았는데 이를 감지할 수 없기 때문에 tab이 존재하지 않아서 close로 인식되어서 잘못 발생하는 것으로 추정됨...
   - 그래서 openPopupWindow을 하고 나서 extension API로 실제로 해당 window가 열렸는지 확인해보고 열렸어야지 resolve하도록 수정