### PR TITLE
fix: Search sorting to correctly handle zero-score field matches

### DIFF
--- a/apps/extension/src/hooks/use-search.ts
+++ b/apps/extension/src/hooks/use-search.ts
@@ -161,8 +161,8 @@ export function performSearch<T>(
       }
 
       for (let i = 0; i < fields.length; i++) {
-        const scoreA = a.fieldMatchScores[i] || SCORE_NONE;
-        const scoreB = b.fieldMatchScores[i] || SCORE_NONE;
+        const scoreA = a.fieldMatchScores[i] ?? SCORE_NONE;
+        const scoreB = b.fieldMatchScores[i] ?? SCORE_NONE;
 
         if (scoreA !== scoreB) {
           return scoreB - scoreA;


### PR DESCRIPTION
celestia를 disable했다 enable하니까 tia on celestia가 tia on flame 밑으로 내려가는 현상 해결

`||` 연산자가 0점을 `SCORE_NONE` (즉 `-Infinity`)로 변환해서 생긴 문제입니다.