### PR TITLE
refactor: Remove unnecessary homeRewardsSuppressedByKeyId ref from useRewards

### DIFF
--- a/apps/extension/src/hooks/use-rewards.ts
+++ b/apps/extension/src/hooks/use-rewards.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo } from "react";
 import { ViewToken } from "../pages/main";
 import { useStore } from "../stores";
 import {
@@ -33,8 +33,6 @@ const USDN_CURRENCY = {
 
 const zeroDec = new Dec(0);
 
-const homeRewardsSuppressedByKeyId = new Set<string>();
-
 export function useRewards() {
   const {
     chainStore,
@@ -52,11 +50,6 @@ export function useRewards() {
     useStarknetClaimRewards();
 
   const { states, getClaimAllEachState } = useClaimAllEachState();
-  const prevSelectedKeyIdRef = useRef(keyRingStore.selectedKeyInfo?.id);
-  const keyId = keyRingStore.selectedKeyInfo?.id ?? "unknown";
-
-  const [claimAllIsCompleted, setClaimAllIsCompleted] = useState(false);
-  const [claimAllIsLoading, setClaimAllIsLoading] = useState(false);
 
   const viewClaimTokens: ViewClaimToken[] = (() => {
     const res: ViewClaimToken[] = [];
@@ -238,10 +231,6 @@ export function useRewards() {
 
   const claimAll = () => {
     analyticsStore.logEvent("click_claimAll");
-    homeRewardsSuppressedByKeyId.delete(keyId);
-
-    setClaimAllIsCompleted(false);
-    setClaimAllIsLoading(true);
 
     for (const viewClaimToken of viewClaimTokens) {
       const state = getClaimAllEachState(
@@ -298,7 +287,7 @@ export function useRewards() {
     return count;
   }, [viewClaimTokens, getClaimAllEachState]);
 
-  const hasAnyInProgress = useMemo(() => {
+  const claimAllIsLoading = useMemo(() => {
     for (const viewClaimToken of viewClaimTokens) {
       const state = getClaimAllEachState(
         viewClaimToken.modularChainInfo.chainId
@@ -310,100 +299,9 @@ export function useRewards() {
     return false;
   }, [viewClaimTokens, getClaimAllEachState]);
 
-  useEffect(() => {
-    setClaimAllIsLoading(hasAnyInProgress);
-  }, [hasAnyInProgress]);
-
-  useEffect(() => {
-    if (homeRewardsSuppressedByKeyId.has(keyId)) {
-      setClaimAllIsCompleted(false);
-      return;
-    }
-    setClaimAllIsCompleted(
-      totalClaimTokenCount > 0 && finishedCount === totalClaimTokenCount
-    );
-  }, [finishedCount, totalClaimTokenCount, keyId]);
-
-  const [count, setCount] = useState(0);
-
-  const claimCountText = useMemo(() => {
-    if (totalClaimTokenCount === 0) {
-      return "";
-    }
-
-    return `${succeededCount}/${totalClaimTokenCount}`;
-  }, [succeededCount, totalClaimTokenCount]);
-
-  useEffect(() => {
-    if (keyRingStore.selectedKeyInfo?.id !== prevSelectedKeyIdRef.current) {
-      return;
-    }
-
-    if (!claimAllIsCompleted) {
-      return;
-    }
-
-    setCount(6);
-
-    const interval = setInterval(() => {
-      setCount((prev) => {
-        if (prev <= 1) {
-          clearInterval(interval);
-          setClaimAllIsCompleted(false);
-          return 0;
-        }
-        return prev - 1;
-      });
-    }, 1000);
-
-    return () => {
-      setCount(0);
-      clearInterval(interval);
-      setClaimAllIsCompleted(false);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [claimAllIsCompleted]);
-
-  useEffect(() => {
-    if (keyRingStore.selectedKeyInfo?.id !== prevSelectedKeyIdRef.current) {
-      setClaimAllIsLoading(false);
-      setClaimAllIsCompleted(false);
-      setCount(0);
-      for (const s of states) {
-        s.reset();
-      }
-      prevSelectedKeyIdRef.current = keyRingStore.selectedKeyInfo?.id;
-      homeRewardsSuppressedByKeyId.delete(keyId);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [keyRingStore.selectedKeyInfo?.id]);
-
-  const claimAllIsCompletedRef = useRef(claimAllIsCompleted);
-  const countRef = useRef(count);
-  const keyIdRef = useRef(keyId);
-
-  // complete 되고 다른 페이지로 이동할 경우에만 UI상태를 초기화 하기 위해서 참조를 유지한다.
-  useEffect(() => {
-    claimAllIsCompletedRef.current = claimAllIsCompleted;
-  }, [claimAllIsCompleted]);
-
-  useEffect(() => {
-    countRef.current = count;
-  }, [count]);
-
-  useEffect(() => {
-    keyIdRef.current = keyId;
-  }, [keyId]);
-
-  useEffect(() => {
-    return () => {
-      if (claimAllIsCompletedRef.current && countRef.current > 0) {
-        homeRewardsSuppressedByKeyId.add(keyIdRef.current);
-        setCount(0);
-        setClaimAllIsCompleted(false);
-      }
-    };
-  }, []);
+  const claimAllIsCompleted = useMemo(() => {
+    return totalClaimTokenCount > 0 && finishedCount === totalClaimTokenCount;
+  }, [finishedCount, totalClaimTokenCount]);
 
   return {
     viewClaimTokens,
@@ -416,7 +314,7 @@ export function useRewards() {
     claimAllIsCompleted,
     getClaimAllEachState,
     states,
-    count,
-    claimCountText,
+    succeededCount,
+    totalClaimTokenCount,
   };
 }


### PR DESCRIPTION
- home > claim all 클릭 > complete 된 이후 count가 세어지고 있는 동안 다른 페이지로 넘어갔다가 돌아왔을 경우, 다시 기본 상태로 돌아가서 claim all 버튼이 보여야 함
- 이 때 기본 상태가 아닌 완료 상태로 보이면서 count만 초기화되는 현상을 방지하기 위해 `homeRewardsSuppressedByKeyId`라는 ref가 사용되고 있었음
- 로직을 단순화하여 loading > complete 되었을 때만 countdown ui를 보여주도록 처리
- 위를 포함하여, 공통이 아닌 home 의 rewards card에만 해당되는 로직은 rewards card 컴포넌트 내에서 처리하도록 개선