### PR TITLE
add margin to evm base fee per gas

### DIFF
--- a/packages/hooks/src/tx/fee.ts
+++ b/packages/hooks/src/tx/fee.ts
@@ -787,10 +787,14 @@ export class FeeConfig extends TxChainSetter implements IFeeConfig {
           ).block;
         const latestBaseFeePerGas = parseInt(block?.baseFeePerGas ?? "0");
         if (latestBaseFeePerGas !== 0) {
+          const multiplier =
+            ETH_FEE_SETTINGS_BY_FEE_TYPE[feeType].baseFeePercentageMultiplier;
           const baseFeePerGasDec = new Dec(latestBaseFeePerGas);
+          const baseFeePerGasWithMargin = baseFeePerGasDec.mul(multiplier);
           const maxPriorityFeePerGas =
             this.calculateOptimalMaxPriorityFeePerGas(ethereumQueries, feeType);
-          const maxFeePerGas = baseFeePerGasDec.add(maxPriorityFeePerGas);
+          const maxFeePerGas =
+            baseFeePerGasWithMargin.add(maxPriorityFeePerGas);
 
           return {
             maxPriorityFeePerGas: maxPriorityFeePerGas.truncateDec(),


### PR DESCRIPTION
<img width="371" height="117" alt="스크린샷 2025-12-15 오후 1 05 55" src="https://github.com/user-attachments/assets/b106f3cd-dd50-401f-bb87-b53319478ab7" />

arbitrum의 경우 priority fee가 존재하지 않으며, base fee 값이 고정된 것이 아니기 때문에 base fee를 가져온 시점의 base fee와 트랜잭션을 실행하는 시점의 base fee의 차이로 트랜잭션이 정상 실행되지 않을 수 있습니다. 따라서 base fee에 마진을 추가하였습니다.