### PR TITLE
Rowan/keplr 949

### DIFF
--- a/apps/extension/src/languages/en.json
+++ b/apps/extension/src/languages/en.json
@@ -805,6 +805,8 @@
   "components.bitcoin-guide-box.title.critical-validation-error": "Unable to sign the transaction",
   "components.bitcoin-guide-box.title.unable-to-get-utxos": "Unable to get UTXOs",
   "components.bitcoin-guide-box.paragraph.unable-to-get-utxos": "UTXOs are temporarily unavailable. Please try again later.",
+  "components.bitcoin-guide-box.title.unable-to-send-bitcoin": "No available UTXOs to send",
+  "components.bitcoin-guide-box.paragraph.unable-to-send-bitcoin": "There are no available UTXOs to send Bitcoin. Please make sure you have sufficient balance that is not locked or pending in other transactions.",
   "components.bitcoin-guide-box.title.partial-signing": "Partial Signing",
   "components.bitcoin-guide-box.paragraph.partial-signing": "You are signing part of the transaction. Only the inputs from this wallet will be signed.",
   "components.bitcoin-guide-box.title.none-of-the-inputs-belong-to-this-wallet": "None of the inputs belong to this wallet",

--- a/apps/extension/src/languages/ko.json
+++ b/apps/extension/src/languages/ko.json
@@ -705,6 +705,8 @@
 
   "components.bitcoin-guide-box.title.critical-validation-error": "트랜잭션 서명 불가",
   "components.bitcoin-guide-box.title.unable-to-get-utxos": "UTXO 조회 불가",
+  "components.bitcoin-guide-box.paragraph.unable-to-send-bitcoin": "전송 가능한 비트코인이 없습니다. 잔액이 충분한지, 또는 다른 거래에 잠겨있거나 대기 중인 상태가 아닌지 확인해주세요.",
+  "components.bitcoin-guide-box.title.unable-to-send-bitcoin": "보낼 수 있는 UTXO가 없음",
   "components.bitcoin-guide-box.paragraph.unable-to-get-utxos": "일시적으로 UTXO 정보를 가져올 수 없습니다. 잠시 후 다시 시도해 주세요.",
   "components.bitcoin-guide-box.title.partial-signing": "부분 서명",
   "components.bitcoin-guide-box.paragraph.partial-signing": "이 지갑에 속한 입력값에 대해서만 서명이 진행됩니다.",

--- a/apps/extension/src/languages/zh-cn.json
+++ b/apps/extension/src/languages/zh-cn.json
@@ -662,6 +662,8 @@
   "components.bitcoin-guide-box.title.critical-validation-error": "无法签名交易",
   "components.bitcoin-guide-box.title.unable-to-get-utxos": "无法获取UTXO",
   "components.bitcoin-guide-box.paragraph.unable-to-get-utxos": "UTXO暂时不可用，请稍后重试。",
+  "components.bitcoin-guide-box.title.unable-to-send-bitcoin": "没有可用的UTXO",
+  "components.bitcoin-guide-box.paragraph.unable-to-send-bitcoin": "没有可用的比特币进行转账。请确认余额充足，且没有被锁定或正在进行其他交易。",
   "components.bitcoin-guide-box.title.partial-signing": "部分签名",
   "components.bitcoin-guide-box.paragraph.partial-signing": "您正在对交易进行部分签名，仅对该钱包的输入进行签名。",
   "components.bitcoin-guide-box.title.none-of-the-inputs-belong-to-this-wallet": "没有属于该钱包的输入",

--- a/apps/extension/src/pages/bitcoin/components/guide-box/index.tsx
+++ b/apps/extension/src/pages/bitcoin/components/guide-box/index.tsx
@@ -6,11 +6,13 @@ export const BitcoinGuideBox: FunctionComponent<{
   isUnableToGetUTXOs?: boolean;
   isPartialSign?: boolean;
   isUnableToSign?: boolean;
+  isUnableToSendBitcoin?: boolean;
   criticalValidationError?: Error;
 }> = ({
   isUnableToGetUTXOs,
   isPartialSign,
   isUnableToSign,
+  isUnableToSendBitcoin,
   criticalValidationError,
 }) => {
   const intl = useIntl();
@@ -19,6 +21,7 @@ export const BitcoinGuideBox: FunctionComponent<{
     !isPartialSign &&
     !isUnableToSign &&
     !isUnableToGetUTXOs &&
+    !isUnableToSendBitcoin &&
     !criticalValidationError
   ) {
     return null;
@@ -28,12 +31,16 @@ export const BitcoinGuideBox: FunctionComponent<{
     ? "components.bitcoin-guide-box.title.critical-validation-error"
     : isUnableToGetUTXOs
     ? "components.bitcoin-guide-box.title.unable-to-get-utxos"
+    : isUnableToSendBitcoin
+    ? "components.bitcoin-guide-box.title.unable-to-send-bitcoin"
     : isUnableToSign
     ? "components.bitcoin-guide-box.title.none-of-the-inputs-belong-to-this-wallet"
     : "components.bitcoin-guide-box.title.partial-signing";
 
   const paragraphId = isUnableToGetUTXOs
     ? "components.bitcoin-guide-box.paragraph.unable-to-get-utxos"
+    : isUnableToSendBitcoin
+    ? "components.bitcoin-guide-box.paragraph.unable-to-send-bitcoin"
     : isUnableToSign
     ? "components.bitcoin-guide-box.paragraph.none-of-the-inputs-belong-to-this-wallet"
     : "components.bitcoin-guide-box.paragraph.partial-signing";

--- a/apps/extension/src/pages/bitcoin/components/input/fee-control/index.tsx
+++ b/apps/extension/src/pages/bitcoin/components/input/fee-control/index.tsx
@@ -256,10 +256,6 @@ export const FeeControl: FunctionComponent<{
               >
                 {(() => {
                   if (feeConfig.uiProperties.error) {
-                    console.log(
-                      "feeConfig.uiProperties.error",
-                      feeConfig.uiProperties.error
-                    );
                     if (
                       feeConfig.uiProperties.error instanceof
                       InsufficientFeeError
@@ -276,10 +272,6 @@ export const FeeControl: FunctionComponent<{
                   }
 
                   if (feeConfig.uiProperties.warning) {
-                    console.log(
-                      "feeConfig.uiProperties.warning",
-                      feeConfig.uiProperties.warning
-                    );
                     return (
                       feeConfig.uiProperties.warning.message ||
                       feeConfig.uiProperties.warning.toString()
@@ -287,10 +279,6 @@ export const FeeControl: FunctionComponent<{
                   }
 
                   if (feeRateConfig.uiProperties.error) {
-                    console.log(
-                      "feeRateConfig.uiProperties.error",
-                      feeRateConfig.uiProperties.error
-                    );
                     return (
                       feeRateConfig.uiProperties.error.message ||
                       feeRateConfig.uiProperties.error.toString()

--- a/apps/extension/src/pages/bitcoin/components/input/fee-control/index.tsx
+++ b/apps/extension/src/pages/bitcoin/components/input/fee-control/index.tsx
@@ -221,7 +221,7 @@ export const FeeControl: FunctionComponent<{
                 <FormattedMessage
                   id="components.input.fee-control.fee-rate"
                   values={{
-                    feeRate: feeRateConfig.feeRate,
+                    feeRate: feeRateConfig.feeRate.toFixed(3),
                   }}
                 />
               </Caption1>

--- a/apps/extension/src/pages/bitcoin/components/transaction-fee-modal/index.tsx
+++ b/apps/extension/src/pages/bitcoin/components/transaction-fee-modal/index.tsx
@@ -5,6 +5,7 @@ import {
   H5,
   Subtitle1,
   Subtitle3,
+  Subtitle4,
 } from "../../../../components/typography";
 import { ColorPalette } from "../../../../styles";
 import styled, { useTheme } from "styled-components";
@@ -22,8 +23,10 @@ import {
   ISenderConfig,
   IFeeConfig,
   IFeeRateConfig,
+  MaximumFeeRateReachedError,
 } from "@keplr-wallet/hooks-bitcoin";
 import { TextInput } from "../../../../components/input";
+import { VerticalResizeTransition } from "../../../../components/transition";
 
 const Styles = {
   Container: styled.div`
@@ -112,18 +115,55 @@ export const TransactionFeeModal: FunctionComponent<{
         </Stack>
 
         {feeRateConfig.feeRateType === "manual" ? (
-          <TextInput
-            label={intl.formatMessage({
-              id: "components.input.fee-control.modal.fee-rate-label",
-            })}
-            disabled={feeRateConfig.feeRateType !== "manual"}
-            value={feeRateConfig.value}
-            onChange={(e) => {
-              e.preventDefault();
-              feeRateConfig.setValue(e.target.value);
-            }}
-          />
+          <React.Fragment>
+            <TextInput
+              label={intl.formatMessage({
+                id: "components.input.fee-control.modal.fee-rate-label",
+              })}
+              disabled={feeRateConfig.feeRateType !== "manual"}
+              value={feeRateConfig.value}
+              onKeyDown={(e) => {
+                const error = feeRateConfig.uiProperties.error;
+                if (error && error instanceof MaximumFeeRateReachedError) {
+                  if (e.key !== "Backspace") {
+                    e.preventDefault();
+                  }
+                }
+              }}
+              onChange={(e) => {
+                e.preventDefault();
+                feeRateConfig.setValue(e.target.value);
+              }}
+            />
+            <VerticalResizeTransition transitionAlign="top">
+              {feeRateConfig.uiProperties.error ? (
+                <Box
+                  marginTop="1.04rem"
+                  borderRadius="0.5rem"
+                  alignX="center"
+                  alignY="center"
+                  paddingY="1.125rem"
+                  backgroundColor={
+                    theme.mode === "light"
+                      ? ColorPalette["orange-50"]
+                      : ColorPalette["yellow-800"]
+                  }
+                >
+                  <Subtitle4
+                    color={
+                      theme.mode === "light"
+                        ? ColorPalette["orange-400"]
+                        : ColorPalette["yellow-400"]
+                    }
+                  >
+                    {feeRateConfig.uiProperties.error.message}
+                  </Subtitle4>
+                </Box>
+              ) : null}
+            </VerticalResizeTransition>
+          </React.Fragment>
         ) : null}
+
         <VerticalCollapseTransition collapsed={!showChangesApplied}>
           <GuideBox
             color="safe"

--- a/apps/extension/src/pages/bitcoin/components/transaction-fee-modal/index.tsx
+++ b/apps/extension/src/pages/bitcoin/components/transaction-fee-modal/index.tsx
@@ -277,7 +277,7 @@ const FeeSelector: FunctionComponent<{
             <FeeRateSelectorStyle.FeeRate
               selected={feeRateConfig.feeRateType === "low"}
             >
-              {`${feeRate.hourFee} sat/vB`}
+              {`${feeRate.hourFee.toFixed(3)} sat/vB`}
             </FeeRateSelectorStyle.FeeRate>
             <FeeRateSelectorStyle.Description
               selected={feeRateConfig.feeRateType === "low"}
@@ -312,7 +312,7 @@ const FeeSelector: FunctionComponent<{
             <FeeRateSelectorStyle.FeeRate
               selected={feeRateConfig.feeRateType === "average"}
             >
-              {`${feeRate.halfHourFee} sat/vB`}
+              {`${feeRate.halfHourFee.toFixed(3)} sat/vB`}
             </FeeRateSelectorStyle.FeeRate>
             <FeeRateSelectorStyle.Description
               selected={feeRateConfig.feeRateType === "average"}
@@ -340,7 +340,7 @@ const FeeSelector: FunctionComponent<{
             <FeeRateSelectorStyle.FeeRate
               selected={feeRateConfig.feeRateType === "high"}
             >
-              {`${feeRate.fastestFee} sat/vB`}
+              {`${feeRate.fastestFee.toFixed(3)} sat/vB`}
             </FeeRateSelectorStyle.FeeRate>
             <FeeRateSelectorStyle.Description
               selected={feeRateConfig.feeRateType === "high"}

--- a/apps/extension/src/pages/bitcoin/sign/tx/view.tsx
+++ b/apps/extension/src/pages/bitcoin/sign/tx/view.tsx
@@ -341,6 +341,8 @@ export const SignBitcoinTxView: FunctionComponent<{
   );
   const isUnableToGetUTXOs =
     hasPsbtCandidate && !isFetchingUTXOs && !!utxoError;
+  const isUnableToSendBitcoin =
+    hasPsbtCandidate && !isFetchingUTXOs && availableUTXOs.length === 0;
 
   const buttonDisabled =
     txConfigsValidate.interactionBlocked ||
@@ -639,6 +641,7 @@ export const SignBitcoinTxView: FunctionComponent<{
           // Show current PSBT based on index
           <PsbtDetailsView
             isUnableToGetUTXOs={isUnableToGetUTXOs}
+            isUnableToSendBitcoin={isUnableToSendBitcoin}
             signerInfo={signerInfo}
             chainId={chainId}
             origin={interactionData.data.origin}
@@ -651,6 +654,7 @@ export const SignBitcoinTxView: FunctionComponent<{
         ) : (
           <PsbtDetailsView
             isUnableToGetUTXOs={isUnableToGetUTXOs}
+            isUnableToSendBitcoin={isUnableToSendBitcoin}
             signerInfo={signerInfo}
             chainId={chainId}
             origin={interactionData.data.origin}
@@ -939,6 +943,7 @@ const PsbtDetailsView: FunctionComponent<{
   };
   origin: string;
   isUnableToGetUTXOs: boolean;
+  isUnableToSendBitcoin: boolean;
   validatedPsbt?: ValidatedPsbt;
   totalPsbts?: number;
   currentPsbtIndex?: number;
@@ -951,6 +956,7 @@ const PsbtDetailsView: FunctionComponent<{
     signerInfo,
     origin,
     isUnableToGetUTXOs,
+    isUnableToSendBitcoin,
     totalPsbts,
     currentPsbtIndex,
     ledgerGuideBox,
@@ -1019,7 +1025,11 @@ const PsbtDetailsView: FunctionComponent<{
       (input) => !input.isMine
     );
     const isUnableToSign = validatedPsbt?.inputsToSign.length === 0;
-    const hasGuideBox = isUnableToGetUTXOs || isPartialSign || isUnableToSign;
+    const hasGuideBox =
+      isUnableToGetUTXOs ||
+      isUnableToSendBitcoin ||
+      isPartialSign ||
+      isUnableToSign;
     const hasLedgerGuideBox =
       totalPsbts && currentPsbtIndex !== undefined
         ? currentPsbtIndex === totalPsbts - 1 && ledgerGuideBox
@@ -1043,6 +1053,7 @@ const PsbtDetailsView: FunctionComponent<{
           isPartialSign={isPartialSign}
           isUnableToGetUTXOs={isUnableToGetUTXOs}
           isUnableToSign={isUnableToSign}
+          isUnableToSendBitcoin={isUnableToSendBitcoin}
           criticalValidationError={criticalValidationError}
         />
         {ledgerGuideBox}

--- a/packages/hooks-bitcoin/src/tx/errors.ts
+++ b/packages/hooks-bitcoin/src/tx/errors.ts
@@ -117,3 +117,11 @@ export class UnableToFindProperUtxosError extends Error {
     Object.setPrototypeOf(this, UnableToFindProperUtxosError.prototype);
   }
 }
+
+export class MaximumFeeRateReachedError extends Error {
+  constructor(m: string) {
+    super(m);
+    // Set the prototype explicitly.
+    Object.setPrototypeOf(this, MaximumFeeRateReachedError.prototype);
+  }
+}

--- a/packages/hooks-bitcoin/src/tx/fee-rate.ts
+++ b/packages/hooks-bitcoin/src/tx/fee-rate.ts
@@ -4,6 +4,7 @@ import { ChainGetter } from "@keplr-wallet/stores";
 import { action, computed, makeObservable, observable } from "mobx";
 import { useState } from "react";
 import { BitcoinQueriesStore } from "@keplr-wallet/stores-bitcoin";
+import { MaximumFeeRateReachedError } from "./errors";
 
 const DEFAULT_MAXIMUM_FEE_RATE = 1000;
 
@@ -111,7 +112,9 @@ export class FeeRateConfig extends TxChainSetter implements IFeeRateConfig {
 
     if (parsed > DEFAULT_MAXIMUM_FEE_RATE) {
       return {
-        error: new Error("Maximum fee rate is 1000"),
+        error: new MaximumFeeRateReachedError(
+          `Maximum fee rate is ${DEFAULT_MAXIMUM_FEE_RATE}`
+        ),
       };
     }
 

--- a/packages/stores-bitcoin/src/account/constant.ts
+++ b/packages/stores-bitcoin/src/account/constant.ts
@@ -1,2 +1,3 @@
 export const DUST_THRESHOLD = 546;
 export const BRANCH_AND_BOUND_TIMEOUT_MS = 1000;
+export const MIN_RELAY_FEE = 157;

--- a/packages/stores-bitcoin/src/queries/indexer/fee-estimates.ts
+++ b/packages/stores-bitcoin/src/queries/indexer/fee-estimates.ts
@@ -15,8 +15,8 @@ export class ObservableQueryBitcoinFeeEstimates extends ObservableBitcoinIndexer
 
   get fees(): Fees {
     const DEFAULT_FEES = {
-      fastestFee: 10,
-      halfHourFee: 5,
+      fastestFee: 5,
+      halfHourFee: 4,
       hourFee: 3,
       economyFee: 2,
       minimumFee: 1,
@@ -36,13 +36,9 @@ export class ObservableQueryBitcoinFeeEstimates extends ObservableBitcoinIndexer
       return DEFAULT_FEES;
     }
 
-    const toFixed = (num: number): number => {
-      return Math.floor(num * 1000) / 1000;
-    };
-
     const getFeeForTarget = (target: number): number => {
       if (data[target.toString()]) {
-        return toFixed(data[target.toString()]);
+        return data[target.toString()];
       }
 
       if (sortedKeys.length === 0) {
@@ -56,12 +52,12 @@ export class ObservableQueryBitcoinFeeEstimates extends ObservableBitcoinIndexer
         }
       }
 
-      return toFixed(data[closest.toString()]);
+      return data[closest.toString()];
     };
 
     const minimumFee =
       sortedKeys.length > 0
-        ? toFixed(data[sortedKeys[sortedKeys.length - 1].toString()])
+        ? data[sortedKeys[sortedKeys.length - 1].toString()]
         : 1;
 
     return {


### PR DESCRIPTION
- unisat에서 ordinals/runes 민팅할 때 signPsbt가 아닌 sendBitcoin 요청을 사용
    - 이 때 계산된 fee가 node의 minimum relay fee 미만으로 계산된 경우, pushTx 요청이 실패하게 됩니다. 따라서 utxo 조합을 생성할 때 minimum relay fee를 고려하도록 수정했습니다.
    - tx sign 페이지에 sendBitcoin 요청이 들어왔을 때 available utxo가 존재하지 않은 경우에 대한 경고 메시지를 추가했습니다.
    - 인덱서의 fee rate 응답값을 소숫점 아래 3자리 밑은 버리는 부분을 제거하고 ui 상에서만 3자리까지 보여지도록 수정했습니다.
- fee rate가 maximum 값을 초과한 경우, backspace로 제거하는 것만 가능하도록 수정했고 fee rate modal에서도 관련된 오류 메시지가 보일 수 있도록 추가했습니다.