### PR TITLE
Calculate maxPriorityFeePerGas based on latest fee history v2

### DIFF
--- a/packages/hooks/src/tx/fee.ts
+++ b/packages/hooks/src/tx/fee.ts
@@ -17,6 +17,7 @@ import { useState } from "react";
 import { InsufficientFeeError } from "./errors";
 import { QueriesStore } from "./internal";
 import { DenomHelper } from "@keplr-wallet/common";
+import { EthereumQueriesImpl } from "@keplr-wallet/stores-eth";
 
 export class FeeConfig extends TxChainSetter implements IFeeConfig {
   @observable.ref
@@ -489,6 +490,18 @@ export class FeeConfig extends TxChainSetter implements IFeeConfig {
           blockQuery.waitFreshResponse();
         }
 
+        const feeHistoryQuery =
+          queries.ethereum.queryEthereumFeeHistory.getQueryByFeeHistoryParams(
+            ETH_FEE_HISTORY_BLOCK_COUNT,
+            ETH_FEE_HISTORY_NEWEST_BLOCK,
+            ETH_FEE_HISTORY_REWARD_PERCENTILES
+          );
+        if (feeHistoryQuery.feeHistory != null) {
+          if (isRefresh) {
+            feeHistoryQuery.waitFreshResponse();
+          }
+        }
+
         const maxPriorityFeePerGasQuery =
           queries.ethereum.queryEthereumMaxPriorityFee;
         if (maxPriorityFeePerGasQuery.maxPriorityFeePerGas != null) {
@@ -819,19 +832,16 @@ export class FeeConfig extends TxChainSetter implements IFeeConfig {
           ).block;
         const latestBaseFeePerGas = parseInt(block?.baseFeePerGas ?? "0");
         if (latestBaseFeePerGas !== 0) {
+          const baseFeePerGasDec = new Dec(latestBaseFeePerGas);
+
           const maxPriorityFeePerGas =
-            ethereumQueries.queryEthereumMaxPriorityFee.maxPriorityFeePerGas;
-          if (maxPriorityFeePerGas != null) {
-            const baseFeePerGasDec = new Dec(latestBaseFeePerGas).mul(
-              ETH_FEE_SETTINGS_BY_FEE_TYPE[feeType].baseFeePercentageMultiplier
-            );
-            const maxPriorityFeePerGasDec = new Dec(
-              BigInt(maxPriorityFeePerGas)
-            );
-            const maxFeePerGas = baseFeePerGasDec.add(maxPriorityFeePerGasDec);
+            this.calculateOptimalMaxPriorityFeePerGas(ethereumQueries, feeType);
+
+          if (maxPriorityFeePerGas.gt(new Dec(0))) {
+            const maxFeePerGas = baseFeePerGasDec.add(maxPriorityFeePerGas);
 
             return {
-              maxPriorityFeePerGas: maxPriorityFeePerGasDec.truncateDec(),
+              maxPriorityFeePerGas: maxPriorityFeePerGas.truncateDec(),
               maxFeePerGas: maxFeePerGas.truncateDec(),
             };
           }
@@ -855,6 +865,48 @@ export class FeeConfig extends TxChainSetter implements IFeeConfig {
       };
     }
   );
+
+  private calculateOptimalMaxPriorityFeePerGas(
+    ethereumQueries: EthereumQueriesImpl,
+    feeType: FeeType
+  ): Dec {
+    const feeHistoryQuery =
+      ethereumQueries.queryEthereumFeeHistory.getQueryByFeeHistoryParams(
+        ETH_FEE_HISTORY_BLOCK_COUNT,
+        ETH_FEE_HISTORY_NEWEST_BLOCK,
+        ETH_FEE_HISTORY_REWARD_PERCENTILES
+      );
+
+    const reasonableMaxPriorityFeePerGas =
+      feeHistoryQuery.reasonableMaxPriorityFeePerGas;
+    const maxPriorityFeePerGas =
+      ethereumQueries.queryEthereumMaxPriorityFee.maxPriorityFeePerGas;
+
+    if (
+      reasonableMaxPriorityFeePerGas &&
+      reasonableMaxPriorityFeePerGas.length > 0
+    ) {
+      const percentile = ETH_FEE_SETTINGS_BY_FEE_TYPE[feeType].percentile;
+      const targetPercentileData = reasonableMaxPriorityFeePerGas.find(
+        (item) => item.percentile === percentile
+      );
+
+      if (targetPercentileData) {
+        const historyBasedFee = new Dec(targetPercentileData.value);
+        const networkFee = new Dec(BigInt(maxPriorityFeePerGas ?? "0x0"));
+
+        return historyBasedFee.gt(networkFee) ? historyBasedFee : networkFee;
+      }
+    }
+
+    if (maxPriorityFeePerGas) {
+      const multiplier =
+        ETH_FEE_SETTINGS_BY_FEE_TYPE[feeType].baseFeePercentageMultiplier;
+      return new Dec(BigInt(maxPriorityFeePerGas)).mul(multiplier);
+    }
+
+    return new Dec(ETH_DEFAULT_MAX_PRIORITY_FEE_PER_GAS);
+  }
 
   protected populateGasPriceStep(
     feeCurrency: FeeCurrency,
@@ -1069,6 +1121,30 @@ export class FeeConfig extends TxChainSetter implements IFeeConfig {
           };
         }
 
+        const feeHistoryQuery =
+          ethereumQueries.queryEthereumFeeHistory.getQueryByFeeHistoryParams(
+            ETH_FEE_HISTORY_BLOCK_COUNT,
+            ETH_FEE_HISTORY_NEWEST_BLOCK,
+            ETH_FEE_HISTORY_REWARD_PERCENTILES
+          );
+        if (feeHistoryQuery.error) {
+          return {
+            warning: new Error(
+              `Failed to fetch fee history. chain id: ${this.chainId}`
+            ),
+          };
+        }
+        if (feeHistoryQuery.isFetching) {
+          return {
+            loadingState: "loading",
+          };
+        }
+        if (!feeHistoryQuery.response) {
+          return {
+            loadingState: "loading-block",
+          };
+        }
+
         const maxPriorityFeePerGasQuery =
           ethereumQueries.queryEthereumMaxPriorityFee;
         if (maxPriorityFeePerGasQuery.error) {
@@ -1213,6 +1289,8 @@ export const useFeeConfig = (
   return config;
 };
 
+const ETH_FEE_HISTORY_BLOCK_COUNT = 20;
+const ETH_FEE_HISTORY_REWARD_PERCENTILES = [10, 25, 45];
 const ETH_FEE_SETTINGS_BY_FEE_TYPE: Record<
   FeeType,
   {
@@ -1221,16 +1299,17 @@ const ETH_FEE_SETTINGS_BY_FEE_TYPE: Record<
   }
 > = {
   low: {
-    percentile: 10,
+    percentile: ETH_FEE_HISTORY_REWARD_PERCENTILES[0],
     baseFeePercentageMultiplier: new Dec(1),
   },
   average: {
-    percentile: 40,
+    percentile: ETH_FEE_HISTORY_REWARD_PERCENTILES[1],
     baseFeePercentageMultiplier: new Dec(1.125),
   },
   high: {
-    percentile: 70,
+    percentile: ETH_FEE_HISTORY_REWARD_PERCENTILES[2],
     baseFeePercentageMultiplier: new Dec(1.25),
   },
 };
 const ETH_FEE_HISTORY_NEWEST_BLOCK = "latest";
+const ETH_DEFAULT_MAX_PRIORITY_FEE_PER_GAS = BigInt(1.5 * 10 ** 9); // 1.5 gwei

--- a/packages/stores-eth/src/queries/fee-histroy.ts
+++ b/packages/stores-eth/src/queries/fee-histroy.ts
@@ -13,6 +13,8 @@ interface EthereumFeeHistory {
 }
 
 export class ObservableQueryEthereumFeeHistoryInner extends ObservableEvmChainJsonRpcQuery<EthereumFeeHistory> {
+  rewardPercentiles: number[];
+
   constructor(
     sharedContext: QuerySharedContext,
     chainId: string,
@@ -33,6 +35,8 @@ export class ObservableQueryEthereumFeeHistoryInner extends ObservableEvmChainJs
     ]);
 
     makeObservable(this);
+
+    this.rewardPercentiles = rewardPercentiles;
   }
 
   @computed
@@ -42,6 +46,54 @@ export class ObservableQueryEthereumFeeHistoryInner extends ObservableEvmChainJs
     }
 
     return this.response.data;
+  }
+
+  @computed
+  get reasonableMaxPriorityFeePerGas():
+    | Array<{
+        percentile: number;
+        value: bigint;
+      }>
+    | undefined {
+    if (!this.feeHistory?.reward || this.feeHistory.reward.length === 0) {
+      return;
+    }
+
+    const rewards = this.feeHistory.reward;
+
+    const results: {
+      percentile: number;
+      value: bigint;
+    }[] = [];
+
+    const percentiles = this.rewardPercentiles;
+    const deviationThreshold = BigInt(1 * 10 ** 9); // 1 Gwei
+
+    for (let idx = 0; idx < percentiles.length; idx++) {
+      const vals = rewards
+        .map((block) => block[idx])
+        .filter((v) => v != null)
+        .map((v) => BigInt(v));
+
+      if (vals.length === 0) continue;
+
+      const sum = vals.reduce((acc, x) => acc + x, BigInt(0));
+      const mean = sum / BigInt(vals.length);
+
+      vals.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+      const median = vals[Math.floor(vals.length / 2)];
+
+      const deviation = mean > median ? mean - median : median - mean;
+      const pick =
+        deviation > deviationThreshold ? (mean > median ? mean : median) : mean;
+
+      results.push({
+        percentile: percentiles[idx],
+        value: pick,
+      });
+    }
+
+    return results.length > 0 ? results : undefined;
   }
 }
 


### PR DESCRIPTION
- https://github.com/chainapsis/keplr-wallet/pull/1559
- arbitrum 등 priority를 지원하지 않는 체인이 존재하므로 0보다 크다는 조건 검사 제거
- fee history 또는 max priority fee를 가져오지 못하는 경우에 대한 ui에서의 에러 처리가 충분하므로 default max priority(1.5 gwei)를 제거하고 0을 반환하도록 수정