### PR TITLE
Add Neutron governance proposal and vote queries to stores package

### DIFF
--- a/packages/stores/src/query/cosmwasm/index.ts
+++ b/packages/stores/src/query/cosmwasm/index.ts
@@ -3,3 +3,5 @@ export * as CosmWasm from "./types";
 export * from "./queries";
 export * from "./neutron/staking-rewards";
 export * from "./neutron/staking-rewards-config";
+export * from "./neutron/governance-proposals";
+export * from "./neutron/governance-vote";

--- a/packages/stores/src/query/cosmwasm/neutron/governance-proposals.ts
+++ b/packages/stores/src/query/cosmwasm/neutron/governance-proposals.ts
@@ -1,0 +1,150 @@
+import { ChainGetter } from "../../../chain";
+import { ObservableCosmwasmContractChainQuery } from "../contract-query";
+import { QuerySharedContext } from "../../../common";
+import { ObservableChainQueryMap } from "../../chain-query";
+import { computed } from "mobx";
+
+export enum NeutronGovProposalStatus {
+  OPEN = "open",
+  PASSED = "passed",
+  REJECTED = "rejected",
+  EXECUTED = "executed",
+  CLOSED = "closed",
+  EXECUTION_FAILED = "execution_failed",
+}
+
+interface NeutronGovThreshold {
+  threshold_quorum?: {
+    threshold: string;
+    quorum: string;
+  };
+  absolute_percentage?: {
+    percentage: string;
+  };
+}
+
+interface NeutronGovProposal {
+  id: number;
+  title: string;
+  description: string;
+  proposer: string;
+  start_height: number;
+  min_voting_period: null;
+  expiration: {
+    at_time?: string;
+    at_height?: string;
+  };
+  threshold: NeutronGovThreshold;
+  total_power: string;
+  msgs: unknown[];
+  status: NeutronGovProposalStatus;
+  votes: {
+    yes: string;
+    no: string;
+    abstain: string;
+  };
+  allow_revoting: boolean;
+}
+
+interface NeutronGovProposalsResponse {
+  proposals: {
+    id: number;
+    proposal: NeutronGovProposal;
+  }[];
+}
+
+class ObservableQueryNeutronGovernanceInner extends ObservableCosmwasmContractChainQuery<NeutronGovProposalsResponse> {
+  public static readonly NEUTRON_PROPOSAL_MODULE_ADDRESS_MAINNET =
+    "neutron1436kxs0w2es6xlqpp9rd35e3d0cjnw4sv8j3a7483sgks29jqwgshlt6zh";
+  public static readonly NEUTRON_PROPOSAL_MODULE_ADDRESS_TESTNET =
+    "neutron19sf2y4dvgt02kczemvhktrwvt4aunrahw8qkjq6u3pehdujwssgqrs5e4h";
+
+  constructor(
+    sharedContext: QuerySharedContext,
+    chainId: string,
+    chainGetter: ChainGetter,
+    protected readonly params: { start_before?: number; limit?: number }
+  ) {
+    const contractAddress =
+      chainId === "neutron-1"
+        ? ObservableQueryNeutronGovernanceInner.NEUTRON_PROPOSAL_MODULE_ADDRESS_MAINNET
+        : chainId === "pion-1"
+        ? ObservableQueryNeutronGovernanceInner.NEUTRON_PROPOSAL_MODULE_ADDRESS_TESTNET
+        : "";
+
+    super(sharedContext, chainId, chainGetter, contractAddress, {
+      reverse_proposals: params || { limit: 20 },
+    });
+  }
+
+  protected override canFetch(): boolean {
+    return (
+      super.canFetch() &&
+      (this.chainId === "neutron-1" || this.chainId === "pion-1")
+    );
+  }
+
+  @computed
+  get proposals(): {
+    id: number;
+    proposal: NeutronGovProposal;
+  }[] {
+    if (!this.response?.data) {
+      return [];
+    }
+    return this.response.data.proposals || [];
+  }
+}
+
+export class ObservableQueryNeutronGovernance extends ObservableChainQueryMap<NeutronGovProposalsResponse> {
+  constructor(
+    sharedContext: QuerySharedContext,
+    chainId: string,
+    chainGetter: ChainGetter
+  ) {
+    super(sharedContext, chainId, chainGetter, (param: string) => {
+      const parsedParams = JSON.parse(param);
+      return new ObservableQueryNeutronGovernanceInner(
+        this.sharedContext,
+        this.chainId,
+        this.chainGetter,
+        parsedParams
+      );
+    });
+  }
+
+  getQueryGovernanceWithPage(params: { page: number; perPageNumber: number }): {
+    proposals: { id: number; proposal: NeutronGovProposal }[];
+    firstFetching: boolean;
+    nextKey: number | null;
+    isFetching: boolean;
+  } {
+    const list = Array.from({ length: params.page + 1 }, (_, i) => {
+      return JSON.stringify({
+        start_before: i === 0 ? undefined : i * params.perPageNumber,
+        limit: params.perPageNumber,
+      });
+    });
+
+    const proposals = list.flatMap((param) => {
+      const query = this.get(param) as ObservableQueryNeutronGovernanceInner;
+      return query.proposals;
+    });
+
+    const lastQuery = this.get(
+      list[list.length - 1]
+    ) as ObservableQueryNeutronGovernanceInner;
+
+    const nextKey =
+      lastQuery.proposals.length === params.perPageNumber
+        ? proposals[proposals.length - 1]?.id
+        : null;
+
+    return {
+      proposals,
+      firstFetching: lastQuery.isFetching && proposals.length === 0,
+      nextKey,
+      isFetching: lastQuery.isFetching,
+    };
+  }
+}

--- a/packages/stores/src/query/cosmwasm/neutron/governance-vote.ts
+++ b/packages/stores/src/query/cosmwasm/neutron/governance-vote.ts
@@ -1,0 +1,109 @@
+import { ChainGetter } from "../../../chain";
+import { ObservableCosmwasmContractChainQuery } from "../contract-query";
+import { QuerySharedContext } from "../../../common";
+import { ObservableChainQueryMap } from "../../chain-query";
+import { computed } from "mobx";
+
+interface NeutronGovVote {
+  voter: string;
+  vote: "yes" | "no" | "abstain";
+  power: string;
+}
+
+interface NeutronGovVoteResponse {
+  vote: NeutronGovVote | null;
+}
+
+class ObservableQueryNeutronProposalVoteInner extends ObservableCosmwasmContractChainQuery<NeutronGovVoteResponse> {
+  public static readonly NEUTRON_PROPOSAL_MODULE_ADDRESS_MAINNET =
+    "neutron1436kxs0w2es6xlqpp9rd35e3d0cjnw4sv8j3a7483sgks29jqwgshlt6zh";
+  public static readonly NEUTRON_PROPOSAL_MODULE_ADDRESS_TESTNET =
+    "neutron19sf2y4dvgt02kczemvhktrwvt4aunrahw8qkjq6u3pehdujwssgqrs5e4h";
+
+  protected proposalId: string;
+  protected bech32Address: string;
+
+  constructor(
+    sharedContext: QuerySharedContext,
+    chainId: string,
+    chainGetter: ChainGetter,
+    proposalId: string,
+    bech32Address: string
+  ) {
+    const contractAddress =
+      chainId === "neutron-1"
+        ? ObservableQueryNeutronProposalVoteInner.NEUTRON_PROPOSAL_MODULE_ADDRESS_MAINNET
+        : chainId === "pion-1"
+        ? ObservableQueryNeutronProposalVoteInner.NEUTRON_PROPOSAL_MODULE_ADDRESS_TESTNET
+        : "";
+
+    super(sharedContext, chainId, chainGetter, contractAddress, {
+      get_vote: { proposal_id: parseInt(proposalId), voter: bech32Address },
+    });
+    this.proposalId = proposalId;
+    this.bech32Address = bech32Address;
+  }
+
+  @computed
+  get vote(): "Yes" | "Abstain" | "No" | "NoWithVeto" | "Unspecified" {
+    if (!this.response?.data?.vote) {
+      return "Unspecified";
+    }
+
+    const voteOption = this.response.data.vote.vote;
+    switch (voteOption) {
+      case "yes":
+        return "Yes";
+      case "abstain":
+        return "Abstain";
+      case "no":
+        return "No";
+      default:
+        return "Unspecified";
+    }
+  }
+
+  refetch() {
+    this.fetch();
+  }
+
+  protected override canFetch(): boolean {
+    return (
+      super.canFetch() &&
+      this.bech32Address.length > 0 &&
+      (this.chainId === "neutron-1" || this.chainId === "pion-1")
+    );
+  }
+}
+
+export class ObservableQueryNeutronProposalVote extends ObservableChainQueryMap<NeutronGovVoteResponse> {
+  constructor(
+    sharedContext: QuerySharedContext,
+    chainId: string,
+    chainGetter: ChainGetter
+  ) {
+    super(sharedContext, chainId, chainGetter, (param: string) => {
+      const { proposalId, voter } = JSON.parse(param);
+
+      return new ObservableQueryNeutronProposalVoteInner(
+        this.sharedContext,
+        this.chainId,
+        this.chainGetter,
+        proposalId,
+        voter
+      );
+    });
+  }
+
+  getVote(
+    proposalId: string,
+    voter: string
+  ): ObservableQueryNeutronProposalVoteInner {
+    const param = JSON.stringify({
+      proposalId,
+      voter,
+    });
+
+    return this.get(param) as ObservableQueryNeutronProposalVoteInner;
+  }
+}

--- a/packages/stores/src/query/cosmwasm/queries.ts
+++ b/packages/stores/src/query/cosmwasm/queries.ts
@@ -6,6 +6,8 @@ import { ObservableQueryCw20BalanceRegistry } from "./cw20-balance";
 import { QuerySharedContext } from "../../common";
 import { ObservableQueryNeutronStakingRewards } from "./neutron/staking-rewards";
 import { ObservableQueryNeutronStakingRewardsConfig } from "./neutron/staking-rewards-config";
+import { ObservableQueryNeutronGovernance } from "./neutron/governance-proposals";
+import { ObservableQueryNeutronProposalVote } from "./neutron/governance-vote";
 
 export interface CosmwasmQueries {
   cosmwasm: CosmwasmQueriesImpl;
@@ -40,6 +42,9 @@ export class CosmwasmQueriesImpl {
   public readonly querycw20ContractInfo: DeepReadonly<ObservableQueryCw20ContractInfo>;
   public readonly queryNeutronStakingRewards: DeepReadonly<ObservableQueryNeutronStakingRewards>;
   public readonly queryNeutronStakingRewardsConfig: DeepReadonly<ObservableQueryNeutronStakingRewardsConfig>;
+  public readonly queryNeutronGovernance: DeepReadonly<ObservableQueryNeutronGovernance>;
+  public readonly queryNeutronVote: DeepReadonly<ObservableQueryNeutronProposalVote>;
+
   constructor(
     base: QueriesSetBase,
     sharedContext: QuerySharedContext,
@@ -68,5 +73,17 @@ export class CosmwasmQueriesImpl {
         chainId,
         chainGetter
       );
+
+    this.queryNeutronGovernance = new ObservableQueryNeutronGovernance(
+      sharedContext,
+      chainId,
+      chainGetter
+    );
+
+    this.queryNeutronVote = new ObservableQueryNeutronProposalVote(
+      sharedContext,
+      chainId,
+      chainGetter
+    );
   }
 }


### PR DESCRIPTION
### 요약
`@keplr-wallet/stores` 패키지에 모바일에서 사용할 Neutron 거버넌스 관련 쿼리 모듈 추가

### 원인
  - Neutron은 일반적인 Cosmos SDK 거버넌스와 달리 CosmWasm 컨트랙트 기반의 거버넌스를 사용합니다.
  - 그러나 지금 모바일은 Neutron 프로퍼절 목록을 가져올 때 Cosmos Gov 엔드포인트를 사용해서 501(Not implemented) 에러가 납니다.

### 해결
  - 모바일에서 CosmWasm 기반 엔드포인트와 쿼리를 사용할 수 있도록 Neutron 전용 거버넌스 쿼리 모듈을 추가합니다.
  (본 레포의 [해당 경로](https://github.com/chainapsis/keplr-wallet/tree/develop/packages/stores/src/query/cosmwasm/neutron)에 모바일에서 사용하는 neutron staking rewards 관련 쿼리 모듈이 이미 존재해서 유사하게 나란히 추가했습니다.)

### 참고
- https://github.com/chainapsis/keplr-mobile-private/pull/348
- https://linear.app/keplrwallet/issue/KEPLR-1361/mob-neutron-%EC%B2%B4%EC%9D%B8-%ED%94%84%EB%A1%9C%ED%8F%AC%EC%A0%88-%EC%95%84%EC%98%88-%EC%95%88-%EB%B3%B4%EC%9D%B4%EB%8A%94-%EC%9D%B4%EC%8A%88
