### PR TITLE
Add missing non native chain infos in register enable chains to amplitude logging

### DIFF
--- a/apps/extension/src/pages/register/enable-chains/index.tsx
+++ b/apps/extension/src/pages/register/enable-chains/index.tsx
@@ -1003,12 +1003,6 @@ export const EnableChainsScene: FunctionComponent<{
       !fallbackBitcoinLedgerApp &&
       keyType === "ledger";
 
-    const searchedAllChains = [
-      ...searchedNativeGroupedModularChainInfos,
-      ...searchedSuggestGroupedModularChainInfos,
-      ...(showLedgerChains ? searchedLedgerChains : []),
-    ];
-
     const { chains: searchedNonNativeChainInfos, infiniteScrollTriggerRef } =
       useGetAllNonNativeChain({
         search,
@@ -1016,6 +1010,13 @@ export const EnableChainsScene: FunctionComponent<{
         fallbackStarknetLedgerApp,
         keyType,
       });
+
+    const searchedAllChains = [
+      ...searchedNativeGroupedModularChainInfos,
+      ...searchedSuggestGroupedModularChainInfos,
+      ...(showLedgerChains ? searchedLedgerChains : []),
+      ...searchedNonNativeChainInfos,
+    ];
 
     const numSelected = useMemo(() => {
       const modularChainInfoMap = new Map<string, ModularChainInfo>();


### PR DESCRIPTION
`searchedNonNativeChainInfos`를 빼먹어서 XRPL EVM Testnet의 index가 -1로 기록되고 있었습니다.