### PR TITLE
Fix starknet amount config cannot identify custom tokens

### DIFF
--- a/packages/hooks-starknet/src/tx/amount.ts
+++ b/packages/hooks-starknet/src/tx/amount.ts
@@ -127,21 +127,23 @@ export class AmountConfig extends TxChainSetter implements IAmountConfig {
 
   @computed
   get currency(): ERC20Currency {
-    const modularChainInfo = this.modularChainInfo;
-    if (!("starknet" in modularChainInfo)) {
+    const modularChainInfoImpl = this.modularChainInfo;
+    if (!("starknet" in modularChainInfoImpl.embedded)) {
       throw new Error("Chain doesn't support the starknet");
     }
 
+    const currencies = modularChainInfoImpl.getCurrencies("starknet");
+
     if (this._currency) {
-      const find = modularChainInfo.starknet.currencies.find(
+      const find = currencies.find(
         (cur) => cur.coinMinimalDenom === this._currency!.coinMinimalDenom
       );
       if (find) {
-        return find;
+        return find as ERC20Currency;
       }
     }
 
-    return modularChainInfo.starknet.currencies[0];
+    return currencies[0] as ERC20Currency;
   }
 
   @action
@@ -164,13 +166,15 @@ export class AmountConfig extends TxChainSetter implements IAmountConfig {
   }
 
   canUseCurrency(currency: ERC20Currency): boolean {
-    const modularChainInfo = this.modularChainInfo;
-    if (!("starknet" in modularChainInfo)) {
+    const modularChainInfoImpl = this.modularChainInfo;
+    if (!("starknet" in modularChainInfoImpl.embedded)) {
       throw new Error("Chain doesn't support the starknet");
     }
 
+    const currencies = modularChainInfoImpl.getCurrencies("starknet");
+
     return (
-      modularChainInfo.starknet.currencies.find(
+      currencies.find(
         (cur) => cur.coinMinimalDenom === currency.coinMinimalDenom
       ) != null
     );

--- a/packages/hooks-starknet/src/tx/chain.ts
+++ b/packages/hooks-starknet/src/tx/chain.ts
@@ -1,7 +1,6 @@
 import { action, computed, makeObservable, observable } from "mobx";
-import { ChainGetter } from "@keplr-wallet/stores";
+import { ChainGetter, IModularChainInfoImpl } from "@keplr-wallet/stores";
 import { ITxChainSetter } from "./types";
-import { ModularChainInfo } from "@keplr-wallet/types";
 
 export class TxChainSetter implements ITxChainSetter {
   @observable
@@ -17,8 +16,8 @@ export class TxChainSetter implements ITxChainSetter {
   }
 
   @computed
-  get modularChainInfo(): ModularChainInfo {
-    return this.chainGetter.getModularChain(this.chainId);
+  get modularChainInfo(): IModularChainInfoImpl {
+    return this.chainGetter.getModularChainInfoImpl(this.chainId);
   }
 
   get chainId(): string {

--- a/packages/hooks-starknet/src/tx/name-service-starknet-id.ts
+++ b/packages/hooks-starknet/src/tx/name-service-starknet-id.ts
@@ -92,7 +92,10 @@ export class StarknetIdNameService implements NameService {
   }
 
   get isEnabled(): boolean {
-    if (!this._starknetID || !("starknet" in this.base.modularChainInfo)) {
+    if (
+      !this._starknetID ||
+      !("starknet" in this.base.modularChainInfo.embedded)
+    ) {
       return false;
     }
 
@@ -162,10 +165,13 @@ export class StarknetIdNameService implements NameService {
   protected async fetchInternal(): Promise<void> {
     const prevValue = this.value;
     try {
-      const modularChainInfo = this.base.modularChainInfo;
-      if (!("starknet" in modularChainInfo)) {
-        throw new Error(`${modularChainInfo.chainId} is not starknet chain`);
+      const modularChainInfoImpl = this.base.modularChainInfo;
+      if (!("starknet" in modularChainInfoImpl.embedded)) {
+        throw new Error(
+          `${modularChainInfoImpl.chainId} is not starknet chain`
+        );
       }
+
       if (!this._starknetID) {
         throw new Error("Starknet id is not set");
       }
@@ -186,7 +192,7 @@ export class StarknetIdNameService implements NameService {
           code?: number;
           message?: string;
         };
-      }>(modularChainInfo.starknet.rpc, "", {
+      }>(modularChainInfoImpl.embedded.starknet.rpc, "", {
         method: "POST",
         headers: {
           "content-type": "application/json",

--- a/packages/hooks-starknet/src/tx/noop-amount.ts
+++ b/packages/hooks-starknet/src/tx/noop-amount.ts
@@ -44,12 +44,12 @@ export class NoopAmountConfig extends TxChainSetter implements IAmountConfig {
 
   @computed
   get currency(): ERC20Currency {
-    const modularChainInfo = this.modularChainInfo;
-    if (!("starknet" in modularChainInfo)) {
+    const modularChainInfoImpl = this.modularChainInfo;
+    if (!("starknet" in modularChainInfoImpl.embedded)) {
       throw new Error("Chain doesn't support the starknet");
     }
 
-    return modularChainInfo.starknet.currencies[0];
+    return modularChainInfoImpl.getCurrencies("starknet")[0] as ERC20Currency;
   }
 
   @action

--- a/packages/hooks-starknet/src/tx/recipient.ts
+++ b/packages/hooks-starknet/src/tx/recipient.ts
@@ -123,8 +123,8 @@ export class RecipientConfig
 
     const rawRecipient = this.value.trim();
 
-    const modularChainInfo = this.modularChainInfo;
-    if (!("starknet" in modularChainInfo)) {
+    const modularChainInfoImpl = this.modularChainInfo;
+    if (!("starknet" in modularChainInfoImpl.embedded)) {
       throw new Error("Chain doesn't support the starknet");
     }
 

--- a/packages/hooks-starknet/src/tx/types.ts
+++ b/packages/hooks-starknet/src/tx/types.ts
@@ -1,11 +1,12 @@
-import { ERC20Currency, ModularChainInfo } from "@keplr-wallet/types";
+import { ERC20Currency } from "@keplr-wallet/types";
 import { CoinPretty } from "@keplr-wallet/unit";
 import { NameService } from "./name-service";
+import { IModularChainInfoImpl } from "@keplr-wallet/stores";
 
 export interface ITxChainSetter {
   chainId: string;
   setChain(chainId: string): void;
-  modularChainInfo: ModularChainInfo;
+  modularChainInfo: IModularChainInfoImpl;
 }
 
 export interface UIProperties {


### PR DESCRIPTION
- `hooks-starknet`의 ModularChainInfo 사용을 IModularChainInfoImpl로 변경