### PR TITLE
Display topup remaining time as hours/minutes when >= 1h, otherwise minutes/seconds

### DIFF
--- a/apps/extension/src/hooks/use-topup.ts
+++ b/apps/extension/src/hooks/use-topup.ts
@@ -50,15 +50,26 @@ export function useTopUp({
 
   const remainingText = (() => {
     if (remainingTimeMs === undefined) return undefined;
-    const minutes = Math.floor(remainingTimeMs / 60000);
-    const seconds = Math.floor((remainingTimeMs % 60000) / 1000);
-    return intl.formatMessage(
-      { id: "components.top-up.wait-time" },
-      {
-        minutes: minutes.toString(),
-        seconds: seconds.toString().padStart(2, "0"),
-      }
-    );
+
+    const HOUR_MS = 60 * 60 * 1000;
+    const MINUTE_MS = 60 * 1000;
+    let time: string;
+
+    if (remainingTimeMs >= HOUR_MS) {
+      const hours = Math.floor(remainingTimeMs / HOUR_MS);
+      const minutes = Math.floor((remainingTimeMs % HOUR_MS) / MINUTE_MS);
+      time = `${hours.toString().padStart(2, "0")}h ${minutes
+        .toString()
+        .padStart(2, "0")}m`;
+    } else {
+      const minutes = Math.floor(remainingTimeMs / MINUTE_MS);
+      const seconds = Math.floor((remainingTimeMs % MINUTE_MS) / 1000);
+      time = `${minutes.toString().padStart(2, "0")}m ${seconds
+        .toString()
+        .padStart(2, "0")}s`;
+    }
+
+    return intl.formatMessage({ id: "components.top-up.wait-time" }, { time });
   })();
 
   useEffect(() => {

--- a/apps/extension/src/languages/en.json
+++ b/apps/extension/src/languages/en.json
@@ -889,7 +889,7 @@
   "components.top-up.tx-fee": "Tx Fee",
   "components.top-up.covered-by-keplr": "Covered by Keplr",
   "components.top-up.keep-window-open": "Keep this window open during the transaction",
-  "components.top-up.wait-time": "Next free tx in {minutes}:{seconds}",
+  "components.top-up.wait-time": "Next free tx in {time}",
 
   "button.confirm": "Confirm",
   "button.ok": "OK",

--- a/apps/extension/src/languages/ko.json
+++ b/apps/extension/src/languages/ko.json
@@ -795,7 +795,7 @@
   "components.top-up.tx-fee": "트랜잭션 수수료",
   "components.top-up.covered-by-keplr": "Keplr가 대신 지불",
   "components.top-up.keep-window-open": "거래 진행 중에는 이 창을 열어두세요",
-  "components.top-up.wait-time": "다음 수수료 지원까지 {minutes}:{seconds}",
+  "components.top-up.wait-time": "다음 수수료 지원까지 {time}",
 
   "button.confirm": "확인",
   "button.ok": "확인",

--- a/apps/extension/src/languages/zh-cn.json
+++ b/apps/extension/src/languages/zh-cn.json
@@ -738,7 +738,7 @@
   "components.top-up.tx-fee": "交易手续费",
   "components.top-up.covered-by-keplr": "由 Keplr 支付",
   "components.top-up.keep-window-open": "交易期间请保持此窗口打开",
-  "components.top-up.wait-time": "下次免费交易在 {minutes}:{seconds}",
+  "components.top-up.wait-time": "下次免费交易在 {time}",
 
   "button.confirm": "确定",
   "button.ok": "好的",


### PR DESCRIPTION
`remainingTimeMs`를 하드코딩해서 테스트했습니다.

<img width="345" height="126" alt="스크린샷 2025-12-02 오후 5 05 16" src="https://github.com/user-attachments/assets/3af6ec00-d990-4b35-ba2b-cd6567c0a69a" />
<img width="345" height="126" alt="스크린샷 2025-12-02 오후 5 04 58" src="https://github.com/user-attachments/assets/117472f2-bc21-4cd4-be55-98305c4a5c54" />
