### PR TITLE
Fix an issue that use chain identifier on permission ui

### DIFF
--- a/apps/extension/src/pages/permission/basic-access-for-bitcoin/index.tsx
+++ b/apps/extension/src/pages/permission/basic-access-for-bitcoin/index.tsx
@@ -39,8 +39,14 @@ export const PermissionBasicAccessForBitcoinPage: FunctionComponent<{
     },
   });
 
+  const defaultModularChainInfo = chainStore.getModularChain(data.chainIds[0]);
+  const defaultChainId =
+    "bitcoin" in defaultModularChainInfo
+      ? defaultModularChainInfo.bitcoin.chainId
+      : defaultModularChainInfo.chainId;
+
   const [currentChainIdForBitcoin, setCurrentChainIdForBitcoin] =
-    useState<string>(data.chainIds[0]);
+    useState<string>(defaultChainId);
   const [preferredPaymentType, setPreferredPaymentType] = useState<
     SupportedPaymentType | undefined
   >(undefined);
@@ -54,8 +60,8 @@ export const PermissionBasicAccessForBitcoinPage: FunctionComponent<{
 
   // 페이지가 언마운트 되지 않고 data만 바뀌는 경우가 있어서 이렇게 처리함
   useEffect(() => {
-    setCurrentChainIdForBitcoin(data.chainIds[0]);
-  }, [data.chainIds]);
+    setCurrentChainIdForBitcoin(defaultChainId);
+  }, [defaultChainId]);
 
   useEffect(() => {
     const getPreferredPaymentType = async () => {
@@ -254,7 +260,7 @@ export const PermissionBasicAccessForBitcoinPage: FunctionComponent<{
                     chainStore.groupedModularChainInfos.find(
                       (chainInfo) =>
                         "bitcoin" in chainInfo &&
-                        chainInfo.bitcoin.chainId === data.chainIds[0]
+                        chainInfo.bitcoin.chainId === currentChainIdForBitcoin
                     )?.chainName
                   }
                 </Subtitle3>

--- a/packages/background/src/permission/service.ts
+++ b/packages/background/src/permission/service.ts
@@ -210,7 +210,7 @@ export class PermissionService {
       if (
         !this.hasPermission(baseChainId, getBasicAccessPermissionType(), origin)
       ) {
-        ungrantedChainIds.push(baseChainId);
+        ungrantedChainIds.push(chainId);
       }
     }
 


### PR DESCRIPTION
`baseChainId` 가 chain id가 아닌 chain identifier라서 이더민트 계열의 체인의 경우 퍼미션 추가하는 UI에 드롭다운에서 기본 선택이 안되는 문제
-> UI에선 chain identifier가 아닌 chainId를 다루도록 변경