### PR TITLE
Fix earn feature state management and bottom tag UI alignment

### DIFF
--- a/apps/extension/src/pages/earn/components/use-earn-bottom-tag.ts
+++ b/apps/extension/src/pages/earn/components/use-earn-bottom-tag.ts
@@ -1,5 +1,5 @@
 import { CoinPretty } from "@keplr-wallet/unit";
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import { ViewToken } from "../../main";
 import { validateIsUsdcFromNoble } from "../utils";
 import { useStore } from "../../../stores";
@@ -10,6 +10,11 @@ export function useEarnBottomTag(balances: ViewToken[]) {
   const usdnAsset = useRef<CoinPretty | null>(null);
 
   const { priceStore } = useStore();
+
+  useEffect(() => {
+    topUsdcFound.current = "";
+    usdnAsset.current = null;
+  }, [balances]);
 
   function getBottomTagInfoProps(
     { token, chainInfo }: ViewToken,
@@ -31,14 +36,14 @@ export function useEarnBottomTag(balances: ViewToken[]) {
       return {};
     }
 
-    usdnAsset.current =
-      usdnAsset.current ??
-      balances.find(
-        ({ token, chainInfo }) =>
-          chainInfo.chainId === NOBLE_CHAIN_ID &&
-          token.currency.coinMinimalDenom === "uusdn"
-      )?.token ??
-      null;
+    if (usdnAsset.current === null) {
+      usdnAsset.current =
+        balances.find(
+          ({ token, chainInfo }) =>
+            chainInfo.chainId === NOBLE_CHAIN_ID &&
+            token.currency.coinMinimalDenom === "uusdn"
+        )?.token ?? null;
+    }
 
     const isUsdcOnTop =
       isUsdcFromNoble &&

--- a/apps/extension/src/pages/main/available.tsx
+++ b/apps/extension/src/pages/main/available.tsx
@@ -390,7 +390,7 @@ export const AvailableTabView: FunctionComponent<{
                           <TokenItem
                             key={key}
                             viewToken={viewToken}
-                            {...getBottomTagInfoProps(viewToken, key)}
+                            {...getBottomTagInfoProps(viewToken)}
                             onClick={() => {
                               setSearchParams((prev) => {
                                 prev.set(

--- a/apps/extension/src/pages/main/components/token/index.tsx
+++ b/apps/extension/src/pages/main/components/token/index.tsx
@@ -60,11 +60,10 @@ const Styles = {
           ? ColorPalette["skeleton-layer-0"]
           : ColorPalette.white
         : ColorPalette["gray-650"]};
-    padding ${({ forChange }) =>
+    padding: ${({ forChange }) =>
       forChange ? "0.875rem 0.25rem 0.875rem 1rem" : "1rem 0.875rem"};
     border-radius: 0.375rem;
     cursor: ${({ disabled }) => (disabled ? "not-allowed" : "pointer")};
-    
     border: ${({ isError }) =>
       isError
         ? `1.5px solid ${Color(ColorPalette["yellow-400"])
@@ -75,8 +74,8 @@ const Styles = {
     box-shadow: ${(props) =>
       props.theme.mode === "light" && !props.isNotReady
         ? "0px 1px 4px 0px rgba(43, 39, 55, 0.10)"
-        : "none"};;
-    
+        : "none"};
+
     ${({ disabled, theme, disableHoverStyle }) => {
       if (!disableHoverStyle && !disabled) {
         return css`
@@ -88,7 +87,6 @@ const Styles = {
         `;
       }
     }}
-    
   `,
   IconContainer: styled.div`
     color: ${ColorPalette["gray-300"]};

--- a/apps/extension/src/pages/main/components/token/wrapper-with-bottom-tag.tsx
+++ b/apps/extension/src/pages/main/components/token/wrapper-with-bottom-tag.tsx
@@ -71,6 +71,7 @@ export const WrapperwithBottomTag = observer(function ({
         }}
         paddingTop="0.875rem"
         paddingBottom="0.375rem"
+        marginBottom="-0.5rem"
         backgroundColor={
           isLightMode
             ? ColorPalette["green-100"]


### PR DESCRIPTION
### 요구되는 기능
- (USDN 잔고가 존재할 경우) balance의 여러 IBC USDC 토큰 중 가장 상단의 것을 찾아 earn bottom tag에 USDN 잔고 노출

### 기존 구조
- USDN 잔고를 `balances: ViewToken[]`(UI에 노출되는 토큰 목록)으로부터 가져와서 ref에 저장
- 가장 상단의 USDC를 찾기 위해 `AvailableTabView` 컴포넌트의 balance 리스트를 순회하며 null일 경우에 ref에 저장

### 문제
- keyring 교체시에 이전 계정의 ref가 그대로 남아있어 earn bottom tag에 이전 계정의 USDN 잔고가 노출됨

### 고려사항
- 기존 구조상에서 `useEarnBottomTag` 안에서 keyring 교체를 감지하려면 balances가 바뀌었을 때 ref 값들을 초기화해줘야 하는데, 이렇게 변경할 시 home에서 USDC를 검색하면 `balances: ViewToken[]`에 USDN이 없어지고 그로 인해 earn bottom tag에 노출할 USDN 잔고 정보가 소실됨

### 해결 방법
`useEarnBottomTag` hook 리팩토링
- USDN 잔고는 balance 쿼리를 직접 사용
  - keyring 변경시 query가 `useMemo`와 매끄럽게 통합되지 않는 문제로 인해 memoization 하지 않음
- `topUsdcToken`은 `getBottomTagInfoProps` 외부에서 계산해두고 재사용
