### PR TITLE
fix: preserve Debouncer execution context

### DIFF
--- a/packages/common/src/utils/debouncer.ts
+++ b/packages/common/src/utils/debouncer.ts
@@ -4,7 +4,7 @@ export class Debouncer {
   ): (...args: ArgumentsType) => Promise<ReturnType> {
     let currentPromise: PromiseLike<ReturnType> | ReturnType | undefined;
 
-    return async (...arguments_) => {
+    return async function (this: unknown, ...arguments_: ArgumentsType): Promise<ReturnType> {
       if (currentPromise) {
         return currentPromise;
       }


### PR DESCRIPTION
- replace the arrow function returned by `Debouncer.promise` with a regular async function
- ensure `fn.apply(this, ...)` receives the caller’s original `this` context