### PR TITLE
Upgrade Starknet Ledger JS library version

### DIFF
--- a/packages/background/package.json
+++ b/packages/background/package.json
@@ -40,7 +40,7 @@
     "@keplr-wallet/types": "0.12.231-rc.0",
     "@keplr-wallet/unit": "0.12.231-rc.0",
     "@ledgerhq/hw-app-eth": "^6.40.3",
-    "@ledgerhq/hw-app-starknet": "^2.4.0",
+    "@ledgerhq/hw-app-starknet": "^2.5.2",
     "@ledgerhq/hw-transport": "^6.31.4",
     "@ledgerhq/hw-transport-webhid": "^6.29.4",
     "@ledgerhq/hw-transport-webusb": "^6.29.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8720,7 +8720,7 @@ __metadata:
     "@keplr-wallet/types": 0.12.231-rc.0
     "@keplr-wallet/unit": 0.12.231-rc.0
     "@ledgerhq/hw-app-eth": ^6.40.3
-    "@ledgerhq/hw-app-starknet": ^2.4.0
+    "@ledgerhq/hw-app-starknet": ^2.5.2
     "@ledgerhq/hw-transport": ^6.31.4
     "@ledgerhq/hw-transport-webhid": ^6.29.4
     "@ledgerhq/hw-transport-webusb": ^6.29.4
@@ -9905,15 +9905,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ledgerhq/hw-app-starknet@npm:^2.4.0":
-  version: 2.4.0
-  resolution: "@ledgerhq/hw-app-starknet@npm:2.4.0"
+"@ledgerhq/hw-app-starknet@npm:^2.5.2":
+  version: 2.5.2
+  resolution: "@ledgerhq/hw-app-starknet@npm:2.5.2"
   dependencies:
     "@ledgerhq/hw-transport": ^6.31.2
     "@types/bn.js": ^5.1.1
     bn.js: ^5.2.1
-    starknet: ^6.11.0
-  checksum: 74a3376d17c8c34042b4973c978c875e774eff31d3a9e18af8596ea692bdc09c9a0ccaa13494ec3fc18bba05b69993dea47f80b926563d1078e88cfbcbe351f2
+  peerDependencies:
+    starknet: ^6.24.1
+  checksum: 4deef68b21b775f73bc3f6c508e2870138547bd3d14790b6bfdc8088bdeeb35ab18c73365cbf8b535a720bb0f55e1dfcd08c6c597b15d9a17e70ae5194e751b0
   languageName: node
   linkType: hard
 
@@ -16643,20 +16644,6 @@ __metadata:
   bin:
     generate: dist/generate.js
   checksum: 4cf69171887c243a4b5857653f791f3b2042eba93a7326fe03120355cb9f0e29944b91650f96ad739bffad7d8ec9d88c71eeb0debe57df3cd905a1b7c9c2c4a8
-  languageName: node
-  linkType: hard
-
-"abi-wan-kanabi@npm:^2.2.3":
-  version: 2.2.3
-  resolution: "abi-wan-kanabi@npm:2.2.3"
-  dependencies:
-    ansicolors: ^0.3.2
-    cardinal: ^2.1.1
-    fs-extra: ^10.0.0
-    yargs: ^17.7.2
-  bin:
-    generate: dist/generate.js
-  checksum: b1b4bb9a8e721dcab643d47db532814e2b71a3148544495326aea52f60d594d14d1e05b8b9d33b2aed39a083acbc928b589f029ac0b0dde070972c3ba54ad292
   languageName: node
   linkType: hard
 
@@ -40765,25 +40752,6 @@ __metadata:
     ts-mixer: ^6.0.3
     url-join: ^4.0.1
   checksum: 997c4a9efad53b0c25d0402c2dcd4e334b83865389ea29791f72ac757e0d9a216cf4634c6fbd5d33154e26389d499d39d893cf52302ec6b4eb9d7f04c034b579
-  languageName: node
-  linkType: hard
-
-"starknet@npm:^6.11.0":
-  version: 6.17.0
-  resolution: "starknet@npm:6.17.0"
-  dependencies:
-    "@noble/curves": ~1.3.0
-    "@noble/hashes": ~1.3.0
-    "@scure/base": ~1.1.3
-    "@scure/starknet": ~1.0.0
-    abi-wan-kanabi: ^2.2.3
-    fetch-cookie: ^3.0.0
-    isomorphic-fetch: ^3.0.0
-    lossless-json: ^4.0.1
-    pako: ^2.0.4
-    starknet-types-07: "npm:@starknet-io/types-js@^0.7.7"
-    ts-mixer: ^6.0.3
-  checksum: e90d7145d9b225badf77d01edf635db117c4a6906136677522ad5e0cc8b7e79c262f2dc336189cb3b81e2f4fea2b58ed81f38b166c2314d196fccad4742eb3d8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
최신 버전(2.3.1)의 Starknet Ledger app을 사용하는 유저는 케플러로 Starknet 트랜잭션 서명이 불가한 이슈
-> 케플러에서 사용하는 Starknet Ledger JS 라이브러리 버전을 최신으로 변경해서 해결