### PR TITLE
Unichain missing `op-stack-l1-data-fee` feature

### DIFF
--- a/apps/extension/src/config.ts
+++ b/apps/extension/src/config.ts
@@ -3062,7 +3062,7 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
         coinGeckoId: "ethereum",
       },
     ],
-    features: [],
+    features: ["op-stack-l1-data-fee"],
   },
   {
     chainId:


### PR DESCRIPTION
- unichain도 op stack으로 처리되도록 피쳐 추가
- 참조: https://github.com/ethereum-optimism/superchain-registry/blob/main/CHAINS.md