### PR TITLE
Update SecretNetwork mainnetConsensusIoPubKey

### DIFF
--- a/packages/background/src/secret-wasm/enigma-utils.ts
+++ b/packages/background/src/secret-wasm/enigma-utils.ts
@@ -23,7 +23,7 @@ const hkdfSalt: Uint8Array = new Uint8Array(
 );
 
 const secretConsensusIoPubKey = new Uint8Array(
-  Buffer.from("79++5YOHfm0SwhlpUDClv7cuCjq9xBZlWqSjDJWkRG8=", "base64")
+  Buffer.from("UyAkgs8Z55YD2091/RjSnmdMH4yF9PKc5lWqjV78nS8=", "base64")
 );
 
 export class EnigmaUtils implements EncryptionUtils {


### PR DESCRIPTION
This commit updates mainnetConsensusIoPubKey in order to work with SecretNetwork v1.21.0 after seed rotation.