### PR TITLE
Apply `ChainIdHelper` to getBaseChainId

### DIFF
--- a/packages/background/src/chains/service.ts
+++ b/packages/background/src/chains/service.ts
@@ -1286,10 +1286,12 @@ export class ChainsService {
    * TODO: 비트 코인 외에도 여러 주소 체계가 존재하는 체인이 추가될 경우, 이 메서드의 부분적인 수정이 필요하다.
    */
   getBaseChainId(chainId: string): string | undefined {
+    chainId = ChainIdHelper.parse(chainId).identifier;
+
     const modularChainInfos = this.getModularChainInfos();
 
     const directMatch = modularChainInfos.find(
-      (info) => info.chainId === chainId
+      (info) => ChainIdHelper.parse(info.chainId).identifier === chainId
     );
     if (directMatch) {
       if ("bitcoin" in directMatch) {


### PR DESCRIPTION
cosmos == cosmos-1 == cosmos-2
위의 세개는 같은 체인으로 취급되어야 함
비트코인을 추가하면서 getBaseChainId가 추가되었는데
getBaseChainId에는 chain identifier 개념이 적용되어 있지 않아서 수정
getBaseChainId에서 eip, bitcoin 주소 체계는 {identifier}-{version}의 형태가 절대로 될 수 없다고 가정하고
chainId를 바로 ChainIdHelper.parse()를 사용해서 비교하도록 수정