### PR TITLE
docs: add JSDoc to open() method callback parameter

### DIFF
--- a/packages/wc-qrcode-modal/src/index.tsx
+++ b/packages/wc-qrcode-modal/src/index.tsx
@@ -49,6 +49,11 @@ export class KeplrQRCodeModalV2 {
     }
   }
 
+  /**
+   * Opens the QR code modal with the provided URI.
+   * @param uri - The WalletConnect URI to display in the QR code
+   * @param cb - Callback function to execute when the modal is closed (used for cleanup logic)
+   */
   open(uri: string, cb: any) {
     const wrapper = document.createElement("div");
     wrapper.setAttribute("id", "keplr-qrcode-modal-v2");


### PR DESCRIPTION
- Add JSDoc comments to open() method
- Document callback parameter purpose for cleanup logic
- Enhance code readability and developer experience