### PR TITLE
Add current_keyring_type as Amplitude User Property

### DIFF
--- a/apps/extension/src/analytics-amplitude.ts
+++ b/apps/extension/src/analytics-amplitude.ts
@@ -21,6 +21,7 @@ import { KVStore } from "@keplr-wallet/common";
 import { Hash } from "@keplr-wallet/crypto";
 import { ViewToken } from "./pages/main";
 import { ChainInfo, Currency } from "@keplr-wallet/types";
+import { PlainObject } from "@keplr-wallet/background";
 
 // https://developer.chrome.com/docs/extensions/mv3/tut_analytics/
 export class AmplitudeAnalyticsClient implements AnalyticsClientV2 {
@@ -67,6 +68,26 @@ export class AmplitudeAnalyticsClient implements AnalyticsClientV2 {
               )
             ).toString("hex");
             amplitude.setUserId(hashedAddress);
+
+            let currentKeyRingType: string = "none";
+
+            currentKeyRingType = this.keyringStore.selectedKeyInfo.insensitive[
+              "keyRingType"
+            ] as string;
+
+            if (currentKeyRingType === "private-key") {
+              const meta = this.keyringStore.selectedKeyInfo.insensitive[
+                "keyRingMeta"
+              ] as PlainObject;
+              if (meta["web3Auth"] && (meta["web3Auth"] as any)["type"]) {
+                currentKeyRingType =
+                  "web3_auth_" + (meta["web3Auth"] as any)["type"];
+              }
+            }
+
+            this.setUserProperties({
+              current_keyring_type: currentKeyRingType,
+            });
           }
         }
       });

--- a/apps/extension/src/pages/ibc-swap/hooks/use-swap-analytics.ts
+++ b/apps/extension/src/pages/ibc-swap/hooks/use-swap-analytics.ts
@@ -55,8 +55,7 @@ export const useSwapAnalytics = ({
   swapFeeBps,
 }: SwapAnalyticsArgs) => {
   const [searchParams] = useSearchParams();
-  const { analyticsAmplitudeStore, keyRingStore, uiConfigStore, priceStore } =
-    useStore();
+  const { analyticsAmplitudeStore, uiConfigStore, priceStore } = useStore();
 
   const quoteIdRef = useRef("");
 
@@ -157,7 +156,6 @@ export const useSwapAnalytics = ({
 
     logEvent("swap_entry", {
       entry_point: entryPoint,
-      wallet_type: keyRingStore.selectedKeyInfo?.type,
     });
   });
 


### PR DESCRIPTION
- 이번 변경으로 인해 `swap_entry` 이벤트의 `wallet_type` property가 redundant 해졌으므로 제거