### PR TITLE
Prevent negative value when subtracting fee from max amount

### DIFF
--- a/packages/hooks/src/tx/amount.ts
+++ b/packages/hooks/src/tx/amount.ts
@@ -110,7 +110,13 @@ export class AmountConfig extends TxChainSetter implements IAmountConfig {
         const subFee = this.feeConfig.fees[0].mul(
           new Dec(this._fractionSubFeeWeight)
         );
-        return maxValue.sub(subFee).toString();
+        const finalValue = maxValue.sub(subFee);
+
+        if (finalValue.toDec().lte(new Dec(0))) {
+          return "0";
+        }
+
+        return finalValue.toString();
       }
 
       return maxValue.toString();


### PR DESCRIPTION
### 변경 사항

(스테이킹시) 수수료를 차감한 최종 금액이 음수가 되지 않도록 처리 추가
- `_fractionSubFeeWeight`를 사용하여 추가 수수료를 차감할 때, 최종 값이 0 이하가 되면 "0"을 반환하도록 가드 추가

### 참고
- [slack](https://keplrwallet.slack.com/archives/C06GFSV4D6W/p1764220175982439?thread_ts=1764073799.277159&cid=C06GFSV4D6W)
- [linear](https://linear.app/keplrwallet/issue/KEPLR-1524/mob-staking-%ED%95%A0-%EB%95%8C-max-%EB%88%84%EB%A5%B8%EA%B2%BD%EC%9A%B0-%EB%A7%88%EC%9D%B4%EB%84%88%EC%8A%A4-%EA%B0%92)