### PR TITLE
[QA] Support Bitcoin - QA 2

### DIFF
--- a/apps/extension/src/pages/bitcoin/components/input/amount-input/input.tsx
+++ b/apps/extension/src/pages/bitcoin/components/input/amount-input/input.tsx
@@ -5,7 +5,7 @@ import {
   IAmountConfig,
   ZeroAmountError,
 } from "@keplr-wallet/hooks-bitcoin";
-import { TextInput } from "../../../../../components/input";
+import { TextInput } from "../../../../../components/input/text-input";
 import { useStore } from "../../../../../stores";
 import { CoinPretty, Dec, DecUtils } from "@keplr-wallet/unit";
 import { Box } from "../../../../../components/box";

--- a/apps/extension/src/pages/main/components/token/index.tsx
+++ b/apps/extension/src/pages/main/components/token/index.tsx
@@ -267,6 +267,24 @@ export const TokenItem: FunctionComponent<TokenItemProps> = observer(
       );
     })();
 
+    const isTokenTagTooLong =
+      viewToken.chainInfo.chainName.length + (tag?.text.length ?? 0) > 24;
+    const TokenTagAndCopyAddressComponents = [
+      tag ? (
+        <Box alignY="center">
+          <TokenTag text={tag.text} tooltip={tag.tooltip} />
+        </Box>
+      ) : null,
+      !isNotReady && copyAddress ? (
+        <Box alignY="center">
+          <XAxis alignY="center">
+            <Gutter size="-0.125rem" />
+            <CopyAddressButton address={copyAddress} parentIsHover={isHover} />
+          </XAxis>
+        </Box>
+      ) : null,
+    ];
+
     const TokenItemContent = () => (
       <Styles.Container
         forChange={forChange}
@@ -418,24 +436,10 @@ export const TokenItem: FunctionComponent<TokenItemProps> = observer(
                     : viewToken.chainInfo.chainName}
                 </Caption1>
               </Skeleton>
-
-              {!isNotReady && copyAddress ? (
-                <Box alignY="center">
-                  <XAxis alignY="center">
-                    <Gutter size="-0.125rem" />
-                    <CopyAddressButton
-                      address={copyAddress}
-                      parentIsHover={isHover}
-                    />
-                  </XAxis>
-                </Box>
-              ) : null}
-
-              {tag ? (
-                <Box alignY="center">
-                  <TokenTag text={tag.text} tooltip={tag.tooltip} />
-                </Box>
-              ) : null}
+              {/** 토큰 태그가 너무 길면 주소 복사 버튼이 줄바꿈 되는데, 복사 버튼 대신 토큰 태그가 줄바꿈 되게 하기 위해 대충 이렇게 처리한다.. */}
+              {isTokenTagTooLong
+                ? TokenTagAndCopyAddressComponents.reverse()
+                : TokenTagAndCopyAddressComponents}
             </Box>
           </Stack>
 

--- a/apps/extension/src/pages/main/components/token/index.tsx
+++ b/apps/extension/src/pages/main/components/token/index.tsx
@@ -267,24 +267,6 @@ export const TokenItem: FunctionComponent<TokenItemProps> = observer(
       );
     })();
 
-    const isTokenTagTooLong =
-      viewToken.chainInfo.chainName.length + (tag?.text.length ?? 0) > 24;
-    const TokenTagAndCopyAddressComponents = [
-      tag ? (
-        <Box alignY="center">
-          <TokenTag text={tag.text} tooltip={tag.tooltip} />
-        </Box>
-      ) : null,
-      !isNotReady && copyAddress ? (
-        <Box alignY="center">
-          <XAxis alignY="center">
-            <Gutter size="-0.125rem" />
-            <CopyAddressButton address={copyAddress} parentIsHover={isHover} />
-          </XAxis>
-        </Box>
-      ) : null,
-    ];
-
     const TokenItemContent = () => (
       <Styles.Container
         forChange={forChange}
@@ -436,10 +418,24 @@ export const TokenItem: FunctionComponent<TokenItemProps> = observer(
                     : viewToken.chainInfo.chainName}
                 </Caption1>
               </Skeleton>
-              {/** 토큰 태그가 너무 길면 주소 복사 버튼이 줄바꿈 되는데, 복사 버튼 대신 토큰 태그가 줄바꿈 되게 하기 위해 대충 이렇게 처리한다.. */}
-              {isTokenTagTooLong
-                ? TokenTagAndCopyAddressComponents.reverse()
-                : TokenTagAndCopyAddressComponents}
+              <XAxis>
+                {tag ? (
+                  <Box alignY="center" key="token-tag">
+                    <TokenTag text={tag.text} tooltip={tag.tooltip} />
+                  </Box>
+                ) : null}
+                {!isNotReady && copyAddress ? (
+                  <Box alignY="center" key="copy-address">
+                    <XAxis alignY="center">
+                      <Gutter size="-0.125rem" />
+                      <CopyAddressButton
+                        address={copyAddress}
+                        parentIsHover={isHover}
+                      />
+                    </XAxis>
+                  </Box>
+                ) : null}
+              </XAxis>
             </Box>
           </Stack>
 

--- a/apps/extension/src/stores/huge-queries/index.ts
+++ b/apps/extension/src/stores/huge-queries/index.ts
@@ -344,10 +344,6 @@ export class HugeQueriesStore {
           ChainIdHelper.parse(modularChainInfo.chainId).identifier
         }/${currency.coinMinimalDenom}`;
         if (!keysUsed.get(key)) {
-          if (queryBalance.balance.toDec().equals(HugeQueriesStore.zeroDec)) {
-            continue;
-          }
-
           keysUsed.set(key, true);
           prevKeyMap.delete(key);
           this.balanceBinarySort.pushAndSort(key, {

--- a/packages/hooks-bitcoin/src/tx/fee.ts
+++ b/packages/hooks-bitcoin/src/tx/fee.ts
@@ -114,9 +114,11 @@ export class FeeConfig extends TxChainSetter implements IFeeConfig {
 
     const amount = this.amountConfig.amount;
 
-    const need = amount.reduce((acc, cur) => {
-      return acc.add(new Dec(cur.toCoin().amount));
-    }, new Dec(0));
+    const need = amount
+      .reduce((acc, cur) => {
+        return acc.add(new Dec(cur.toCoin().amount));
+      }, new Dec(0))
+      .add(new Dec(fee.toCoin().amount));
 
     const availableBalance =
       this.availableBalanceConfig.availableBalanceByAddress(

--- a/packages/stores-bitcoin/src/account/base.ts
+++ b/packages/stores-bitcoin/src/account/base.ts
@@ -209,7 +209,13 @@ export class BitcoinAccountBase {
       };
     }
 
-    return null;
+    // isSendMax는 아니지만 수량이 max 근처(?)인 경우
+    return {
+      selectedUtxos,
+      txSize: withoutChangeTxSize,
+      remainderStatus: RemainderStatus.None,
+      remainderValue: "0",
+    };
   }
 
   private calculateOutputParams(


### PR DESCRIPTION
- 비트코인이 enable 되어 있으면 메인에서 밸런스가 0이더라도 보여주도록 수정
- TokenItem에서 체인 이름 + 태그 + Copy Address 버튼이 너무 길어지면 태그가 줄바꿈되도록 수정
- 비트코인 Send 페이지에서 max가 아니지만 max 수량과 비슷할 때 올바른 에러가 보이도록 수정