### PR TITLE
Disable some etheremint chains not working with ledger

### DIFF
--- a/apps/extension/src/hooks/use-get-all-non-native-chain.ts
+++ b/apps/extension/src/hooks/use-get-all-non-native-chain.ts
@@ -128,6 +128,10 @@ export const useGetAllNonNativeChain = ({
               );
               return true;
             } catch {
+              // NOTE: 이미 enable된 체인이면 일단 표시되도록 하여 사용자가 disable 처리할 수 있도록 한다.
+              if (chainStore.isEnabledChain(chainInfo.chainId)) {
+                return true;
+              }
               return false;
             }
           })();
@@ -154,7 +158,13 @@ export const useGetAllNonNativeChain = ({
     }
 
     setLedgerFilteredChains(chains);
-  }, [chains, fallbackEthereumLedgerApp, fallbackStarknetLedgerApp, keyType]);
+  }, [
+    chainStore,
+    chains,
+    fallbackEthereumLedgerApp,
+    fallbackStarknetLedgerApp,
+    keyType,
+  ]);
 
   const searchedChains = useSearch(ledgerFilteredChains, search, searchFields);
 

--- a/apps/extension/src/pages/manage-chains/index.tsx
+++ b/apps/extension/src/pages/manage-chains/index.tsx
@@ -409,6 +409,11 @@ export const ManageChainsPage: FunctionComponent = observer(() => {
               );
               return true;
             } catch {
+              // NOTE: 이미 enable된 체인이면 일단 표시되도록 하여 사용자가 disable 처리할 수 있도록 한다.
+              if (chainStore.isEnabledChain(cosmosChainInfo.chainId)) {
+                return true;
+              }
+
               return false;
             }
           })();

--- a/apps/extension/src/pages/register/enable-chains/index.tsx
+++ b/apps/extension/src/pages/register/enable-chains/index.tsx
@@ -646,6 +646,10 @@ export const EnableChainsScene: FunctionComponent<{
                 );
                 return true;
               } catch {
+                // NOTE: 이미 enable된 체인이면 일단 표시되도록 하여 사용자가 disable 처리할 수 있도록 한다.
+                if (chainStore.isEnabledChain(chainInfo.chainId)) {
+                  return true;
+                }
                 return false;
               }
             }
@@ -1646,6 +1650,10 @@ export const EnableChainsScene: FunctionComponent<{
                       );
                       return true;
                     } catch {
+                      // NOTE: 이미 enable된 체인이면 일단 표시되도록 하여 사용자가 disable 처리할 수 있도록 한다.
+                      if (chainStore.isEnabledChain(chainInfo.chainId)) {
+                        return true;
+                      }
                       return false;
                     }
                   })();

--- a/packages/background/src/keyring-cosmos/service.ts
+++ b/packages/background/src/keyring-cosmos/service.ts
@@ -1676,6 +1676,7 @@ Salt: ${salt}`;
     chainId: string
   ) {
     if (
+      // !chainId.startsWith("evmos_") &&
       !chainId.startsWith("injective") &&
       !chainId.startsWith("nim_") &&
       // NOTE: disable xpla and dymension as EIP712 signing is not supported on cosmos/evm module atm.


### PR DESCRIPTION
- evmos, dymension: `/ethermint.types.v1.ExtensionOptionsWeb3Tx` 지원 안 됨
- xpla: cosmos/evm
- zetachain: `/ethermint.types.v1.ExtensionOptionsWeb3Tx`는 deprecated 상태이나 지원하긴 함. 하지만 cosmos/evm 모듈과 cosmos chain id format을 혼용함으로 인해 cosmos chain id를 uint로 파싱하려고 시도해서 트랜잭션이 실행되지 않음. 이건 노드 설정값 또는 로직 문제.

> 우선은 보류