### PR TITLE
Fix an issue that parsing ethermint chain id on background

### DIFF
--- a/packages/background/src/chains/service.ts
+++ b/packages/background/src/chains/service.ts
@@ -404,6 +404,16 @@ export class ChainsService {
     }
   );
 
+  getChainInfoByEVMChainIdOrThrow = computedFn(
+    (evmChainId: number): ChainInfo => {
+      const chainInfo = this.getChainInfoByEVMChainId(evmChainId);
+      if (!chainInfo) {
+        throw new Error(`There is no chain info for ${evmChainId}`);
+      }
+      return chainInfo;
+    }
+  );
+
   hasChainInfo(chainId: string): boolean {
     return this.getChainInfo(chainId) != null;
   }

--- a/packages/background/src/keyring-ethereum/service.ts
+++ b/packages/background/src/keyring-ethereum/service.ts
@@ -346,7 +346,7 @@ export class KeyRingEthereumService {
             ).toString("hex")}`;
 
             return {
-              currentEvmChainId: this.parseChainId(currentChainId).evmChainId,
+              currentEvmChainId: this.getEVMChainId(currentChainId),
               currentChainId: currentChainId,
               selectedAddress,
             };
@@ -366,7 +366,7 @@ export class KeyRingEthereumService {
             ).toString("hex")}`;
 
             return {
-              currentEvmChainId: this.parseChainId(currentChainId).evmChainId,
+              currentEvmChainId: this.getEVMChainId(currentChainId),
               currentChainId: currentChainId,
               selectedAddress,
             };
@@ -380,13 +380,11 @@ export class KeyRingEthereumService {
         }
         case "eth_chainId": {
           const currentChainId = this.forceGetCurrentChainId(origin, chainId);
-          return `0x${this.parseChainId(currentChainId).evmChainId.toString(
-            16
-          )}`;
+          return `0x${this.getEVMChainId(currentChainId).toString(16)}`;
         }
         case "net_version": {
           const currentChainId = this.forceGetCurrentChainId(origin, chainId);
-          return this.parseChainId(currentChainId).evmChainId.toString();
+          return this.getEVMChainId(currentChainId).toString();
         }
         case "eth_accounts": {
           const currentChainId = this.getCurrentChainId(origin, chainId);
@@ -443,9 +441,7 @@ export class KeyRingEthereumService {
                 }
               })()
             );
-            if (
-              evmChainIdFromTx !== this.parseChainId(currentChainId).evmChainId
-            ) {
+            if (evmChainIdFromTx !== this.getEVMChainId(currentChainId)) {
               throw new Error(
                 "The current active chain id does not match the one in the transaction."
               );
@@ -473,7 +469,7 @@ export class KeyRingEthereumService {
           const unsignedTx: UnsignedTransaction = {
             ...restTx,
             gasLimit: restTx?.gasLimit ?? gas,
-            chainId: this.parseChainId(currentChainId).evmChainId,
+            chainId: this.getEVMChainId(currentChainId),
             nonce,
           };
 
@@ -537,9 +533,7 @@ export class KeyRingEthereumService {
                 }
               })()
             );
-            if (
-              evmChainIdFromTx !== this.parseChainId(currentChainId).evmChainId
-            ) {
+            if (evmChainIdFromTx !== this.getEVMChainId(currentChainId)) {
               throw new Error(
                 "The current active chain id does not match the one in the transaction."
               );
@@ -567,7 +561,7 @@ export class KeyRingEthereumService {
           const unsignedTx: UnsignedTransaction = {
             ...restTx,
             gasLimit: restTx?.gasLimit ?? gas,
-            chainId: this.parseChainId(currentChainId).evmChainId,
+            chainId: this.getEVMChainId(currentChainId),
             nonce,
           };
 
@@ -1074,8 +1068,10 @@ export class KeyRingEthereumService {
         }
 
         const newEvmChainId = validateEVMChainId(parseInt(param.chainId, 16));
+        const chainInfo =
+          this.chainsService.getChainInfoByEVMChainIdOrThrow(newEvmChainId);
 
-        return `eip155:${newEvmChainId}`;
+        return chainInfo.chainId;
       }
       default: {
         return;
@@ -1103,12 +1099,9 @@ export class KeyRingEthereumService {
     );
   }
 
-  private parseChainId(chainId: string) {
-    const [, evmChainId] = chainId.split(":");
-    const validEVMChainId = validateEVMChainId(parseInt(evmChainId, 10));
+  private getEVMChainId(chainId: string) {
+    const evmInfo = this.chainsService.getEVMInfoOrThrow(chainId);
 
-    return {
-      evmChainId: validEVMChainId,
-    };
+    return evmInfo.chainId;
   }
 }


### PR DESCRIPTION
이더민트 계열의 체인이 `currentChainId`가 되면 chain id를 파싱이 필요한 JSON RPC 요청에서 오류가 남
-> chain id를 직접 파싱하지 않고 chainInfo를 조회하여 `chainInfo.evm.chainId`를 반환하도록 수정