### PR TITLE
Improve ethereum `preferNoSetFee` behavior

### DIFF
--- a/apps/extension/src/pages/sign/cosmos/tx/view.tsx
+++ b/apps/extension/src/pages/sign/cosmos/tx/view.tsx
@@ -415,19 +415,13 @@ export const CosmosTxView: FunctionComponent<{
       isLedgerAndDirect,
   });
 
-  // Disable the button if transaction validity check data is not ready.
-  // NOTE: Consider whether this part should be handled inside useTxConfigsValidate.
-  const initialGuard =
-    !signDocHelper.signDocWrapper ||
-    amountConfig.uiProperties.loadingState === "loading" ||
-    feeConfig.uiProperties.loadingState === "loading";
-
   const buttonDisabled =
     txConfigsValidate.interactionBlocked ||
-    initialGuard ||
+    !signDocHelper.signDocWrapper ||
     isLedgerAndDirect ||
     (isSendAuthzGrant && !isSendAuthzGrantChecked) ||
-    (isHighFee && !isHighFeeApproved);
+    (isHighFee && !isHighFeeApproved) ||
+    (shouldTopUp && (isTopUpInProgress || !isTopUpAvailable));
 
   const approve = async () => {
     if (signDocHelper.signDocWrapper) {

--- a/apps/extension/src/pages/sign/ethereum/views/sign-tx-view.tsx
+++ b/apps/extension/src/pages/sign/ethereum/views/sign-tx-view.tsx
@@ -393,13 +393,7 @@ export const EthereumSignTxView: FunctionComponent<{
     isLedgerInteracting ||
     isKeystoneInteracting;
 
-  // TODO: ethereum fee config is refreshed every 12 seconds,
-  // so we need to consider the initial state condition.
-  const initialGuard =
-    amountConfig.uiProperties.loadingState === "loading" ||
-    feeConfig.uiProperties.loadingState === "loading";
-
-  const buttonDisabled = txConfigsValidate.interactionBlocked || initialGuard;
+  const buttonDisabled = txConfigsValidate.interactionBlocked;
 
   const bottomButtons: HeaderProps["bottomButtons"] = [
     {


### PR DESCRIPTION
- ethereum 서명 요청에 dApp에서 설정한 수수료가 있는 경우
    - fee data refresh 하지 않도록 수정
    - 수수료 옵션을 선택한 경우, `preferNoSetFee`가 false가 되도록 수정
 - ethereum 서명 요청이 내부 요청인 경우
   - fee data refresh 하지 않도록 수정