### PR TITLE
prevent displaying top-up message on non-supported chain

### DIFF
--- a/apps/extension/src/components/top-up/index.tsx
+++ b/apps/extension/src/components/top-up/index.tsx
@@ -23,9 +23,9 @@ export const FeeCoverageDescription: FunctionComponent<{
         color={ColorPalette["gray-300"]}
         style={{ textAlign: "center" }}
       >
-        <FormattedMessage id="components.top-up.description.no-fees" />
         {isTopUpAvailable ? (
           <React.Fragment>
+            <FormattedMessage id="components.top-up.description.no-fees" />
             <br />
             <span style={{ color: ColorPalette["blue-500"] }}>
               <FormattedMessage id="components.top-up.description.we-cover" />

--- a/apps/extension/src/pages/ibc-swap/index.tsx
+++ b/apps/extension/src/pages/ibc-swap/index.tsx
@@ -2008,7 +2008,7 @@ export const IBCSwapPage: FunctionComponent = observer(() => {
           }}
         />
         <Gutter size="0.75rem" />
-        <VerticalCollapseTransition collapsed={shouldTopUp}>
+        <VerticalCollapseTransition collapsed={shouldTopUp && isTopUpAvailable}>
           <SwapFeeInfo
             senderConfig={ibcSwapConfigs.senderConfig}
             amountConfig={ibcSwapConfigs.amountConfig}
@@ -2022,7 +2022,9 @@ export const IBCSwapPage: FunctionComponent = observer(() => {
             shouldTopUp={shouldTopUp}
           />
         </VerticalCollapseTransition>
-        <VerticalCollapseTransition collapsed={!shouldTopUp}>
+        <VerticalCollapseTransition
+          collapsed={!(shouldTopUp && isTopUpAvailable)}
+        >
           <FeeCoverageDescription isTopUpAvailable={isTopUpAvailable} />
         </VerticalCollapseTransition>
 

--- a/apps/extension/src/pages/ibc-transfer/amount/index.tsx
+++ b/apps/extension/src/pages/ibc-transfer/amount/index.tsx
@@ -57,22 +57,23 @@ export const IBCTransferAmountView: FunctionComponent<{
               id: "components.input.memo-input.optional-placeholder",
             })}
           />
-
-          <div style={{ flex: 1 }} />
-          <VerticalCollapseTransition collapsed={shouldTopUp}>
-            <FeeControl
-              senderConfig={senderConfig}
-              feeConfig={feeConfig}
-              gasConfig={gasConfig}
-              gasSimulator={gasSimulator}
-              disableAutomaticFeeSet={shouldTopUp}
-              shouldTopUp={shouldTopUp}
-            />
-          </VerticalCollapseTransition>
-          <VerticalCollapseTransition collapsed={!shouldTopUp}>
-            <FeeCoverageDescription isTopUpAvailable={isTopUpAvailable} />
-          </VerticalCollapseTransition>
         </Stack>
+        <div style={{ flex: 1 }} />
+        <VerticalCollapseTransition collapsed={shouldTopUp}>
+          <FeeControl
+            senderConfig={senderConfig}
+            feeConfig={feeConfig}
+            gasConfig={gasConfig}
+            gasSimulator={gasSimulator}
+            disableAutomaticFeeSet={shouldTopUp}
+            shouldTopUp={shouldTopUp}
+          />
+        </VerticalCollapseTransition>
+        <VerticalCollapseTransition
+          collapsed={!(shouldTopUp && isTopUpAvailable)}
+        >
+          <FeeCoverageDescription isTopUpAvailable={isTopUpAvailable} />
+        </VerticalCollapseTransition>
       </Box>
     );
   }

--- a/apps/extension/src/pages/send/amount/index.tsx
+++ b/apps/extension/src/pages/send/amount/index.tsx
@@ -2278,7 +2278,9 @@ export const SendAmountPage: FunctionComponent = observer(() => {
             />
           </VerticalCollapseTransition>
           <Gutter size="0" />
-          <VerticalCollapseTransition collapsed={!shouldTopUp}>
+          <VerticalCollapseTransition
+            collapsed={!(shouldTopUp && isTopUpAvailable)}
+          >
             <FeeCoverageDescription isTopUpAvailable={isTopUpAvailable} />
           </VerticalCollapseTransition>
           <Gutter size="0" />

--- a/apps/extension/src/pages/sign/cosmos/tx/view.tsx
+++ b/apps/extension/src/pages/sign/cosmos/tx/view.tsx
@@ -616,7 +616,8 @@ export const CosmosTxView: FunctionComponent<{
         },
       ]}
       bottomBackground={
-        shouldTopUp && !interactionData.isInternal ? (
+        ((shouldTopUp && isTopUpAvailable) || topUpCompleted) &&
+        !interactionData.isInternal ? (
           <FeeCoverageBackground
             hideIcon={
               !!topUpError ||
@@ -780,6 +781,11 @@ export const CosmosTxView: FunctionComponent<{
           </React.Fragment>
         ) : null}
 
+        {/**
+         // Since shouldTopUp can temporarily become true during the balance check process in fee config,
+         // we only check shouldTopUp || topUpCompleted so that the section can remain collapsed temporarily,
+         // and if top-up is not available, fee control section can be displayed.
+         */}
         <VerticalCollapseTransition collapsed={shouldTopUp || topUpCompleted}>
           <Box
             style={{
@@ -820,8 +826,11 @@ export const CosmosTxView: FunctionComponent<{
             ) : null}
           </Box>
         </VerticalCollapseTransition>
+        {/**
+         * fee coverage section should be displayed when top-up is should be done and available, or completed.
+         */}
         <VerticalCollapseTransition
-          collapsed={!(shouldTopUp || topUpCompleted)}
+          collapsed={!((shouldTopUp && isTopUpAvailable) || topUpCompleted)}
         >
           {interactionData.isInternal ? (
             <FeeCoverageBox feeConfig={feeConfig} />


### PR DESCRIPTION
- topup 지원되지 않는 체인에서 `shouldTopUp`이 잠깐 true로 계산되어서 flicker가 발생하던 현상 수정
- ibc transfer amount 페이지의 fee 관련 ui 하단 버튼에 붙도록 수정