### PR TITLE
New Tokens Found 변경

### DIFF
--- a/apps/extension/src/pages/main/components/token-found-modal/index.tsx
+++ b/apps/extension/src/pages/main/components/token-found-modal/index.tsx
@@ -41,7 +41,8 @@ import { useTokenTag } from "../../../../hooks/use-token-tag";
 
 export const TokenFoundModal: FunctionComponent<{
   close: () => void;
-}> = observer(({ close }) => {
+  tokenScans: TokenScan[];
+}> = observer(({ close, tokenScans }) => {
   const { chainStore, keyRingStore } = useStore();
   const intl = useIntl();
   const theme = useTheme();
@@ -51,13 +52,13 @@ export const TokenFoundModal: FunctionComponent<{
   >([]);
 
   const numFoundToken = useMemo(() => {
-    if (chainStore.tokenScans.length === 0) {
+    if (tokenScans.length === 0) {
       return 0;
     }
 
     const set = new Set<string>();
 
-    for (const tokenScan of chainStore.tokenScans) {
+    for (const tokenScan of tokenScans) {
       for (const info of tokenScan.infos) {
         for (const asset of info.assets) {
           const key = `${ChainIdHelper.parse(tokenScan.chainId).identifier}/${
@@ -69,7 +70,7 @@ export const TokenFoundModal: FunctionComponent<{
     }
 
     return Array.from(set).length;
-  }, [chainStore.tokenScans]);
+  }, [tokenScans]);
 
   const buttonClicked = async () => {
     if (!keyRingStore.selectedKeyInfo) {
@@ -80,7 +81,7 @@ export const TokenFoundModal: FunctionComponent<{
       .filter((identifier) => !chainStore.isEnabledChain(identifier))
       .filter((identifier) => {
         return (
-          chainStore.tokenScans.find((tokenScan) => {
+          tokenScans.find((tokenScan) => {
             return (
               ChainIdHelper.parse(tokenScan.chainId).identifier === identifier
             );
@@ -89,11 +90,6 @@ export const TokenFoundModal: FunctionComponent<{
       });
 
     const needBIP44Selects: string[] = [];
-
-    // chainStore.tokenScans는 체인이 enable되고 나면 그 체인은 사라진다.
-    // 근데 로직상 enable 이후에 추가 로직이 있다.
-    // 그래서 일단 얇은 복사를 하고 이 값을 사용한다.
-    const tokenScans = chainStore.tokenScans.slice();
 
     const linkedEnables = new Set<string>();
 
@@ -237,7 +233,7 @@ export const TokenFoundModal: FunctionComponent<{
         }}
       >
         <Stack gutter="0.75rem">
-          {chainStore.tokenScans.map((tokenScan) => {
+          {tokenScans.map((tokenScan) => {
             return (
               <FoundChainView
                 key={tokenScan.chainId}
@@ -279,13 +275,11 @@ export const TokenFoundModal: FunctionComponent<{
           onClick={(e) => {
             e.preventDefault();
 
-            if (
-              chainStore.tokenScans.length === checkedChainIdentifiers.length
-            ) {
+            if (tokenScans.length === checkedChainIdentifiers.length) {
               setCheckedChainIdentifiers([]);
             } else {
               setCheckedChainIdentifiers(
-                chainStore.tokenScans.map((tokenScan) => {
+                tokenScans.map((tokenScan) => {
                   return ChainIdHelper.parse(tokenScan.chainId).identifier;
                 })
               );
@@ -301,9 +295,7 @@ export const TokenFoundModal: FunctionComponent<{
 
             <Checkbox
               size="small"
-              checked={
-                chainStore.tokenScans.length === checkedChainIdentifiers.length
-              }
+              checked={tokenScans.length === checkedChainIdentifiers.length}
               onChange={() => {}}
             />
           </XAxis>

--- a/apps/extension/src/pages/main/spendable.tsx
+++ b/apps/extension/src/pages/main/spendable.tsx
@@ -503,13 +503,13 @@ export const SpendableAssetView: FunctionComponent<{
     });
 
     const numFoundToken = useMemo(() => {
-      if (chainStore.tokenScans.length === 0) {
+      if (chainStore.tokenScansWithoutDismissed.length === 0) {
         return 0;
       }
 
       const set = new Set<string>();
 
-      for (const tokenScan of chainStore.tokenScans) {
+      for (const tokenScan of chainStore.tokenScansWithoutDismissed) {
         for (const info of tokenScan.infos) {
           for (const asset of info.assets) {
             const key = `${ChainIdHelper.parse(tokenScan.chainId).identifier}/${
@@ -521,7 +521,7 @@ export const SpendableAssetView: FunctionComponent<{
       }
 
       return Array.from(set).length;
-    }, [chainStore.tokenScans]);
+    }, [chainStore.tokenScansWithoutDismissed]);
 
     const { allBalancesSearchFiltered, lowBalanceTokens, isFirstTime } =
       useAllBalances(trimSearch);
@@ -720,10 +720,9 @@ export const SpendableAssetView: FunctionComponent<{
                 </React.Fragment>
               </VerticalCollapseTransition>
 
-              {numFoundToken > 0 && chainStore.isShowNewTokenFoundInMain && (
+              {numFoundToken > 0 && (
                 <NewTokenFoundButtonContainer
                   onClick={() => {
-                    chainStore.dismissNewTokenFoundInMain();
                     setIsFoundTokenModalOpen(true);
                   }}
                 >
@@ -923,8 +922,18 @@ export const SpendableAssetView: FunctionComponent<{
           isOpen={isFoundTokenModalOpen && numFoundToken > 0}
           align="bottom"
           close={() => setIsFoundTokenModalOpen(false)}
+          onCloseTransitionEnd={() => {
+            chainStore.dismissNewTokenFoundInMain();
+          }}
         >
-          <TokenFoundModal close={() => setIsFoundTokenModalOpen(false)} />
+          {/*
+            여기서 tokenScansWithoutDismissed가 아니라 tokenScans를 사용하는 건 의도된 행동임
+            new tokens 정보가 변했을때 변경된 토큰들만이 아니라 전체 new tokens를 다 보여주도록 함
+          */}
+          <TokenFoundModal
+            tokenScans={chainStore.tokenScans}
+            close={() => setIsFoundTokenModalOpen(false)}
+          />
         </Modal>
       </React.Fragment>
     );

--- a/apps/extension/src/pages/manage-view-asset-token-list/index.tsx
+++ b/apps/extension/src/pages/manage-view-asset-token-list/index.tsx
@@ -298,7 +298,10 @@ export const ManageViewAssetTokenListPage: FunctionComponent = observer(() => {
         align="bottom"
         close={() => setIsFoundTokenModalOpen(false)}
       >
-        <TokenFoundModal close={() => setIsFoundTokenModalOpen(false)} />
+        <TokenFoundModal
+          tokenScans={chainStore.tokenScans}
+          close={() => setIsFoundTokenModalOpen(false)}
+        />
       </Modal>
     </HeaderLayout>
   );

--- a/packages/background/src/token-scan/init.ts
+++ b/packages/background/src/token-scan/init.ts
@@ -1,11 +1,8 @@
 import { Router } from "@keplr-wallet/router";
 import {
   DismissNewTokenFoundInMainMsg,
-  GetIsShowNewTokenFoundInMainMsg,
   GetTokenScansMsg,
   RevalidateTokenScansMsg,
-  SyncTokenScanInfosMsg,
-  UpdateIsShowNewTokenFoundInMainMsg,
 } from "./messages";
 import { ROUTE } from "./constants";
 import { getHandler } from "./handler";
@@ -14,9 +11,6 @@ import { TokenScanService } from "./service";
 export function init(router: Router, service: TokenScanService): void {
   router.registerMessage(GetTokenScansMsg);
   router.registerMessage(RevalidateTokenScansMsg);
-  router.registerMessage(SyncTokenScanInfosMsg);
-  router.registerMessage(GetIsShowNewTokenFoundInMainMsg);
-  router.registerMessage(UpdateIsShowNewTokenFoundInMainMsg);
   router.registerMessage(DismissNewTokenFoundInMainMsg);
 
   router.addHandler(ROUTE, getHandler(service));

--- a/packages/background/src/token-scan/messages.ts
+++ b/packages/background/src/token-scan/messages.ts
@@ -2,7 +2,11 @@ import { Message } from "@keplr-wallet/router";
 import { TokenScan } from "./service";
 import { ROUTE } from "./constants";
 
-export class GetTokenScansMsg extends Message<TokenScan[]> {
+export class GetTokenScansMsg extends Message<{
+  vaultId: string;
+  tokenScans: TokenScan[];
+  tokenScansWithoutDismissed: TokenScan[];
+}> {
   public static type() {
     return "get-token-scans";
   }
@@ -29,6 +33,7 @@ export class GetTokenScansMsg extends Message<TokenScan[]> {
 export class RevalidateTokenScansMsg extends Message<{
   vaultId: string;
   tokenScans: TokenScan[];
+  tokenScansWithoutDismissed: TokenScan[];
 }> {
   public static type() {
     return "revalidate-token-scans";
@@ -53,82 +58,11 @@ export class RevalidateTokenScansMsg extends Message<{
   }
 }
 
-export class SyncTokenScanInfosMsg extends Message<{
+export class DismissNewTokenFoundInMainMsg extends Message<{
   vaultId: string;
   tokenScans: TokenScan[];
+  tokenScansWithoutDismissed: TokenScan[];
 }> {
-  public static type() {
-    return "sync-token-scan-infos";
-  }
-
-  constructor(public readonly vaultId: string) {
-    super();
-  }
-
-  validateBasic(): void {
-    if (!this.vaultId) {
-      throw new Error("Empty vault id");
-    }
-  }
-
-  route(): string {
-    return ROUTE;
-  }
-
-  type(): string {
-    return SyncTokenScanInfosMsg.type();
-  }
-}
-
-export class GetIsShowNewTokenFoundInMainMsg extends Message<boolean> {
-  public static type() {
-    return "get-is-show-new-token-found-in-main";
-  }
-
-  constructor(public readonly vaultId: string) {
-    super();
-  }
-
-  validateBasic(): void {
-    if (!this.vaultId) {
-      throw new Error("Empty vault id");
-    }
-  }
-
-  route(): string {
-    return ROUTE;
-  }
-
-  type(): string {
-    return GetIsShowNewTokenFoundInMainMsg.type();
-  }
-}
-
-export class UpdateIsShowNewTokenFoundInMainMsg extends Message<boolean> {
-  public static type() {
-    return "update-is-show-new-token-found-in-main";
-  }
-
-  constructor(public readonly vaultId: string) {
-    super();
-  }
-
-  validateBasic(): void {
-    if (!this.vaultId) {
-      throw new Error("Empty vault id");
-    }
-  }
-
-  route(): string {
-    return ROUTE;
-  }
-
-  type(): string {
-    return UpdateIsShowNewTokenFoundInMainMsg.type();
-  }
-}
-
-export class DismissNewTokenFoundInMainMsg extends Message<boolean> {
   public static type() {
     return "dismiss-new-token-found-in-main";
   }


### PR DESCRIPTION
# 구현사항
- main에서 보이는 new tokne found 버튼이 보이는 조건 수정 참고[ link](https://linear.app/keplrwallet/issue/KEPLR-1531/new-tokens-found-홈에서는-한번-눌러보고-나면-다시-안뜨게-적용#comment-ba0128dd)
- token-service 수정사항
   -  TokenScan에 prevInfos를 추가해서 직전 tokenScan info를 저장해서 chainStore에서 활용 하도록 수정
      - 기존의 chain이 disable될때 tokenScan에서 해당 chain을 삭제 하는 로직 수정
          -  native 체인을 disable (이때  new tokne found 버튼을 Main에서 클릭)  -> enable -> disable 한 경우 Main에서 다시 버튼을 보여주기 않기 위해서 tokenScan을 삭제 하지 않음
          - suggeted된 chain의 경우 해당 체인을 삭제 할때 tokenScan에서 삭제함 
 - chainStore 수정 사항
     - shouldShowNewTokenFoundInMain, dismissNewTokenFoundInHome를 추가하여 main에서 버튼을 보여줄지 말지를 검사
     - updateEnabledChainIdentifiersFromBackground가 실행될때 resetDismissIfNeeded, isMeaningfulTokenScanChange 실행을 통해서 필요하다면 _newTokenFoundDismissed값 업데이트
     - isMeaningfulTokenScanChange에서 [ link](https://linear.app/keplrwallet/issue/KEPLR-1531/new-tokens-found-홈에서는-한번-눌러보고-나면-다시-안뜨게-적용#comment-ba0128dd) 해당 변경조건에 따라서 reset를 해야 하는지 판단 