### PR TITLE
safe cast to hex with `num.toHex`

### DIFF
--- a/apps/extension/src/hooks/claim/use-starknet-claim-rewards.ts
+++ b/apps/extension/src/hooks/claim/use-starknet-claim-rewards.ts
@@ -321,16 +321,24 @@ export const useStarknetClaimRewards = () => {
       const maxL1GasPrice = new Dec(l1_gas_price).mul(margin);
       const maxL2GasPrice = new Dec(l2_gas_price ?? 0).mul(margin);
 
+      const safeToHex = (value: any): string => {
+        if (value === null || value === undefined) {
+          return "0";
+        }
+        const val = value.toString();
+        return num.toHex(val === "0x" ? "0" : val);
+      };
+
       const { transaction_hash: txHash } = await starknetAccount.execute(
         account.starknetHexAddress,
         calls,
         {
-          l1MaxGas: num.toHex(maxL1Gas.truncate().toString()),
-          l1MaxGasPrice: num.toHex(maxL1GasPrice.truncate().toString()),
-          l1MaxDataGas: num.toHex(maxL1DataGas.truncate().toString()),
-          l1MaxDataGasPrice: num.toHex(maxL1DataGasPrice.truncate().toString()),
-          l2MaxGas: num.toHex(maxL2Gas.truncate().toString()),
-          l2MaxGasPrice: num.toHex(maxL2GasPrice.truncate().toString()),
+          l1MaxGas: safeToHex(maxL1Gas.truncate()),
+          l1MaxGasPrice: safeToHex(maxL1GasPrice.truncate()),
+          l1MaxDataGas: safeToHex(maxL1DataGas.truncate()),
+          l1MaxDataGasPrice: safeToHex(maxL1DataGasPrice.truncate()),
+          l2MaxGas: safeToHex(maxL2Gas.truncate()),
+          l2MaxGasPrice: safeToHex(maxL2GasPrice.truncate()),
         }
       );
       if (!txHash) {

--- a/apps/extension/src/pages/sign/utils/handle-starknet-sign.ts
+++ b/apps/extension/src/pages/sign/utils/handle-starknet-sign.ts
@@ -119,6 +119,14 @@ export const connectAndSignDeployAccountTxWithLedger = async (
     chainId.replace("starknet:", "")
   ) as constants.StarknetChainId;
 
+  const safeToHex = (value: any): string => {
+    if (value === null || value === undefined) {
+      return "0";
+    }
+    const val = value.toString();
+    return num.toHex(val === "0x" ? "0" : val);
+  };
+
   const transaction: V3DeployAccountSignerDetails = {
     version: "0x3",
     chainId: starknetChainId,
@@ -129,16 +137,16 @@ export const connectAndSignDeployAccountTxWithLedger = async (
     addressSalt,
     resourceBounds: {
       l1_gas: {
-        max_amount: num.toHex(fee.l1MaxGas),
-        max_price_per_unit: num.toHex(fee.l1MaxGasPrice),
+        max_amount: safeToHex(fee.l1MaxGas),
+        max_price_per_unit: safeToHex(fee.l1MaxGasPrice),
       },
       l2_gas: {
-        max_amount: num.toHex(fee.l2MaxGas ?? "0"),
-        max_price_per_unit: num.toHex(fee.l2MaxGasPrice ?? "0"),
+        max_amount: safeToHex(fee.l2MaxGas),
+        max_price_per_unit: safeToHex(fee.l2MaxGasPrice),
       },
       l1_data_gas: {
-        max_amount: num.toHex(fee.l1MaxDataGas),
-        max_price_per_unit: num.toHex(fee.l1MaxDataGasPrice),
+        max_amount: safeToHex(fee.l1MaxDataGas),
+        max_price_per_unit: safeToHex(fee.l1MaxDataGasPrice),
       },
     },
     tip: "0x0",

--- a/apps/extension/src/pages/starknet/sign/tx/view.tsx
+++ b/apps/extension/src/pages/starknet/sign/tx/view.tsx
@@ -305,6 +305,14 @@ export const SignStarknetTxView: FunctionComponent<{
       const maxL1GasPrice = new Dec(l1Gas.price).mul(margin);
       const maxL2GasPrice = new Dec(l2Gas.price).mul(margin);
 
+      const safeToHex = (value: any): string => {
+        if (value === null || value === undefined) {
+          return "0";
+        }
+        const val = value.toString();
+        return num.toHex(val === "0x" ? "0" : val);
+      };
+
       const details: InvocationsSignerDetails = {
         version: "0x3",
         walletAddress: interactionData.data.details.walletAddress,
@@ -314,18 +322,16 @@ export const SignStarknetTxView: FunctionComponent<{
         skipValidate: false,
         resourceBounds: {
           l1_data_gas: {
-            max_amount: num.toHex(maxL1DataGas.truncate().toString()),
-            max_price_per_unit: num.toHex(
-              maxL1DataGasPrice.truncate().toString()
-            ),
+            max_amount: safeToHex(maxL1DataGas.truncate()),
+            max_price_per_unit: safeToHex(maxL1DataGasPrice.truncate()),
           },
           l1_gas: {
-            max_amount: num.toHex(maxL1Gas.truncate().toString()),
-            max_price_per_unit: num.toHex(maxL1GasPrice.truncate().toString()),
+            max_amount: safeToHex(maxL1Gas.truncate()),
+            max_price_per_unit: safeToHex(maxL1GasPrice.truncate()),
           },
           l2_gas: {
-            max_amount: num.toHex(maxL2Gas.truncate().toString()),
-            max_price_per_unit: num.toHex(maxL2GasPrice.truncate().toString()),
+            max_amount: safeToHex(maxL2Gas.truncate()),
+            max_price_per_unit: safeToHex(maxL2GasPrice.truncate()),
           },
         },
         tip: "0x0",

--- a/packages/stores-starknet/src/account/internal.ts
+++ b/packages/stores-starknet/src/account/internal.ts
@@ -149,6 +149,14 @@ export class StoreAccount extends Account {
         0
       );
 
+    const safeToHex = (value: any): string => {
+      if (value === null || value === undefined) {
+        return "0";
+      }
+      const val = value.toString();
+      return num.toHex(val === "0x" ? "0" : val);
+    };
+
     const signerDetails: DeployAccountSignerDetails = {
       ...stark.v3Details({}, "0.8.1"),
       classHash,
@@ -160,16 +168,16 @@ export class StoreAccount extends Account {
       chainId: chainId,
       resourceBounds: {
         l1_gas: {
-          max_amount: num.toHex(fee.l1MaxGas),
-          max_price_per_unit: num.toHex(fee.l1MaxGasPrice),
+          max_amount: safeToHex(fee.l1MaxGas),
+          max_price_per_unit: safeToHex(fee.l1MaxGasPrice),
         },
         l2_gas: {
-          max_amount: num.toHex(fee.l2MaxGas ?? "0"),
-          max_price_per_unit: num.toHex(fee.l2MaxGasPrice ?? "0"),
+          max_amount: safeToHex(fee.l2MaxGas),
+          max_price_per_unit: safeToHex(fee.l2MaxGasPrice),
         },
         l1_data_gas: {
-          max_amount: num.toHex(fee.l1MaxDataGas),
-          max_price_per_unit: num.toHex(fee.l1MaxDataGasPrice),
+          max_amount: safeToHex(fee.l1MaxDataGas),
+          max_price_per_unit: safeToHex(fee.l1MaxDataGasPrice),
         },
       },
     };
@@ -274,6 +282,14 @@ export class StoreAccount extends Account {
     const nonce = await this.getNonce();
     const chainId = await this.getChainId();
 
+    const safeToHex = (value: any): string => {
+      if (value === null || value === undefined) {
+        return "0";
+      }
+      const val = value.toString();
+      return num.toHex(val === "0x" ? "0" : val);
+    };
+
     const signerDetails: InvocationsSignerDetails = {
       ...stark.v3Details({}, "0.8.1"),
       version: ETransactionVersion.V3,
@@ -284,16 +300,16 @@ export class StoreAccount extends Account {
       skipValidate: false,
       resourceBounds: {
         l1_gas: {
-          max_amount: num.toHex(fee.l1MaxGas),
-          max_price_per_unit: num.toHex(fee.l1MaxGasPrice),
+          max_amount: safeToHex(fee.l1MaxGas),
+          max_price_per_unit: safeToHex(fee.l1MaxGasPrice),
         },
         l2_gas: {
-          max_amount: num.toHex(fee.l2MaxGas ?? "0"),
-          max_price_per_unit: num.toHex(fee.l2MaxGasPrice ?? "0"),
+          max_amount: safeToHex(fee.l2MaxGas),
+          max_price_per_unit: safeToHex(fee.l2MaxGasPrice),
         },
         l1_data_gas: {
-          max_amount: num.toHex(fee.l1MaxDataGas),
-          max_price_per_unit: num.toHex(fee.l1MaxDataGasPrice),
+          max_amount: safeToHex(fee.l1MaxDataGas),
+          max_price_per_unit: safeToHex(fee.l1MaxDataGasPrice),
         },
       },
     };


### PR DESCRIPTION
- `Cannot convert 0x to a BigInt` 오류가 `num.toHex`에서 발생할 것이라고 추정
- 에러 재현해보려면 vesu.xyz에서 reward claim이 열릴 때 까지 며칠 기다려야 합니다