### PR TITLE
handle bitcoin tx size as floating point number

### DIFF
--- a/apps/extension/src/hooks/bitcoin/use-tx-configs-query-string.ts
+++ b/apps/extension/src/hooks/bitcoin/use-tx-configs-query-string.ts
@@ -39,7 +39,7 @@ export const useBitcoinTxConfigsQueryString = (configs: {
 
     const initialTxSize = searchParams.get("initialTxSize");
     if (initialTxSize) {
-      configs.txSizeConfig.setValue(Number.parseInt(initialTxSize));
+      configs.txSizeConfig.setValue(Number.parseFloat(initialTxSize));
     }
 
     const initialFeeRateType = searchParams.get("initialFeeRateType");

--- a/packages/hooks-bitcoin/src/tx/fee.ts
+++ b/packages/hooks-bitcoin/src/tx/fee.ts
@@ -88,10 +88,15 @@ export class FeeConfig extends TxChainSetter implements IFeeConfig {
         return undefined;
       }
 
-      return new CoinPretty(
-        this.amountConfig.currency,
+      if (this.txSizeConfig.txSize <= 0) {
+        return new CoinPretty(this.amountConfig.currency, new Dec(0));
+      }
+
+      const feeDec = new Dec(
         this.txSizeConfig.txSize * this.feeRateConfig.feeRate + this.remainder
-      );
+      ).roundUpDec();
+
+      return new CoinPretty(this.amountConfig.currency, feeDec);
     }
 
     return new CoinPretty(this.amountConfig.currency, this._value);

--- a/packages/hooks-bitcoin/src/tx/psbt-simulator.ts
+++ b/packages/hooks-bitcoin/src/tx/psbt-simulator.ts
@@ -80,7 +80,7 @@ class PsbtSimulatorState {
   @action
   setInitialTxSize(value: number | string) {
     if (typeof value === "string") {
-      value = parseInt(value);
+      value = Number.parseFloat(value);
     }
 
     this._initialTxSize = value;

--- a/packages/hooks-bitcoin/src/tx/tx-size.ts
+++ b/packages/hooks-bitcoin/src/tx/tx-size.ts
@@ -48,7 +48,7 @@ export class TxSizeConfig extends TxChainSetter implements ITxSizeConfig {
       return 0;
     }
 
-    const num = Number.parseInt(this._value);
+    const num = Number.parseFloat(this._value);
     if (Number.isNaN(num)) {
       if (this._disallowZeroTxSize) {
         return undefined;
@@ -67,7 +67,7 @@ export class TxSizeConfig extends TxChainSetter implements ITxSizeConfig {
       };
     }
 
-    const num = Number.parseInt(this._value);
+    const num = Number.parseFloat(this._value);
     if (Number.isNaN(num)) {
       return {
         error: new Error("Tx size is not valid number"),


### PR DESCRIPTION
- 문제: 1.0 fee rate로 전송할 때 수수료가 비트코인 네트워크의 minimum relay fee(virtual tx size * 1)보다 적게 계산이 돼서 트랜잭션이 실패하는 이슈가 발생하였습니다.
- 원인: tx size를 parseInt로 정수로 변환하면서 버려진 값이 수수료 계산에 적용이 안돼서 최소한의 수수료 기준을 충족시키지 못하는 것이었습니다.
- 해결: tx size를 실수로 처리하도록 수정했습니다.