### PR TITLE
Fix broken link to CosmJS offline signers section in get-key guide

### DIFF
--- a/docs/docs/guide/get-key.md
+++ b/docs/docs/guide/get-key.md
@@ -50,7 +50,7 @@ interface Key {
 
 :::info
 Hardware Wallet Support:
-- Ledger wallets typically use the Amino JSON sign mode due to limited support for Protobuf-based SIGN_MODE_DIRECT. Check more details [here](../use-with/cosmjs#types-of-offline-signers).
+- Ledger wallets typically use the Amino JSON sign mode due to limited support for Protobuf-based SIGN_MODE_DIRECT. Check more details [here](../use-with/cosmjs.md#types-of-offline-signers).
 - Use the `isNanoLedger` and `isKeystone` properties to determine the appropriate signing mode for hardware wallets.
 :::
 


### PR DESCRIPTION
This commit updates the hardware wallet support info in docs/docs/guide/get-key.md by correcting the link to the "Types of Offline Signers" section in the CosmJS integration guide. The previous link was broken due to a missing .md extension. The new link now correctly points to ../use-with/cosmjs.md#types-of-offline-signers, ensuring users can access the relevant documentation about offline signers and hardware wallet compatibility.