### PR TITLE
Close context menu/dropdown when scroll

### DIFF
--- a/apps/extension/src/pages/main/components/context-menu/index.tsx
+++ b/apps/extension/src/pages/main/components/context-menu/index.tsx
@@ -318,17 +318,35 @@ export const ViewOptionsContextMenu: FunctionComponent<{
       if (scrollElement) {
         /**
          * 사용자가 직접 스크롤(wheel/touchmove)했을 때만 메뉴를 닫는다.
+         * 단, 터치의 미세한 떨림은 무시한다.
          */
-        scrollElement.addEventListener("wheel", closeMenu);
-        scrollElement.addEventListener("touchmove", closeMenu);
-      }
+        let touchStartY = 0;
+        const TOUCH_MOVE_THRESHOLD = 10; // px
 
-      return () => {
-        scrollElement?.removeEventListener("wheel", closeMenu);
-        scrollElement?.removeEventListener("touchmove", closeMenu);
-      };
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isOpen, closeMenu]);
+        const onTouchStart = (e: TouchEvent) => {
+          touchStartY = e.touches[0].clientY;
+        };
+
+        const onTouchMove = (e: TouchEvent) => {
+          const currentY = e.touches[0].clientY;
+          const diff = Math.abs(currentY - touchStartY);
+
+          if (diff > TOUCH_MOVE_THRESHOLD) {
+            closeMenu();
+          }
+        };
+
+        scrollElement.addEventListener("wheel", closeMenu);
+        scrollElement.addEventListener("touchstart", onTouchStart);
+        scrollElement.addEventListener("touchmove", onTouchMove);
+
+        return () => {
+          scrollElement.removeEventListener("wheel", closeMenu);
+          scrollElement.removeEventListener("touchstart", onTouchStart);
+          scrollElement.removeEventListener("touchmove", onTouchMove);
+        };
+      }
+    }, [isOpen, closeMenu, globalSimpleBar]);
 
     const toggleMenu = () => {
       analyticsAmplitudeStore.logEvent("click_view_options_context_menu", {

--- a/apps/extension/src/pages/manage-chains/components/ecosystem-filter-dropdown.tsx
+++ b/apps/extension/src/pages/manage-chains/components/ecosystem-filter-dropdown.tsx
@@ -34,15 +34,41 @@ export const EcosystemFilterDropdown: FunctionComponent<Props> = ({
     if (!isOpen) {
       return;
     }
+
     const scrollElement = globalSimpleBar.ref.current?.getScrollElement();
 
-    scrollElement?.addEventListener("scroll", closeDropdown);
+    if (scrollElement) {
+      /**
+       * 사용자가 직접 스크롤(wheel/touchmove)했을 때만 메뉴를 닫는다.
+       * 단, 터치의 미세한 떨림은 무시한다.
+       */
+      let touchStartY = 0;
+      const TOUCH_MOVE_THRESHOLD = 10; // px
 
-    return () => {
-      scrollElement?.removeEventListener("scroll", closeDropdown);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen]);
+      const onTouchStart = (e: TouchEvent) => {
+        touchStartY = e.touches[0].clientY;
+      };
+
+      const onTouchMove = (e: TouchEvent) => {
+        const currentY = e.touches[0].clientY;
+        const diff = Math.abs(currentY - touchStartY);
+
+        if (diff > TOUCH_MOVE_THRESHOLD) {
+          closeDropdown();
+        }
+      };
+
+      scrollElement.addEventListener("wheel", closeDropdown);
+      scrollElement.addEventListener("touchstart", onTouchStart);
+      scrollElement.addEventListener("touchmove", onTouchMove);
+
+      return () => {
+        scrollElement.removeEventListener("wheel", closeDropdown);
+        scrollElement.removeEventListener("touchstart", onTouchStart);
+        scrollElement.removeEventListener("touchmove", onTouchMove);
+      };
+    }
+  }, [closeDropdown, globalSimpleBar, isOpen]);
 
   return (
     <Styles.MenuContainer>


### PR DESCRIPTION
### 문제
일부 드롭다운류 컴포넌트(context-menu, ecosystem-filter-dropdown)가 스크롤시에도 닫히지 않아 헤더 영역을 침범함

### 해결
스크롤되거나 휠할 때 닫히도록 수정

#### AS-IS
<img width="434" height="532" alt="스크린샷 2025-11-14 오후 2 50 34" src="https://github.com/user-attachments/assets/e408d0b8-fab9-4eb0-95d5-b0a4e30ce42d" />
<img width="381" height="669" alt="스크린샷 2025-11-14 오후 2 50 24" src="https://github.com/user-attachments/assets/420ba40b-6e8c-432b-b74a-5f3f9262d795" />


#### TO-BE

https://github.com/user-attachments/assets/c5fc0c07-005d-4a95-a519-b4b2255b7b01


https://github.com/user-attachments/assets/1524a8f1-e6e5-4009-8712-1866a1b051d4

#### 참고
https://linear.app/keplrwallet/issue/KEPLR-1406/fe-dev-ext-close-context-menu-when-scroll


