### PR TITLE
Normalize evm unsigned tx

### DIFF
--- a/packages/background/src/keyring-ethereum/service.ts
+++ b/packages/background/src/keyring-ethereum/service.ts
@@ -1335,6 +1335,7 @@ export class KeyRingEthereumService {
     const unsignedTx: UnsignedTransaction = {
       ...restTx,
       value: this.toHexQty(value),
+      gasLimit: this.toHexQty(gasLimit ?? gas),
       gasPrice: this.toHexQty(gasPrice),
       maxFeePerGas: this.toHexQty(maxFeePerGas),
       maxPriorityFeePerGas: this.toHexQty(maxPriorityFeePerGas),
@@ -1342,21 +1343,20 @@ export class KeyRingEthereumService {
       nonce,
     };
 
-    if (gasLimit == null && gas != null) {
-      unsignedTx.gasLimit = this.toHexQty(gas);
-    } else if (gasLimit != null) {
-      unsignedTx.gasLimit = this.toHexQty(gasLimit);
-    }
-
     if (data != null && typeof data === "string") {
       unsignedTx.data = data.startsWith("0x") ? data : `0x${data}`;
     }
 
-    const hasEIP1559 =
-      unsignedTx.maxFeePerGas !== undefined ||
+    const isLegacy = unsignedTx.gasPrice !== undefined;
+    const isEIP1559 =
+      unsignedTx.maxFeePerGas !== undefined &&
       unsignedTx.maxPriorityFeePerGas !== undefined;
-    if (hasEIP1559) {
+
+    if (isEIP1559) {
       delete unsignedTx.gasPrice;
+    } else if (isLegacy) {
+      delete unsignedTx.maxFeePerGas;
+      delete unsignedTx.maxPriorityFeePerGas;
     }
 
     return unsignedTx;


### PR DESCRIPTION
- uniswap - unichain에서 스왑을 실행할 때 
    - gas, gasPrice 필드에 decimal string이 포함되어 있는데 이를 dapp에서 제시한 수수료로 그대로 사용하고 있어서 트랜잭션 검증 및 브로드캐스팅이 안되는 문제 발생
    - value 필드에는 leading 0가 포함된 hex string이 포함되어 있어 gas estimation 오류 발생
- 다른 dapp에서도 동일한 문제가 발생할 수 있으므로 서명 페이지로 요청이 넘어가기 전에 tx를 nomalize하도록 로직 추가