### PR TITLE
Prevent unintended cached psbt to be loaded with enhanced simulator key

### DIFF
--- a/apps/extension/src/pages/bitcoin/sign/tx/view.tsx
+++ b/apps/extension/src/pages/bitcoin/sign/tx/view.tsx
@@ -1347,7 +1347,6 @@ const AddressesWithValues: FunctionComponent<{
                 {new CoinPretty(currency, data.value)
                   .trim(true)
                   .maxDecimals(8)
-                  .hideDenom(true)
                   .toString()}
               </Body2>
             </Columns>

--- a/apps/extension/src/pages/bitcoin/sign/tx/view.tsx
+++ b/apps/extension/src/pages/bitcoin/sign/tx/view.tsx
@@ -329,10 +329,6 @@ export const SignBitcoinTxView: FunctionComponent<{
     feeConfig,
   });
 
-  const isReadyToSign =
-    (hasPsbtCandidate && !isFetchingUTXOs && !psbtSimulator.isSimulating) ||
-    isInitialized;
-
   const hasUnableToSignPsbt = validatedPsbts.some(
     (data) => data.inputsToSign.length === 0
   );

--- a/packages/hooks-bitcoin/src/tx/psbt-simulator.ts
+++ b/packages/hooks-bitcoin/src/tx/psbt-simulator.ts
@@ -375,6 +375,7 @@ export class PsbtSimulator extends TxChainSetter implements IPsbtSimulator {
           promise
             .then(({ psbtHex, txSize, remainderValue, remainderStatus }) => {
               if (
+                state.recentPsbtHex === null ||
                 state.recentTxSize === null ||
                 state.recentTxSize > txSize.txVBytes
               ) {


### PR DESCRIPTION
### issue

- 동일한 주소 형식, 동일한 금액으로 번갈아 send 요청을 실행하면 이전에 캐시된 psbt를 불러오는 문제
    1. sendBitcoin 요청으로 1차적으로 bc1p...0x 주소로 1000 satoshi를 보내는 요청을 실행
    2. 서명 페이지에서 reject하고 이번에는 bc1p...dc 주소로 1000 satoshi를 보내는 요청을 실행
    3. 2번의 경우 1번에서 캐시된 Psbt가 불러와지면서 recipient 주소가 bc1p...0x로 처리되는 문제가 발생
    4. 내부 send page에서도 동일하게 발생
- psbt simulator key에 address prefix를 사용해서 native-segwit인지 taproot인지만 구분하게 해서 주소가 변경될 때마다 state를 생성하지 않도록 하려는 의도였지만, 키가 중복됨으로 인해 의도치 않은, 캐시된 Psbt를 불러오는 문제가 발생하는 것을 확인했습니다.

### resolve

- psbt simulator key에 address prefix만 사용했던 것을 주소 전체를 집어넣도록 수정
- sendBitcoin 요청으로 외부에서 들어오는 요청의 경우, simulator key에 요청 id를 추가로 포함하도록 수정
- `sendBitcoin` 요청에서 `isFetchingUTXOs`가 false인 경우에만 시뮬레이션이 실행되도록 수정
    - 기존에는 `availableUTXOs`의 값이 재계산되면서 시뮬레이션이 재실행되어 화면에 표시되는 값이 계속 변경됨
- `usePsbtsValidate` 훅에서 `psbtsHexes`의 변경을 감지하고 검증 로직을 재실행할 수 있도록 수정
