### PR TITLE
Normalize ERC20 token's `coinMinimalDenom`

### DIFF
--- a/packages/common/src/denom/index.ts
+++ b/packages/common/src/denom/index.ts
@@ -24,6 +24,16 @@ export class DenomHelper {
         .toUpperCase()
     );
   }
+  static normalizeDenom(denom: string): string {
+    const denomHelper = new DenomHelper(denom);
+
+    switch (denomHelper.type) {
+      case "erc20":
+        return `erc20:${denomHelper.contractAddress.toLowerCase()}`;
+      default:
+        return denomHelper.denom;
+    }
+  }
 
   protected readonly _type: string;
   protected readonly _contractAddress: string;

--- a/packages/stores-eth/src/queries/erc20-balances.ts
+++ b/packages/stores-eth/src/queries/erc20-balances.ts
@@ -112,9 +112,10 @@ export class ObservableQueryThirdpartyERC20BalancesImpl
       return new CoinPretty(currency, new Int(0)).ready(false);
     }
 
-    const contractAddress = this.denomHelper.denom.replace("erc20:", "");
     const tokenBalance = this.response.data.tokenBalances.find(
-      (bal) => bal.contractAddress === contractAddress
+      (bal) =>
+        DenomHelper.normalizeDenom(`erc20:${bal.contractAddress}`) ===
+        DenomHelper.normalizeDenom(this.denomHelper.denom)
     );
     if (tokenBalance?.tokenBalance == null) {
       return new CoinPretty(currency, new Int(0)).ready(false);


### PR DESCRIPTION
각 체인 정보에 추가된 ERC20 currency 중에 contract address가 mixed-case인 경우와 lower-case인 경우가 중복으로 보이는 문제가 있음
-> chain store, background chain service, erc20 balances query에서 정보를 조회하는 로직에서 coinMinimalDenom을 lower-case로 하여 조회하도록 수정