### PR TITLE
Log clicks on search results to Amplitude

### DIFF
--- a/apps/extension/src/analytics-amplitude.ts
+++ b/apps/extension/src/analytics-amplitude.ts
@@ -12,12 +12,15 @@ import { CoinPretty } from "@keplr-wallet/unit";
 import { NOBLE_CHAIN_ID } from "./config.ui";
 import {
   IAccountStore,
+  IChainInfoImpl,
   IChainStore,
   IQueriesStore,
   NobleQueries,
 } from "@keplr-wallet/stores";
 import { KVStore } from "@keplr-wallet/common";
 import { Hash } from "@keplr-wallet/crypto";
+import { ViewToken } from "./pages/main";
+import { ChainInfo, Currency } from "@keplr-wallet/types";
 
 // https://developer.chrome.com/docs/extensions/mv3/tut_analytics/
 export class AmplitudeAnalyticsClient implements AnalyticsClientV2 {
@@ -281,3 +284,43 @@ export const logNobleClaimAnalytics = async (
     Number(claimableAmountDec.toString())
   );
 };
+
+export function getTokenSearchResultClickAnalyticsProperties(
+  viewToken: ViewToken,
+  search: string,
+  balance: (
+    | ViewToken
+    | { currency: Currency; chainInfo: IChainInfoImpl<ChainInfo> }
+  )[], // ibc swap select asset page remaining tokens
+  index: number
+): Properties {
+  return {
+    coinDenom: viewToken.token.currency.coinDenom,
+    chainName: viewToken.chainInfo.chainName,
+    query: search.trim(),
+    searchResultCount: balance.length,
+    index,
+    upperItems: balance
+      .slice(0, index)
+      .slice(-3)
+      .map(
+        (item) =>
+          `${item.chainInfo.chainName}/${
+            "token" in item
+              ? item.token.currency.coinDenom
+              : item.currency.coinDenom
+          }`
+      ),
+    lowerItems: balance
+      .slice(index + 1)
+      .slice(0, 3)
+      .map(
+        (item) =>
+          `${item.chainInfo.chainName}/${
+            "token" in item
+              ? item.token.currency.coinDenom
+              : item.currency.coinDenom
+          }`
+      ),
+  };
+}

--- a/apps/extension/src/analytics-amplitude.ts
+++ b/apps/extension/src/analytics-amplitude.ts
@@ -324,3 +324,19 @@ export function getTokenSearchResultClickAnalyticsProperties(
       ),
   };
 }
+
+export function getChainSearchResultClickAnalyticsProperties(
+  chainName: string,
+  search: string,
+  chainNames: string[],
+  index: number
+): Properties {
+  return {
+    chainName,
+    query: search.trim(),
+    searchResultCount: chainNames.length,
+    index,
+    upperItems: chainNames.slice(0, index).slice(-3),
+    lowerItems: chainNames.slice(index + 1).slice(0, 3),
+  };
+}

--- a/apps/extension/src/pages/main/available.tsx
+++ b/apps/extension/src/pages/main/available.tsx
@@ -501,7 +501,10 @@ export const AvailableTabView: FunctionComponent<{
                 {allBalancesSearchFiltered.length > 0 && (
                   <Gutter size="1rem" direction="vertical" />
                 )}
-                <LookingForChains lookingForChains={searchedLookingForChains} />
+                <LookingForChains
+                  lookingForChains={searchedLookingForChains}
+                  search={search}
+                />
               </React.Fragment>
             )}
 

--- a/apps/extension/src/pages/main/available.tsx
+++ b/apps/extension/src/pages/main/available.tsx
@@ -33,6 +33,7 @@ import { useGetSearchChains } from "../../hooks/use-get-search-chains";
 import { useEarnBottomTag } from "../earn/components/use-earn-bottom-tag";
 import { AdjustmentIcon } from "../../components/icon/adjustment";
 import { useSearch } from "../../hooks/use-search";
+import { getTokenSearchResultClickAnalyticsProperties } from "../../analytics-amplitude";
 
 const zeroDec = new Dec(0);
 
@@ -141,8 +142,13 @@ export const AvailableTabView: FunctionComponent<{
   onMoreTokensClosed: () => void;
 }> = observer(
   ({ search, isNotReady, onClickGetStarted, onMoreTokensClosed }) => {
-    const { hugeQueriesStore, chainStore, accountStore, uiConfigStore } =
-      useStore();
+    const {
+      hugeQueriesStore,
+      chainStore,
+      accountStore,
+      uiConfigStore,
+      analyticsAmplitudeStore,
+    } = useStore();
     const intl = useIntl();
     const theme = useTheme();
     const navigate = useNavigate();
@@ -414,7 +420,7 @@ export const AvailableTabView: FunctionComponent<{
                         />
                       }
                       lenAlwaysShown={lenAlwaysShown}
-                      items={balance.map((viewToken) => {
+                      items={balance.map((viewToken, index) => {
                         const key = `${viewToken.chainInfo.chainId}-${viewToken.token.currency.coinMinimalDenom}`;
                         return (
                           <TokenItem
@@ -422,6 +428,17 @@ export const AvailableTabView: FunctionComponent<{
                             viewToken={viewToken}
                             {...getBottomTagInfoProps(viewToken)}
                             onClick={() => {
+                              if (search.trim().length > 0) {
+                                analyticsAmplitudeStore.logEvent(
+                                  "click_token_item_search_results_available_tab",
+                                  getTokenSearchResultClickAnalyticsProperties(
+                                    viewToken,
+                                    search,
+                                    balance,
+                                    index
+                                  )
+                                );
+                              }
                               setSearchParams((prev) => {
                                 prev.set(
                                   "tokenChainId",

--- a/apps/extension/src/pages/manage-view-asset-token-list/index.tsx
+++ b/apps/extension/src/pages/manage-view-asset-token-list/index.tsx
@@ -27,6 +27,7 @@ import { Modal } from "../../components/modal";
 import { Subtitle3 } from "../../components/typography";
 import { useSearch } from "../../hooks/use-search";
 import { ViewToken } from "../main";
+import { getTokenSearchResultClickAnalyticsProperties } from "../../analytics-amplitude";
 
 const searchFields = [
   {
@@ -43,8 +44,13 @@ const searchFields = [
 ];
 
 export const ManageViewAssetTokenListPage: FunctionComponent = observer(() => {
-  const { hugeQueriesStore, keyRingStore, uiConfigStore, chainStore } =
-    useStore();
+  const {
+    hugeQueriesStore,
+    keyRingStore,
+    uiConfigStore,
+    chainStore,
+    analyticsAmplitudeStore,
+  } = useStore();
   const intl = useIntl();
   const [sortMode, setSortMode] = useState<"asc" | "desc" | undefined>(
     undefined
@@ -253,7 +259,7 @@ export const ManageViewAssetTokenListPage: FunctionComponent = observer(() => {
               </XAxis>
             </Styles.NewTokenFoundButtonContainer>
           )}
-          {sortedBalances.map((viewToken) => {
+          {sortedBalances.map((viewToken, index) => {
             const chainIdentifier = ChainIdHelper.parse(
               viewToken.chainInfo.chainId
             ).identifier;
@@ -264,6 +270,19 @@ export const ManageViewAssetTokenListPage: FunctionComponent = observer(() => {
 
             return (
               <TokenItem
+                onClick={() => {
+                  if (search.trim().length > 0) {
+                    analyticsAmplitudeStore.logEvent(
+                      "click_token_item_search_results_manage_view_asset",
+                      getTokenSearchResultClickAnalyticsProperties(
+                        viewToken,
+                        search,
+                        sortedBalances,
+                        index
+                      )
+                    );
+                  }
+                }}
                 key={`${viewToken.chainInfo.chainId}-${viewToken.token.currency.coinMinimalDenom}`}
                 viewToken={viewToken}
                 disableHoverStyle={true}

--- a/apps/extension/src/pages/send/select-asset/index.tsx
+++ b/apps/extension/src/pages/send/select-asset/index.tsx
@@ -23,6 +23,7 @@ import { YAxis } from "../../../components/axis";
 import { StackIcon } from "../../../components/icon/stack";
 import { useSearch } from "../../../hooks/use-search";
 import { ViewToken } from "../../main";
+import { getTokenSearchResultClickAnalyticsProperties } from "../../../analytics-amplitude";
 
 const Styles = {
   Container: styled(Stack)<{ isNobleEarn: boolean }>`
@@ -46,7 +47,12 @@ const searchFields = [
 ];
 
 export const SendSelectAssetPage: FunctionComponent = observer(() => {
-  const { hugeQueriesStore, skipQueriesStore, chainStore } = useStore();
+  const {
+    hugeQueriesStore,
+    skipQueriesStore,
+    chainStore,
+    analyticsAmplitudeStore,
+  } = useStore();
   const navigate = useNavigate();
   const intl = useIntl();
   const theme = useTheme();
@@ -234,7 +240,7 @@ export const SendSelectAssetPage: FunctionComponent = observer(() => {
           </Box>
         ) : null}
 
-        {filteredTokens.map((viewToken) => {
+        {filteredTokens.map((viewToken, index) => {
           const modularChainInfo = chainStore.getModularChain(
             viewToken.chainInfo.chainId
           );
@@ -254,6 +260,17 @@ export const SendSelectAssetPage: FunctionComponent = observer(() => {
               viewToken={viewToken}
               key={`${viewToken.chainInfo.chainId}-${viewToken.token.currency.coinMinimalDenom}`}
               onClick={() => {
+                if (search.trim().length > 0) {
+                  analyticsAmplitudeStore.logEvent(
+                    "click_token_item_search_results_select_asset_send",
+                    getTokenSearchResultClickAnalyticsProperties(
+                      viewToken,
+                      search,
+                      filteredTokens,
+                      index
+                    )
+                  );
+                }
                 if (paramNavigateTo) {
                   navigate(
                     paramNavigateTo


### PR DESCRIPTION
### Added Events
**Token**
- `click_token_item_search_results_available_tab`
- `click_token_item_search_results_select_asset_send`
- `click_token_item_search_results_select_asset_ibc_swap`
- `click_token_item_search_results_manage_view_asset`

**Chain**
- `click_looking_for_chain_search_results_available_tab`
- `click_looking_for_chain_search_results_deposit_modal`
- `click_copy_address_item_search_results_deposit_modal`
- `click_chain_item_search_results_register`

### Event Property
**공통**
- `query`: 검색어
- `searchResultCount`: 검색 결과의 전체 항목 개수
- `index`: 선택된 항목이 검색 결과의 전체 항목 중 몇 번째인지
- `upperItems`: 선택된 항목의 위 3개의 fields를 각각 join한 array
  - ex. Token - `["usdc/injective", "usdc/osmosis", "usdc/noble"]`
- `lowerItems`: 선택된 항목의 아래 3개의 fields를 각각 join한 array

**Token**
- `coinDenom`
- `chainName`

**Chain**
- `chainName`