### PR TITLE
Rewards card update

### DIFF
--- a/apps/extension/src/pages/main/components/rewards-card/index.tsx
+++ b/apps/extension/src/pages/main/components/rewards-card/index.tsx
@@ -288,6 +288,9 @@ const ClaimAllButton: FunctionComponent<ClaimAllButtonProps> = ({
   return (
     <Box
       onHoverStateChange={(hovered) => {
+        if (claimAllDisabled || claimAllIsLoading) {
+          return;
+        }
         if (!hovered) {
           setIsPressed(false);
         }


### PR DESCRIPTION
- claim all 버튼과 rewards card의 click 및 hover영역 구분
- claim all 버튼에 hover interaction 추가
- rewards card의 claim all 버튼을 제외한 요소에 hover시 opacity 적용
- rewards card 우측 상단에 carousel arrow right icon 추가