### PR TITLE
Handle ledger low level request in order on starknet ledger app

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -78,6 +78,7 @@
     "lodash.throttle": "^4.1.1",
     "lottie-web": "^5.10.2",
     "os-browserify": "^0.3.0",
+    "p-queue": "^6.6.2",
     "process": "^0.11.10",
     "qrcode.react": "^3.1.0",
     "query-string": "^6.8.3",

--- a/apps/extension/src/pages/sign/utils/handle-starknet-sign.ts
+++ b/apps/extension/src/pages/sign/utils/handle-starknet-sign.ts
@@ -35,6 +35,7 @@ import {
 } from "@ledgerhq/hw-app-starknet";
 import { PubKeyStarknet } from "@keplr-wallet/crypto";
 import { Fee } from "@keplr-wallet/stores-starknet/build/account/internal";
+import PQueue from "p-queue";
 
 // eip-2645 derivation path, m/2645'/starknet'/{application}'/0'/{accountId}'/0
 export const STARKNET_LEDGER_DERIVATION_PATH =
@@ -212,7 +213,7 @@ export const connectAndSignInvokeTxWithLedger = async (
 
   const origExchange = transport.exchange.bind(transport);
   transport.exchange = async (apdu, options) => {
-    return await ledgerRequestQueue.enqueue(() => origExchange(apdu, options));
+    return await ledgerRequestQueue.add(() => origExchange(apdu, options));
   };
 
   try {
@@ -403,27 +404,6 @@ async function checkStarknetPubKey(
   }
 }
 
-class LedgerRequestQueue {
-  private last: Promise<unknown> = Promise.resolve();
-
-  /**
-   * add a job to the queue and return the result.
-   * wait for the previous job to finish before executing job().
-   * if the previous job fails, the queue will stop.
-   *
-   * @param job a function that calls Ledger transport.exchange etc.
-   * @returns a promise of the result of job()
-   */
-  enqueue<T>(job: () => Promise<T>): Promise<T> {
-    const next = this.last.then(
-      () => job(),
-      (e) => Promise.reject(e)
-    );
-
-    this.last = next;
-
-    return next;
-  }
-}
-
-const ledgerRequestQueue = new LedgerRequestQueue();
+const ledgerRequestQueue = new PQueue({
+  concurrency: 1,
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6101,6 +6101,7 @@ __metadata:
     lodash.throttle: ^4.1.1
     lottie-web: ^5.10.2
     os-browserify: ^0.3.0
+    p-queue: ^6.6.2
     process: ^0.11.10
     qrcode.react: ^3.1.0
     query-string: ^6.8.3


### PR DESCRIPTION
### issue

- 여러 개의 콜데이터가 들어있는 트랜잭션을 실행할 때, (ex. swap on [ekubo](https://app.ekubo.org/?inputCurrency=STRK&amount=0.1&outputCurrency=EKUBO))
- 콜데이터를 파싱하는 과정에서 로우 레벨에서 렛져로 2개 이상의 요청이 거의 동시에 들어가고 순차적으로 처리되지 않는 문제가 발생
    - error: `An action was already pending on the Ledger device. Please deny or reconnect.`
    - ledger nano s+ 및 stax 모두 동일한 오류 발생
- ledger(transport) 및 starknet 라이브러리 버전을 최신으로 올려서 테스트 해봐도 동일한 문제가 발생해서 라이브러리 문제인지는 판별이 어렵습니다

### resolve

- 임시방편으로 로우 레벨 요청을 수행하는 메서드의 요청을 가로채서 요청 큐에 넣어 순차적으로 실행하도록 구현