### PR TITLE
Implement `getInscriptions` bitcoin wallet api

### DIFF
--- a/docs/docs/multi-ecosystem-support/bitcoin.md
+++ b/docs/docs/multi-ecosystem-support/bitcoin.md
@@ -148,7 +148,64 @@ await window.bitcoin_keplr.getBalance()
 
 ### getInscriptions
 
-**Not implemented yet.**
+#### Interface
+
+```typescript
+interface Inscription {
+  id: string; // Unique identifier
+  inscriptionId: string; // Ordinal inscription ID
+  content: string; // Content data
+  number: number; // Inscription number
+  address: string; // Current owner address
+  contentType: string; // MIME type of content
+  output: string; // UTXO containing the inscription
+  location: string; // Location within the UTXO
+  genesisTransaction: string; // Transaction where inscription was created
+  height: number; // Block height of inscription
+  preview: string; // Preview URL if available
+  outputValue: number; // Value of the UTXO
+  offset?: number; // Offset within the UTXO
+}
+```
+
+```typescript
+interface KeplrBitcoinProvider {
+  getInscriptions: (offset?: number, limit?: number) => Promise<{
+    total: number;
+    list: Inscription[];
+  }>; // return a list of inscriptions with total count
+}
+```
+
+#### Example
+
+```typescript
+await window.bitcoin_keplr.getInscriptions(0, 20)
+// {
+//   total: 20,
+//   list: [
+//     {
+//       id: "1",
+//       content: "https://example.com/content",
+//       contentType: "text/plain;charset=utf-8",
+//       output: "txid:outputIndex",
+//       location: "txid:outputIndex:satIndex",
+//       genesisTransaction: "genesis_txid",
+//       height: 892836,
+//       preview: "",
+//       outputValue: 100000000,
+//       offset: satIndex,
+//     },
+//     ...
+//   ]
+// }
+```
+
+**Note:**
+
+- `offset` is the offset of the inscriptions list. It must be a multiple of 20.
+- `limit` is the limit of the inscriptions list. It must be between 20 and 2000.
+
 
 ## Getting Network Info and Switching Current Network
 

--- a/packages/background/src/keyring-bitcoin/constants.ts
+++ b/packages/background/src/keyring-bitcoin/constants.ts
@@ -32,3 +32,21 @@ export const signet = {
   ...testnet,
   id: Network.SIGNET,
 };
+
+export enum BitcoinInscriptionsApiUrl {
+  MAINNET = "https://mainnet-btc-inscriptions.keplr.app",
+  TESTNET = "https://testnet-btc-inscriptions.keplr.app",
+  SIGNET = "https://signet-btc-inscriptions.keplr.app",
+}
+
+export const getBitcoinInscriptionsApiUrl = (network: Network) => {
+  switch (network) {
+    case Network.LIVENET:
+    case Network.MAINNET:
+      return BitcoinInscriptionsApiUrl.MAINNET;
+    case Network.TESTNET:
+      return BitcoinInscriptionsApiUrl.TESTNET;
+    case Network.SIGNET:
+      return BitcoinInscriptionsApiUrl.SIGNET;
+  }
+};

--- a/packages/background/src/keyring-bitcoin/handler.ts
+++ b/packages/background/src/keyring-bitcoin/handler.ts
@@ -415,7 +415,7 @@ const handleRequestBitcoinGetInscriptionsMsg: (
   return async (env, msg) => {
     await permissionInteractionService.ensureEnabledForBitcoin(env, msg.origin);
 
-    return await service.getInscriptions();
+    return await service.getInscriptions(msg.origin, msg.offset, msg.limit);
   };
 };
 

--- a/packages/background/src/keyring-bitcoin/messages.ts
+++ b/packages/background/src/keyring-bitcoin/messages.ts
@@ -6,6 +6,7 @@ import {
   SupportedPaymentType,
   Network as BitcoinNetwork,
   ChainType as BitcoinChainType,
+  Inscription,
 } from "@keplr-wallet/types";
 import { ROUTE } from "./constants";
 import { Psbt } from "bitcoinjs-lib";
@@ -529,17 +530,30 @@ export class RequestBitcoinGetBalanceMsg extends Message<{
   }
 }
 
-export class RequestBitcoinGetInscriptionsMsg extends Message<void> {
+export class RequestBitcoinGetInscriptionsMsg extends Message<{
+  total: number;
+  list: Inscription[];
+}> {
   public static type() {
     return "request-bitcoin-get-inscriptions";
   }
 
-  constructor() {
+  constructor(public readonly offset?: number, public readonly limit?: number) {
     super();
   }
 
   validateBasic(): void {
-    // noop
+    if (this.offset && this.offset < 0) {
+      throw new Error("offset must be greater than or equal to 0");
+    }
+
+    if (this.offset && this.offset % 20 !== 0) {
+      throw new Error("offset must be a multiple of 20");
+    }
+
+    if (this.limit && (this.limit < 20 || this.limit > 2000)) {
+      throw new Error("limit must be between 20 and 2000");
+    }
   }
 
   override approveExternal(): boolean {

--- a/packages/background/src/keyring-bitcoin/rate-limiter.test.ts
+++ b/packages/background/src/keyring-bitcoin/rate-limiter.test.ts
@@ -1,0 +1,104 @@
+import { RateLimiter } from "./rate-limiter";
+
+describe("RateLimiter", () => {
+  let rateLimiter: RateLimiter;
+
+  beforeEach(() => {
+    rateLimiter = new RateLimiter({
+      interval: 1000,
+      maxRequests: 2,
+      timeout: 5000,
+    });
+  });
+
+  it("should execute requests within rate limit immediately", async () => {
+    const startTime = Date.now();
+
+    const results = await Promise.all([
+      rateLimiter.add(() => Promise.resolve("request1")),
+      rateLimiter.add(() => Promise.resolve("request2")),
+    ]);
+
+    const endTime = Date.now();
+    const duration = endTime - startTime;
+
+    expect(results).toEqual(["request1", "request2"]);
+    expect(duration).toBeLessThan(100); // immediately executed 2 requests
+  });
+
+  it("should delay requests that exceed rate limit", async () => {
+    const startTime = Date.now();
+
+    // 3 requests (limit is 2)
+    const results = await Promise.all([
+      rateLimiter.add(() => Promise.resolve("request1")),
+      rateLimiter.add(() => Promise.resolve("request2")),
+      rateLimiter.add(() => Promise.resolve("request3")), // this request will be delayed
+    ]);
+
+    const endTime = Date.now();
+    const duration = endTime - startTime;
+
+    expect(results).toEqual(["request1", "request2", "request3"]);
+    expect(duration).toBeGreaterThan(900); // approximately 1 second delay
+  });
+
+  it("should handle requests in FIFO order", async () => {
+    const results: string[] = [];
+
+    // add requests in order
+    const firstPromise = rateLimiter.add(() => {
+      results.push("first");
+      return Promise.resolve("first");
+    });
+
+    const secondPromise = rateLimiter.add(() => {
+      results.push("second");
+      return Promise.resolve("second");
+    });
+
+    await Promise.all([firstPromise, secondPromise]);
+
+    // requests should be executed in FIFO order
+    expect(results[0]).toBe("first");
+    expect(results[1]).toBe("second");
+  });
+
+  it("should handle timeout correctly", async () => {
+    const rateLimiterWithShortTimeout = new RateLimiter({
+      interval: 1000,
+      maxRequests: 1,
+      timeout: 100, // 100ms timeout
+    });
+
+    // use rate limit for the first request
+    await rateLimiterWithShortTimeout.add(() => Promise.resolve("first"));
+
+    // second request will be timeout
+    await expect(
+      rateLimiterWithShortTimeout.add(
+        () =>
+          new Promise((resolve) => setTimeout(() => resolve("timeout"), 200)),
+        { timeout: 100 }
+      )
+    ).rejects.toThrow("Request timeout");
+  });
+
+  it("should handle API errors correctly", async () => {
+    const error = new Error("API Error");
+
+    await expect(rateLimiter.add(() => Promise.reject(error))).rejects.toThrow(
+      "API Error"
+    );
+  });
+
+  it("should track queue size correctly", () => {
+    expect(rateLimiter.getQueueSize()).toBe(0);
+
+    // add request to the queue (not await)
+    rateLimiter.add(() => new Promise((resolve) => setTimeout(resolve, 100)));
+    rateLimiter.add(() => new Promise((resolve) => setTimeout(resolve, 100)));
+
+    expect(rateLimiter.getQueueSize()).toBeGreaterThan(0);
+  });
+});

--- a/packages/background/src/keyring-bitcoin/rate-limiter.ts
+++ b/packages/background/src/keyring-bitcoin/rate-limiter.ts
@@ -1,0 +1,132 @@
+export interface RateLimiterOptions {
+  interval: number;
+  maxRequests: number;
+  timeout?: number;
+}
+
+export interface QueuedRequest<T> {
+  fn: () => Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: Error) => void;
+  addedAt: number;
+}
+
+export const DEFAULT_RATE_LIMIT_TIMEOUT = 30000;
+
+export class RateLimiter {
+  private queue: QueuedRequest<any>[] = [];
+  private processing = false;
+  private requestHistory: number[] = [];
+  private readonly options: Required<RateLimiterOptions>;
+
+  constructor(options: RateLimiterOptions) {
+    this.options = {
+      timeout: DEFAULT_RATE_LIMIT_TIMEOUT,
+      ...options,
+    };
+  }
+
+  async add<T>(
+    fn: () => Promise<T>,
+    options?: { timeout?: number }
+  ): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const timeout = options?.timeout ?? this.options.timeout;
+      const addedAt = Date.now();
+
+      // set timeout
+      const timeoutId = setTimeout(() => {
+        // remove from queue
+        const index = this.queue.findIndex((req) => req.addedAt === addedAt);
+        if (index !== -1) {
+          this.queue.splice(index, 1);
+        }
+        reject(new Error("Request timeout"));
+      }, timeout);
+
+      const queuedRequest: QueuedRequest<T> = {
+        fn,
+        resolve: (value: T) => {
+          clearTimeout(timeoutId);
+          resolve(value);
+        },
+        reject: (error: Error) => {
+          clearTimeout(timeoutId);
+          reject(error);
+        },
+        addedAt,
+      };
+
+      this.queue.push(queuedRequest);
+
+      this.processQueue();
+    });
+  }
+
+  private async processQueue(): Promise<void> {
+    if (this.processing || this.queue.length === 0) {
+      return;
+    }
+
+    this.processing = true;
+
+    while (this.queue.length > 0) {
+      // check rate limit
+      await this.waitIfNeeded();
+
+      const request = this.queue.shift();
+      if (!request) break;
+
+      try {
+        // record request before execution
+        this.requestHistory.push(Date.now());
+
+        const result = await request.fn();
+        request.resolve(result);
+      } catch (error) {
+        request.reject(
+          error instanceof Error ? error : new Error(String(error))
+        );
+      }
+    }
+
+    this.processing = false;
+  }
+
+  private async waitIfNeeded(): Promise<void> {
+    const now = Date.now();
+
+    // remove expired request history
+    this.requestHistory = this.requestHistory.filter(
+      (timestamp) => now - timestamp < this.options.interval
+    );
+
+    // check rate limit
+    if (this.requestHistory.length >= this.options.maxRequests) {
+      const oldestRequest = this.requestHistory[0];
+      const waitTime = this.options.interval - (now - oldestRequest);
+
+      if (waitTime > 0) {
+        await this.delay(waitTime);
+      }
+    }
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  getQueueSize(): number {
+    return this.queue.length;
+  }
+
+  getPendingRequests(): number {
+    return this.requestHistory.length;
+  }
+}
+
+export const bitcoinInscriptionsRateLimiter = new RateLimiter({
+  interval: 1000,
+  maxRequests: 10,
+  timeout: 5000,
+});

--- a/packages/background/src/keyring-bitcoin/service.ts
+++ b/packages/background/src/keyring-bitcoin/service.ts
@@ -14,6 +14,7 @@ import {
   GENESIS_HASH_TO_CHAIN_TYPE,
   CHAIN_TYPE_TO_GENESIS_HASH,
   SignPsbtOptions,
+  Inscription,
 } from "@keplr-wallet/types";
 import { Env, KeplrError, WEBPAGE_PORT } from "@keplr-wallet/router";
 import { Psbt, address } from "bitcoinjs-lib";
@@ -25,7 +26,12 @@ import { BackgroundTxService } from "../tx";
 import validate, {
   Network as BitcoinNetwork,
 } from "bitcoin-address-validation";
-import { mainnet, signet, testnet } from "./constants";
+import {
+  getBitcoinInscriptionsApiUrl,
+  mainnet,
+  signet,
+  testnet,
+} from "./constants";
 import { AnalyticsService } from "../analytics";
 import { KVStore } from "@keplr-wallet/common";
 import { action, autorun, makeObservable, observable, runInAction } from "mobx";
@@ -726,8 +732,101 @@ export class KeyRingBitcoinService {
     };
   }
 
-  async getInscriptions() {
-    throw new Error("Not implemented.");
+  async getInscriptions(origin: string, offset = 0, limit = 20) {
+    const currentChainId = this.forceGetCurrentChainId(origin);
+    const bitcoinKey = await this.getBitcoinKeySelected(currentChainId);
+
+    const network = this.getNetworkConfig(currentChainId).id;
+
+    const apiUrl = getBitcoinInscriptionsApiUrl(network);
+
+    const params = new URLSearchParams();
+    params.append("sort_by", "inscr_num");
+    params.append("order", "desc");
+    params.append("exclude_brc20", "false");
+    params.append("address", bitcoinKey.address);
+    params.append("offset", offset.toString());
+    params.append("count", limit.toString());
+
+    const res = await simpleFetch<{
+      data: Array<{
+        inscription_name?: string;
+        inscription_id: string;
+        inscription_number: number;
+        parent_ids: string[];
+        output_value: number;
+        genesis_block_hash: string;
+        genesis_ts: string;
+        genesis_height: number;
+        metadata: any;
+        mime_type?: string;
+        owner_wallet_addr: string;
+        last_sale_price?: number;
+        slug?: string;
+        collection_name?: string;
+        satpoint: string;
+        last_transfer_block_height?: number;
+        content_url: string;
+        bis_url: string;
+        render_url?: string;
+        bitmap_number?: number;
+        delegate?: {
+          delegate_id: string;
+          render_url?: string;
+          mime_type?: string;
+          content_url: string;
+          bis_url: string;
+        };
+      }>;
+      block_height: number;
+    }>(`${apiUrl}/wallet/inscriptions?${params.toString()}`);
+
+    if (res.status === 429) {
+      throw new Error("Rate limit exceeded, 10 requests per minute");
+    }
+
+    if (res.status !== 200) {
+      throw new Error("Failed to get inscriptions");
+    }
+
+    const list: Inscription[] = [];
+
+    for (const item of res.data.data) {
+      const {
+        inscription_id,
+        inscription_number,
+        owner_wallet_addr,
+        mime_type,
+        satpoint,
+        output_value,
+        genesis_height,
+        content_url,
+        render_url,
+      } = item;
+
+      const [txid, outputIndex, satIndex] = satpoint.split(":");
+
+      list.push({
+        id: inscription_id,
+        inscriptionId: inscription_id,
+        content: content_url,
+        number: inscription_number,
+        address: owner_wallet_addr,
+        contentType: mime_type ?? "",
+        output: `${txid}:${outputIndex}`,
+        location: satpoint,
+        genesisTransaction: txid,
+        height: genesis_height,
+        preview: render_url ?? "",
+        outputValue: output_value,
+        offset: parseInt(satIndex, 10),
+      });
+    }
+
+    return {
+      total: list.length,
+      list,
+    };
   }
 
   async sendBitcoin(

--- a/packages/background/src/keyring-bitcoin/service.ts
+++ b/packages/background/src/keyring-bitcoin/service.ts
@@ -732,7 +732,7 @@ export class KeyRingBitcoinService {
     };
   }
 
-  async getInscriptions(origin: string, offset = 0, limit = 20) {
+  async getInscriptions(origin: string, offset?: number, limit?: number) {
     const currentChainId = this.forceGetCurrentChainId(origin);
     const bitcoinKey = await this.getBitcoinKeySelected(currentChainId);
 
@@ -745,8 +745,8 @@ export class KeyRingBitcoinService {
     params.append("order", "desc");
     params.append("exclude_brc20", "false");
     params.append("address", bitcoinKey.address);
-    params.append("offset", offset.toString());
-    params.append("count", limit.toString());
+    params.append("offset", offset?.toString() ?? "0");
+    params.append("count", limit?.toString() ?? "20");
 
     const res = await simpleFetch<{
       data: Array<{

--- a/packages/provider-extension/src/keplr.ts
+++ b/packages/provider-extension/src/keplr.ts
@@ -30,6 +30,7 @@ import {
   ChainType as BitcoinChainType,
   Network as BitcoinNetwork,
   BitcoinSignMessageType,
+  Inscription,
 } from "@keplr-wallet/types";
 import { JSONUint8Array } from "./uint8-array";
 import deepmerge from "deepmerge";
@@ -1155,8 +1156,11 @@ export class BitcoinProvider extends EventEmitter implements IBitcoinProvider {
     return BitcoinProvider._requestMethod("getBalance", []);
   }
 
-  async getInscriptions(): Promise<string[]> {
-    return BitcoinProvider._requestMethod("getInscriptions", []);
+  async getInscriptions(
+    offset?: number,
+    limit?: number
+  ): Promise<{ total: number; list: Inscription[] }> {
+    return BitcoinProvider._requestMethod("getInscriptions", [offset, limit]);
   }
 
   async signMessage(

--- a/packages/provider/src/core.ts
+++ b/packages/provider/src/core.ts
@@ -28,6 +28,7 @@ import {
   BitcoinSignMessageType,
   ChainType as BitcoinChainType,
   SignPsbtOptions,
+  Inscription,
 } from "@keplr-wallet/types";
 import {
   BACKGROUND_PORT,
@@ -2048,7 +2049,10 @@ class BitcoinProvider extends EventEmitter implements IBitcoinProvider {
     );
   }
 
-  async getInscriptions(): Promise<string[]> {
+  async getInscriptions(
+    offset?: number,
+    limit?: number
+  ): Promise<{ total: number; list: Inscription[] }> {
     await this.protectedEnableAccess();
 
     return await sendSimpleMessage(
@@ -2056,7 +2060,10 @@ class BitcoinProvider extends EventEmitter implements IBitcoinProvider {
       BACKGROUND_PORT,
       "keyring-bitcoin",
       "request-bitcoin-get-inscriptions",
-      {}
+      {
+        offset,
+        limit,
+      }
     );
   }
 

--- a/packages/provider/src/inject.ts
+++ b/packages/provider/src/inject.ts
@@ -34,6 +34,7 @@ import {
   BitcoinSignMessageType,
   ChainType as BitcoinChainType,
   SignPsbtOptions,
+  Inscription,
 } from "@keplr-wallet/types";
 import {
   Result,
@@ -1837,8 +1838,11 @@ export class BitcoinProvider extends EventEmitter implements IBitcoinProvider {
     return this._requestMethod("getBalance", []);
   }
 
-  async getInscriptions(): Promise<string[]> {
-    return this._requestMethod("getInscriptions", []);
+  async getInscriptions(
+    offset?: number,
+    limit?: number
+  ): Promise<{ total: number; list: Inscription[] }> {
+    return this._requestMethod("getInscriptions", [offset, limit]);
   }
 
   async signMessage(

--- a/packages/types/src/wallet/bitcoin.ts
+++ b/packages/types/src/wallet/bitcoin.ts
@@ -63,6 +63,22 @@ export type SignPsbtOptions = {
   }>;
 };
 
+export interface Inscription {
+  id: string; // Unique identifier
+  inscriptionId: string; // Ordinal inscription ID
+  content: string; // Content data
+  number: number; // Inscription number
+  address: string; // Current owner address
+  contentType: string; // MIME type of content
+  output: string; // UTXO containing the inscription
+  location: string; // Location within the UTXO
+  genesisTransaction: string; // Transaction where inscription was created
+  height: number; // Block height of inscription
+  preview: string; // Preview URL if available
+  outputValue: number; // Value of the UTXO
+  offset?: number; // Offset within the UTXO
+}
+
 export interface IBitcoinProvider extends EventEmitter {
   getAccounts: () => Promise<string[]>;
   requestAccounts: () => Promise<string[]>;
@@ -81,7 +97,13 @@ export interface IBitcoinProvider extends EventEmitter {
     unconfirmed: number;
     total: number;
   }>;
-  getInscriptions: () => Promise<string[]>;
+  getInscriptions: (
+    offset?: number,
+    limit?: number
+  ) => Promise<{
+    total: number;
+    list: Inscription[];
+  }>;
   signMessage: (
     message: string,
     type?: BitcoinSignMessageType


### PR DESCRIPTION
- `getInscriptions` 구현
- docs에 example 추가
- server rate limit로 인한 실패를 최소화하기 위해 킄라이언트 딴에 rate limiter 추가
    -  너무 많은 요청이 쌓이지 않도록 timeout은 5초로 지정