### PR TITLE
[QA] Bitcoin send page freezing

### DIFF
--- a/apps/extension/src/hooks/bitcoin/use-psbt-validate.ts
+++ b/apps/extension/src/hooks/bitcoin/use-psbt-validate.ts
@@ -144,7 +144,9 @@ export const usePsbtsValidate = (
         .map(([address, value]) => ({
           address,
           value,
-          isMine: inputsToSign.some((input) => input.address === address),
+          isMine:
+            inputsToSign.some((input) => input.address === address) ||
+            bitcoinKeys.some((key) => key.address === address),
         }))
         .sort((a, b) => {
           if (a.isMine && b.isMine) {
@@ -165,7 +167,7 @@ export const usePsbtsValidate = (
           return 1;
         });
     };
-  }, []);
+  }, [bitcoinKeys]);
 
   const getInputToSignInfo = useCallback(
     (
@@ -491,6 +493,7 @@ export const usePsbtsValidate = (
           sumOutputValueByAddress: processOutputValuesByAddress(
             sumOutputValueByAddressRecord,
             inputsToSign
+            // 사용자의 주소
           ),
           decodedRawData: decodePsbt(psbt),
         });
@@ -506,8 +509,7 @@ export const usePsbtsValidate = (
       feeConfig.setValue(totalFee.truncate().toString());
       setIsInitialized(true);
     } catch (e) {
-      // psbt deserialize 오류 또는 입력의 합이 출력의 합보다 작은 psbt가 있는 경우
-      // 이는 더 이상 검증을 진행할 수 없는 치명적인 오류이다.
+      // psbt deserialize가 실패하는 경우, 이는 더 이상 검증을 진행할 수 없는 치명적인 오류이다.
       setCriticalValidationError(e as Error);
       console.error(e);
     }

--- a/packages/stores-bitcoin/src/account/constant.ts
+++ b/packages/stores-bitcoin/src/account/constant.ts
@@ -1,3 +1,5 @@
 export const DUST_THRESHOLD = 546;
 export const BRANCH_AND_BOUND_TIMEOUT_MS = 1000;
 export const MIN_RELAY_FEE = 157;
+export const MAX_SAFE_OUTPUT = 2 ** 53 - 1;
+export const MAX_BITCOIN_SUPPLY = 210000000000000;

--- a/packages/stores-bitcoin/src/account/types.ts
+++ b/packages/stores-bitcoin/src/account/types.ts
@@ -1,11 +1,13 @@
 import { Dec } from "@keplr-wallet/unit";
+import { AddressInfo } from "bitcoin-address-validation";
 
 export interface SelectUTXOsParams {
   senderAddress: string;
   utxos: UTXO[];
-  recipients: IPsbtOutput[];
+  outputs: IPsbtOutput[];
   feeRate: number;
   isSendMax?: boolean;
+  prevalidatedAddressInfos?: AddressInfo[];
 }
 
 export interface SelectionParams {
@@ -34,6 +36,7 @@ export interface BuildPsbtParams {
   changeAddress?: string;
   isSendMax?: boolean;
   hasChange?: boolean;
+  prevalidatedAddressInfos?: AddressInfo[];
 }
 
 export enum RemainderStatus {


### PR DESCRIPTION
### Ref

- https://linear.app/keplrwallet/issue/KEPLR-991/page-unresponsive

### 이슈 개요  
- 잘못된 입력을 연속해서 넣으면 시뮬레이션이 실행되지 않다가
- 사용자가 **max** 버튼을 눌러 시뮬레이션 실행 후, 다시 잘못된 입력으로 돌아오면  
  - 새 키가 설정되기 전에 캐시된 시뮬레이션이 실행됨 
  - 이 과정에서 잘못된 입력으로 수천 개의 output을 생성하며 유효성 검사가 진행되어  
  - 검증 시간이 과도하게 소요되고 익스텐션이 프리징되는 문제가 발생

### 변경 사항  
- **Safe Guard 추가**  
  - 시뮬레이션 실행 순서 조정은 어려워서, 불필요한 검증이 실행되지 않도록 충분한 안전장치를 추가했습니다.  
  - 검증 로직 관련 사항:  
    - **총 output 값이 비트코인 최대 공급량을 초과하거나, dust threshold보다 낮은지** 체크  
    - **중복된 주소 검증**을 최소화하도록 추가 개선

- **코드 구조 개선**  
  - output 생성 로직을 `prepareOutputsForSingleRecipient` 메서드로 분리  
  - 해당 메서드는 `BitcoinAccountBase`와 같은 파일에 위치시켜 관리