### PR TITLE
Resolve other account's bitcoin address are cached on mobile

### DIFF
--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -190,6 +190,7 @@ export class AccountSetBase {
             this._bech32Address = key.bech32Address;
             this._ethereumHexAddress = key.ethereumHexAddress;
             this._starknetHexAddress = "";
+            this._bitcoinAddress = undefined;
             this._isNanoLedger = key.isNanoLedger;
             this._isKeystone = key.isKeystone;
             this._name = key.name;
@@ -212,6 +213,7 @@ export class AccountSetBase {
             this._bech32Address = "";
             this._ethereumHexAddress = "";
             this._starknetHexAddress = key.hexAddress;
+            this._bitcoinAddress = undefined;
             this._isNanoLedger = key.isNanoLedger;
             this._isKeystone = false;
             this._name = key.name;
@@ -226,6 +228,7 @@ export class AccountSetBase {
           this._bech32Address = "";
           this._ethereumHexAddress = "";
           this._starknetHexAddress = "";
+          this._bitcoinAddress = undefined;
           this._isNanoLedger = false;
           this._isKeystone = false;
           this._name = "";


### PR DESCRIPTION
- 익스텐션에서는 enable chains 페이지가 새로운 웹페이지에서 열리므로 콘텍스트가 달라져서 새로 getKey 요청이 들어가기 때문에 문제가 없지만, 
- 모바일은 동일한 콘텍스트에서 enable chains 페이지가 열리므로 캐시된 키를 사용
- 따라서 비트코인 키 정보가 존재하지 않거나 다른 유형의 키인 경우 undefined 처리를 하도록 추가했습니다.