### PR TITLE
Rename approve claim tx amplitude event in earn overview page

### DIFF
--- a/apps/extension/src/pages/earn/components/overview-claim-section.tsx
+++ b/apps/extension/src/pages/earn/components/overview-claim-section.tsx
@@ -86,7 +86,7 @@ export const EarnOverviewClaimSection: FunctionComponent<{
               queriesStore,
               accountStore,
               analyticsAmplitudeStore,
-              "noble_earn_claim_yield"
+              "click_approve_btn_usdn_claim_tx_sign"
             );
           },
           onFulfill: (tx: any) => {


### PR DESCRIPTION
이벤트 이름이 정의되지 않았어서 `noble_earn_claim_yield`라는 모호한 이름으로 기록되고 있었습니다.
새로 정의한 이름으로 기록하고, amplitude의 transform -> merge duplicate 기능 이용하여 합치려고 합니다.