### PR TITLE
Extract sigHashType from psbt and remove fee validation

### DIFF
--- a/apps/extension/src/hooks/bitcoin/use-psbt-validate.ts
+++ b/apps/extension/src/hooks/bitcoin/use-psbt-validate.ts
@@ -390,6 +390,9 @@ export const usePsbtsValidate = (
                 index,
                 address,
                 hdPath,
+                sighashTypes: input.sighashType
+                  ? [input.sighashType]
+                  : undefined,
                 tapLeafHashesToSign,
               });
             }
@@ -477,36 +480,26 @@ export const usePsbtsValidate = (
 
         const fee = sumInputValue.sub(sumOutputValue);
 
-        // 수수료가 0보다 작으면 유효하지 않은 psbt이다.
-        if (fee.lte(new Dec(0))) {
-          throw new Error(
-            "Insufficient fee: inputs must be greater than outputs"
-          );
-        } else {
-          validatedPsbtResults.push({
-            psbt,
-            inputsToSign,
-            fee,
-            sumInputValueByAddress: processInputValuesByAddress(
-              sumInputValueByAddressRecord,
-              inputsToSign
-            ),
-            sumOutputValueByAddress: processOutputValuesByAddress(
-              sumOutputValueByAddressRecord,
-              inputsToSign
-            ),
-            decodedRawData: decodePsbt(psbt),
-          });
+        validatedPsbtResults.push({
+          psbt,
+          inputsToSign,
+          fee,
+          sumInputValueByAddress: processInputValuesByAddress(
+            sumInputValueByAddressRecord,
+            inputsToSign
+          ),
+          sumOutputValueByAddress: processOutputValuesByAddress(
+            sumOutputValueByAddressRecord,
+            inputsToSign
+          ),
+          decodedRawData: decodePsbt(psbt),
+        });
 
-          totalInputValue = totalInputValue.add(sumInputValue);
-          totalOutputValue = totalOutputValue.add(sumOutputValue);
-        }
+        totalInputValue = totalInputValue.add(sumInputValue);
+        totalOutputValue = totalOutputValue.add(sumOutputValue);
       }
 
       const totalFee = totalInputValue.sub(totalOutputValue);
-      if (totalFee.lte(new Dec(0))) {
-        throw new Error("Insufficient fee for transaction");
-      }
 
       // 각 psbt의 유효성 검증 결과를 저장하고 계산된 수수료를 설정한다.
       setValidatedPsbts(validatedPsbtResults);


### PR DESCRIPTION
- `inputsToSign` 구성할 때 각 input에서 `sighashType`을 추출하여 추가 (unisat inscription/runes linsting/unlisting 동작 확인)
- fee validation 로직 제거 (totalInput > totalOutput)
    - 유효한 서명을 받아서 보관해놨다가 나중에 사용하려는 용도로 특정 index에 서명이 필요한 입력을 배치해놓고 나머지는 더미 데이터로 채우는 경우, 입력의 합이 출력의 합보다 작아질 수 있으므로 fee validation이 불필요