### PR TITLE
Add cosmos-evm pubkey and feature

### DIFF
--- a/packages/chain-validator/src/feature.ts
+++ b/packages/chain-validator/src/feature.ts
@@ -29,7 +29,7 @@ export const SupportedChainFeatures = [
   "evm-ledger-sign-plain-json",
   "initia-dynamicfee",
   "eth-secp256k1-initia",
-  "cosmos-evm",
+  "eth-secp256k1-cosmos",
 ];
 
 /**

--- a/packages/chain-validator/src/feature.ts
+++ b/packages/chain-validator/src/feature.ts
@@ -29,6 +29,7 @@ export const SupportedChainFeatures = [
   "evm-ledger-sign-plain-json",
   "initia-dynamicfee",
   "eth-secp256k1-initia",
+  "cosmos-evm",
 ];
 
 /**

--- a/packages/stores/src/account/cosmos.ts
+++ b/packages/stores/src/account/cosmos.ts
@@ -590,7 +590,7 @@ export class CosmosAccountImpl {
                         return "/stratos.crypto.v1.ethsecp256k1.PubKey";
                       }
 
-                      if (chainInfo.hasFeature("cosmos-evm")) {
+                      if (chainInfo.hasFeature("eth-secp256k1-cosmos")) {
                         return "/cosmos.evm.crypto.v1.ethsecp256k1.PubKey";
                       }
 

--- a/packages/stores/src/account/cosmos.ts
+++ b/packages/stores/src/account/cosmos.ts
@@ -590,11 +590,11 @@ export class CosmosAccountImpl {
                         return "/stratos.crypto.v1.ethsecp256k1.PubKey";
                       }
 
-                      if (chainInfo.hasFeature("eth-secp256k1-initia")) {
+                      if (chainInfo.hasFeature("cosmos-evm")) {
                         return "/cosmos.evm.crypto.v1.ethsecp256k1.PubKey";
                       }
 
-                      if (chainInfo.hasFeature("cosmos-evm")) {
+                      if (chainInfo.hasFeature("eth-secp256k1-initia")) {
                         return "/initia.crypto.v1beta1.ethsecp256k1.PubKey";
                       }
 

--- a/packages/stores/src/account/cosmos.ts
+++ b/packages/stores/src/account/cosmos.ts
@@ -591,8 +591,13 @@ export class CosmosAccountImpl {
                       }
 
                       if (chainInfo.hasFeature("eth-secp256k1-initia")) {
+                        return "/cosmos.evm.crypto.v1.ethsecp256k1.PubKey";
+                      }
+
+                      if (chainInfo.hasFeature("cosmos-evm")) {
                         return "/initia.crypto.v1beta1.ethsecp256k1.PubKey";
                       }
+
                       return "/ethermint.crypto.v1.ethsecp256k1.PubKey";
                     })(),
                     value: PubKey.encode({


### PR DESCRIPTION
Adds Cosmos EVM pubkey support using the new `/cosmos.evm.crypto.v1.ethsecp256k1.PubKey` pubkey.

Proto ref: https://github.com/cosmos/evm/blob/26aa83df0c62e0bd70cef66331430c5a8ba4cf9a/proto/cosmos/evm/crypto/v1/ethsecp256k1/keys.proto#L12