### PR TITLE
논네이티브 체인 추가되는 시점에 해당 체인에 자산이 있는 경우 체인 활성화

### DIFF
--- a/apps/extension/src/stores/root.tsx
+++ b/apps/extension/src/stores/root.tsx
@@ -55,6 +55,7 @@ import {
   SignStarknetMessageInteractionStore,
   SignBitcoinTxInteractionStore,
   SignBitcoinMessageInteractionStore,
+  ChainsUIForegroundStore,
 } from "@keplr-wallet/stores-core";
 import {
   KeplrETCQueries,
@@ -129,6 +130,7 @@ export class RootStore {
 
   public readonly keyRingStore: KeyRingStore;
   public readonly chainStore: ChainStore;
+  public readonly chainsUIForegroundStore: ChainsUIForegroundStore;
   public readonly ibcChannelStore: IBCChannelStore;
 
   public readonly permissionManagerStore: PermissionManagerStore;
@@ -318,6 +320,15 @@ export class RootStore {
       // register 페이지에서는 enable되지 않은 체인도 쉽게 등장(?)하기 때문에
       // 모든 체인에 대한 정보 업데이트를 시도해야함
       window.location.pathname === "/register.html"
+    );
+
+    this.chainsUIForegroundStore = new ChainsUIForegroundStore(
+      router,
+      (vaultId) => {
+        if (this.keyRingStore.selectedKeyInfo?.id === vaultId) {
+          this.chainStore.updateEnabledChainIdentifiersFromBackground();
+        }
+      }
     );
 
     this.ibcChannelStore = new IBCChannelStore(

--- a/packages/background/src/chains-ui/foreground/constants.ts
+++ b/packages/background/src/chains-ui/foreground/constants.ts
@@ -1,0 +1,1 @@
+export const ROUTE = "chains-ui-foreground";

--- a/packages/background/src/chains-ui/foreground/handler.ts
+++ b/packages/background/src/chains-ui/foreground/handler.ts
@@ -1,0 +1,33 @@
+import {
+  Env,
+  Handler,
+  InternalHandler,
+  KeplrError,
+  Message,
+} from "@keplr-wallet/router";
+import { EnabledChainIdentifiersUpdatedMsg } from "./messages";
+import { ChainsUIForegroundService } from "./service";
+
+export const getHandler: (service: ChainsUIForegroundService) => Handler = (
+  service: ChainsUIForegroundService
+) => {
+  return (env: Env, msg: Message<unknown>) => {
+    switch (msg.constructor) {
+      case EnabledChainIdentifiersUpdatedMsg:
+        return handleEnabledChainIdentifiersUpdatedMsg(service)(
+          env,
+          msg as EnabledChainIdentifiersUpdatedMsg
+        );
+      default:
+        throw new KeplrError("interaction", 110, "Unknown msg type");
+    }
+  };
+};
+
+const handleEnabledChainIdentifiersUpdatedMsg: (
+  service: ChainsUIForegroundService
+) => InternalHandler<EnabledChainIdentifiersUpdatedMsg> = (service) => {
+  return (_, msg) => {
+    return service.invoke(msg);
+  };
+};

--- a/packages/background/src/chains-ui/foreground/index.ts
+++ b/packages/background/src/chains-ui/foreground/index.ts
@@ -1,4 +1,3 @@
 export * from "./service";
 export * from "./messages";
-
-export * from "./foreground";
+export * from "./init";

--- a/packages/background/src/chains-ui/foreground/init.ts
+++ b/packages/background/src/chains-ui/foreground/init.ts
@@ -1,0 +1,14 @@
+import { Router } from "@keplr-wallet/router";
+import { EnabledChainIdentifiersUpdatedMsg } from "./messages";
+import { ROUTE } from "./constants";
+import { getHandler } from "./handler";
+import { ChainsUIForegroundService } from "./service";
+
+export function chainsUIForegroundInit(
+  router: Router,
+  service: ChainsUIForegroundService
+): void {
+  router.registerMessage(EnabledChainIdentifiersUpdatedMsg);
+
+  router.addHandler(ROUTE, getHandler(service));
+}

--- a/packages/background/src/chains-ui/foreground/messages.ts
+++ b/packages/background/src/chains-ui/foreground/messages.ts
@@ -1,0 +1,24 @@
+import { Message } from "@keplr-wallet/router";
+import { ROUTE } from "./constants";
+
+export class EnabledChainIdentifiersUpdatedMsg extends Message<void> {
+  public static type() {
+    return "EnabledChainIdentifiersUpdatedMsg";
+  }
+
+  constructor(public readonly vaultId: string) {
+    super();
+  }
+
+  validateBasic(): void {
+    // noop
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return EnabledChainIdentifiersUpdatedMsg.type();
+  }
+}

--- a/packages/background/src/chains-ui/foreground/service.ts
+++ b/packages/background/src/chains-ui/foreground/service.ts
@@ -1,0 +1,22 @@
+import { EnabledChainIdentifiersUpdatedMsg } from "./messages";
+import { APP_PORT, MessageRequester } from "@keplr-wallet/router";
+
+export class ChainsUIForegroundService {
+  static invokeEnabledChainIdentifiersUpdated(
+    eventMsgRequester: MessageRequester,
+    valutId: string
+  ) {
+    eventMsgRequester
+      .sendMessage(APP_PORT, new EnabledChainIdentifiersUpdatedMsg(valutId))
+      .catch((e) => {
+        console.log(e);
+        // noop
+      });
+  }
+
+  constructor(protected handler: (vaultId: string) => void) {}
+
+  invoke(msg: EnabledChainIdentifiersUpdatedMsg): void {
+    this.handler(msg.vaultId);
+  }
+}

--- a/packages/background/src/chains/service.ts
+++ b/packages/background/src/chains/service.ts
@@ -1278,6 +1278,35 @@ export class ChainsService {
     }
   );
 
+  getModularChainInfoWithLinkedChainKey = computedFn(
+    (chainId: string): ModularChainInfo[] => {
+      const res: ModularChainInfo[] = [];
+
+      let linkedChainKey: string | undefined;
+      if (this.hasModularChainInfo(chainId)) {
+        const modularChainInfo = this.getModularChainInfoOrThrow(chainId);
+        if ("linkedChainKey" in modularChainInfo) {
+          linkedChainKey = modularChainInfo.linkedChainKey;
+        }
+        res.push(modularChainInfo);
+      }
+
+      if (linkedChainKey) {
+        for (const modularChainInfo of this.modularChainInfos) {
+          if (
+            modularChainInfo.chainId !== chainId &&
+            "linkedChainKey" in modularChainInfo &&
+            modularChainInfo.linkedChainKey === linkedChainKey
+          ) {
+            res.push(modularChainInfo);
+          }
+        }
+      }
+
+      return res;
+    }
+  );
+
   getModularChainInfoOrThrow(chainId: string): ModularChainInfo {
     const modularChainInfo = this.getModularChainInfo(chainId);
     if (!modularChainInfo) {

--- a/packages/background/src/chains/service.ts
+++ b/packages/background/src/chains/service.ts
@@ -1292,9 +1292,11 @@ export class ChainsService {
       }
 
       if (linkedChainKey) {
+        const chainIdentifier = ChainIdHelper.parse(chainId).identifier;
         for (const modularChainInfo of this.modularChainInfos) {
           if (
-            modularChainInfo.chainId !== chainId &&
+            ChainIdHelper.parse(modularChainInfo.chainId).identifier !==
+              chainIdentifier &&
             "linkedChainKey" in modularChainInfo &&
             modularChainInfo.linkedChainKey === linkedChainKey
           ) {

--- a/packages/background/src/index.ts
+++ b/packages/background/src/index.ts
@@ -198,6 +198,7 @@ export function init(
         keyRingMigrations.getDisabledChainIdentifiers,
       chainsUIService,
     },
+    eventMsgRequester,
     chainsService,
     chainsUIService,
     interactionService,
@@ -280,6 +281,7 @@ export function init(
 
   const tokenScanService = new TokenScan.TokenScanService(
     storeCreator("token-scan"),
+    eventMsgRequester,
     chainsService,
     chainsUIService,
     vaultService,

--- a/packages/background/src/keyring/service.ts
+++ b/packages/background/src/keyring/service.ts
@@ -7,7 +7,7 @@ import {
   KeyRing,
   KeyRingStatus,
 } from "./types";
-import { Env, WEBPAGE_PORT } from "@keplr-wallet/router";
+import { Env, MessageRequester, WEBPAGE_PORT } from "@keplr-wallet/router";
 import {
   PubKeyBitcoinCompatible,
   PubKeySecp256k1,
@@ -25,7 +25,7 @@ import {
 } from "@keplr-wallet/types";
 import { Buffer } from "buffer/";
 import * as Legacy from "./legacy";
-import { ChainsUIService } from "../chains-ui";
+import { ChainsUIForegroundService, ChainsUIService } from "../chains-ui";
 import { MultiAccounts } from "../keyring-keystone";
 import { AnalyticsService } from "../analytics";
 import { Primitive } from "utility-types";
@@ -53,6 +53,7 @@ export class KeyRingService {
       readonly chainsUIService: ChainsUIService;
       readonly getDisabledChainIdentifiers: () => Promise<string[]>;
     },
+    protected readonly eventMsgRequester: MessageRequester,
     protected readonly chainsService: ChainsService,
     protected readonly chainsUIService: ChainsUIService,
     protected readonly interactionService: InteractionService,
@@ -1366,6 +1367,7 @@ export class KeyRingService {
       this.finalizeKeyCoinType(vault.id, chainId, coinType);
     }
 
+    let enabledChanges = false;
     for (const modularChainInfo of this.chainsService.getModularChainInfoWithLinkedChainKey(
       chainId
     )) {
@@ -1375,7 +1377,14 @@ export class KeyRingService {
         !this.chainsUIService.isEnabled(vault.id, chainId)
       ) {
         this.chainsUIService.enableChain(vault.id, chainId);
+        enabledChanges = true;
       }
+    }
+    if (enabledChanges) {
+      ChainsUIForegroundService.invokeEnabledChainIdentifiersUpdated(
+        this.eventMsgRequester,
+        vault.id
+      );
     }
 
     return signature;
@@ -1436,6 +1445,7 @@ export class KeyRingService {
       this.finalizeKeyCoinType(vault.id, chainId, coinType);
     }
 
+    let enabledChanges = false;
     for (const modularChainInfo of this.chainsService.getModularChainInfoWithLinkedChainKey(
       chainId
     )) {
@@ -1445,7 +1455,14 @@ export class KeyRingService {
         !this.chainsUIService.isEnabled(vault.id, chainId)
       ) {
         this.chainsUIService.enableChain(vault.id, chainId);
+        enabledChanges = true;
       }
+    }
+    if (enabledChanges) {
+      ChainsUIForegroundService.invokeEnabledChainIdentifiersUpdated(
+        this.eventMsgRequester,
+        vault.id
+      );
     }
 
     return signedPsbt;

--- a/packages/background/src/keyring/service.ts
+++ b/packages/background/src/keyring/service.ts
@@ -703,7 +703,7 @@ export class KeyRingService {
       ChainIdHelper.parse(chainId).identifier
     }-coinType`;
 
-    return !vault.insensitive[coinTypeTag];
+    return vault.insensitive[coinTypeTag] == null;
   }
 
   async createMnemonicKeyRing(

--- a/packages/background/src/keyring/service.ts
+++ b/packages/background/src/keyring/service.ts
@@ -1366,11 +1366,16 @@ export class KeyRingService {
       this.finalizeKeyCoinType(vault.id, chainId, coinType);
     }
 
-    if (
-      !this.needKeyCoinTypeFinalize(vault.id, chainId) &&
-      !this.chainsUIService.isEnabled(vault.id, chainId)
-    ) {
-      this.chainsUIService.enableChain(vault.id, chainId);
+    for (const modularChainInfo of this.chainsService.getModularChainInfoWithLinkedChainKey(
+      chainId
+    )) {
+      const chainId = modularChainInfo.chainId;
+      if (
+        !this.needKeyCoinTypeFinalize(vault.id, chainId) &&
+        !this.chainsUIService.isEnabled(vault.id, chainId)
+      ) {
+        this.chainsUIService.enableChain(vault.id, chainId);
+      }
     }
 
     return signature;
@@ -1431,11 +1436,16 @@ export class KeyRingService {
       this.finalizeKeyCoinType(vault.id, chainId, coinType);
     }
 
-    if (
-      !this.needKeyCoinTypeFinalize(vault.id, chainId) &&
-      !this.chainsUIService.isEnabled(vault.id, chainId)
-    ) {
-      this.chainsUIService.enableChain(vault.id, chainId);
+    for (const modularChainInfo of this.chainsService.getModularChainInfoWithLinkedChainKey(
+      chainId
+    )) {
+      const chainId = modularChainInfo.chainId;
+      if (
+        !this.needKeyCoinTypeFinalize(vault.id, chainId) &&
+        !this.chainsUIService.isEnabled(vault.id, chainId)
+      ) {
+        this.chainsUIService.enableChain(vault.id, chainId);
+      }
     }
 
     return signedPsbt;

--- a/packages/background/src/token-scan/service.ts
+++ b/packages/background/src/token-scan/service.ts
@@ -76,7 +76,29 @@ export class TokenScanService {
     this.chainsService.addChainSuggestedHandler((chainInfo) => {
       // 여기서 await을 하면 suggest chain이 계정이 늘어날수록 늦어진다.
       // 절대로 await을 하지않기...
-      this.scanWithAllVaults(chainInfo.chainId);
+      this.scanWithAllVaults(chainInfo.chainId).then(() => {
+        // suggest chain 이후에 한번에 한해서 자동으로 enable을 해준다.
+        // scanWithAllVaults이 끝났으면 this.vaultToMap이 업데이트가 완료되었을 것이다.
+        for (const keyRing of this.keyRingService.getKeyInfos()) {
+          const vaultId = keyRing.id;
+          const tokenScans = this.getTokenScans(vaultId);
+          for (const tokenScan of tokenScans) {
+            if (
+              tokenScan.chainId === chainInfo.chainId &&
+              tokenScan.infos.length === 1
+            ) {
+              for (const modularChainInfo of this.chainsService.getModularChainInfoWithLinkedChainKey(
+                chainInfo.chainId
+              )) {
+                const chainId = modularChainInfo.chainId;
+                if (!this.chainsUIService.isEnabled(vaultId, chainId)) {
+                  this.chainsUIService.enableChain(vaultId, chainId);
+                }
+              }
+            }
+          }
+        }
+      });
     });
     this.chainsUIService.addChainUIEnabledChangedHandler(
       (vaultId, chainIdentifiers) => {

--- a/packages/background/src/token-scan/service.ts
+++ b/packages/background/src/token-scan/service.ts
@@ -175,8 +175,13 @@ export class TokenScanService {
         return 0;
       });
     for (const vaultId of vaultIds) {
-      // 얘는 계정 수를 예상하기 힘드니까 그냥 순차적으로 한다...
-      await this.scan(vaultId, chainId);
+      try {
+        // 얘는 계정 수를 예상하기 힘드니까 그냥 순차적으로 한다...
+        await this.scan(vaultId, chainId);
+      } catch (e) {
+        console.log(e);
+        // noop
+      }
     }
   }
 

--- a/packages/stores-core/src/core/chains-ui/index.ts
+++ b/packages/stores-core/src/core/chains-ui/index.ts
@@ -1,0 +1,15 @@
+import {
+  chainsUIForegroundInit,
+  ChainsUIForegroundService,
+} from "@keplr-wallet/background";
+import { Router } from "@keplr-wallet/router";
+
+export class ChainsUIForegroundStore {
+  constructor(
+    protected readonly router: Router,
+    protected readonly handler: (vaultId: string) => void
+  ) {
+    const service = new ChainsUIForegroundService(handler);
+    chainsUIForegroundInit(router, service);
+  }
+}

--- a/packages/stores-core/src/core/index.ts
+++ b/packages/stores-core/src/core/index.ts
@@ -2,3 +2,4 @@ export * from "./interaction";
 export * from "./keyring";
 export * from "./tokens";
 export * from "./permission-manager";
+export * from "./chains-ui";


### PR DESCRIPTION
- background의 token scan service에서 suggest chain 이후 token scan이 완료되면 자동으로 token scan에서 결과가 하나인 경우 (바로 enable 해줘도 문제 없는 경우) 자동으로 enable 하도록 수정
- background에서 자동으로 enable될때 UI가 켜져있으면 자동으로 sync해주기 위해서 ChainsUIForeground 추가
- bitcoin같이 여러 체인이 하나로 붙어있는(?) 경우를 처리하기 위해서 ChainsService에 getModularChainInfoWithLinkedChainKey()라는 메소드 추가 -> 해당하는 체인에 linkedChainKey가 있을 경우 같은 linkedChainKey를 가진 modularChainInfo를 같이 반환