### PR TITLE
Redesign changelog modal

### DIFF
--- a/apps/extension/src/pages/main/components/update-note-modal/paragraph-with-links.tsx
+++ b/apps/extension/src/pages/main/components/update-note-modal/paragraph-with-links.tsx
@@ -3,6 +3,7 @@ import { FormattedMessage } from "react-intl";
 import styled from "styled-components";
 import { ColorPalette } from "../../../../styles";
 import { UpdateNotePageData } from ".";
+import { Gutter } from "../../../../components/gutter";
 
 const Styles = {
   Link: styled.span`
@@ -26,7 +27,10 @@ export const ParagraphWithLinks: FunctionComponent<{
       defaultMessage={paragraph}
       values={{
         br: <br />,
-        b: (...chunks: React.ReactNode[]) => <b>{chunks}</b>,
+        b: (...chunks: React.ReactNode[]) => (
+          <b style={{ fontWeight: 500 }}>{chunks}</b>
+        ),
+        gutter: <Gutter size="0.625rem" />,
         link: links
           ? (...chunks: React.ReactNode[]) => {
               const flattenedChunks: React.ReactNode[] = [];

--- a/apps/extension/src/pages/main/index.tsx
+++ b/apps/extension/src/pages/main/index.tsx
@@ -485,6 +485,7 @@ export const MainPage: FunctionComponent<{
               for (const scene of info.scenes) {
                 res.push({
                   title: scene.title,
+                  subtitle: scene.subtitle,
                   image:
                     scene.image && scene.aspectRatio
                       ? {
@@ -495,7 +496,8 @@ export const MainPage: FunctionComponent<{
                       : undefined,
                   paragraph: scene.paragraph,
                   links: scene.links,
-                  isSidePanelBeta: info.isSidePanelBeta,
+                  closeText: scene.closeText,
+                  closeLink: scene.closeLink,
                 });
               }
             }

--- a/apps/extension/src/stores/ui-config/changelog.ts
+++ b/apps/extension/src/stores/ui-config/changelog.ts
@@ -9,14 +9,12 @@ import {
 import { KVStore, PrefixKVStore } from "@keplr-wallet/common";
 import { simpleFetch } from "@keplr-wallet/simple-fetch";
 import Joi from "joi";
-import { GetSidePanelIsSupportedMsg } from "@keplr-wallet/background";
-import { InExtensionMessageRequester } from "@keplr-wallet/router-extension";
-import { BACKGROUND_PORT } from "@keplr-wallet/router";
 
 interface VersionHistory {
   version: string;
   scenes: {
     title: string;
+    subtitle?: string;
     image?: {
       default: string;
       light: string;
@@ -26,8 +24,9 @@ interface VersionHistory {
     links?: {
       [key: string]: string;
     };
+    closeText?: string;
+    closeLink?: string;
   }[];
-  isSidePanelBeta?: boolean;
 }
 
 const Schema = Joi.object<{
@@ -41,6 +40,7 @@ const Schema = Joi.object<{
           .items(
             Joi.object({
               title: Joi.string().required(),
+              subtitle: Joi.string().optional(),
               image: Joi.object({
                 default: Joi.string().required(),
                 light: Joi.string().required(),
@@ -50,11 +50,12 @@ const Schema = Joi.object<{
               links: Joi.object()
                 .pattern(Joi.string(), Joi.string())
                 .optional(),
+              closeText: Joi.string().optional(),
+              closeLink: Joi.string().optional(),
             })
           )
           .min(1)
           .required(),
-        isSidePanelBeta: Joi.boolean().optional(),
       })
     )
     .required(),
@@ -117,28 +118,6 @@ export class ChangelogConfig {
       );
 
       const validated = await Schema.validateAsync(res.data);
-
-      if (
-        validated.versions &&
-        validated.versions.find((v: any) => v.isSidePanelBeta === true)
-      ) {
-        const msg = new GetSidePanelIsSupportedMsg();
-        const res = await new InExtensionMessageRequester().sendMessage(
-          BACKGROUND_PORT,
-          msg
-        );
-        if (!res.supported) {
-          runInAction(() => {
-            this._lastInfo = {
-              lastVersion,
-              currentVersion,
-              cleared: true,
-              histories: [],
-            };
-          });
-          return;
-        }
-      }
 
       runInAction(() => {
         this._lastInfo = {


### PR DESCRIPTION
<img width="754" height="1754" alt="CleanShot 2025-12-24 at 15 33 48@2x" src="https://github.com/user-attachments/assets/408a1bd2-03bf-4e0a-9496-842b6d80d4f6" />


ChangelogConfig의 showingInfo()를 아래와 같이 임시로 바꿔서 테스트 가능
```
get showingInfo(): VersionHistory[] {
    return [
      {
        version: "0.0.1",
        scenes: [
          {
            title: "$OM → $MANTRA Upgrade",
            subtitle:
              "Legacy ERC20 $OM will be{br}deprecated on <b>Jan 15, 2026.</b>",
            image: {
              default:
                "https://keplr-ext-update-note-images.s3.amazonaws.com/mantra-img-dark.png",
              light:
                "https://keplr-ext-update-note-images.s3.amazonaws.com/mantra-img-light.png",
            },
            aspectRatio: "296/128",
            paragraph:
              "<b>$OM on MANTRA Chain:</b> No action required{gutter}<b>$OM on other Cosmos chains:</b> Transfer $OM to the MANTRA Chain{gutter}<b>Osmosis LPs:</b> Unwind LP positions and transfer $OM to the MANTRA Chain{gutter}<b>$OM on EVM networks:</b> Migrate $OM to the MANTRA Chain via the <link>official migration bridge</link>.",
            links: {
              "official migration bridge": "https://mantra.zone/migrate",
            },
            closeText: "Learn More",
            closeLink:
              "https://mantrachain.io/resources/announcements/mantra-chain-coin-upgrade-timeline-and-key-details",
          },
        ],
      },
    ];
  }
```
- isSidePanelBeta는 전혀 쓸모가 없어져서 삭제
- 디자인에 텍스트 줄 간의 여백이 생겼는데 이건 {br} (줄바꿈)으로 표현할 수 없기 때문에 {gutter}라는 새로운 기능 추가 {gutter}를 쓰면 0.625rem을 그냥 차지함
- closeText?: string; closeLink?: string; 추가
- subtitle?: string; 추가
- 닉의 디자인에서 텍스트가 기존 typography와 맞지 않아서 BaseTypography를 사용하면서 그냥 inline 스타일로 폰트 속성을 정의해서 사용함
- UI 자체를 변경했기 때문에 기존의 체인지로그는 이상하게 보이게 됨
  - 하지만 이런 유저의 경우 이미 몇주동안 케플러를 실행시키지 않은 유저이기 때문에... 기존의 체인지로그를 볼 필요는 없어보임
  - 이번 버전에서 체인지로그 공지를 하면서 config-server에서 기존의 체인지로그 정보를 다 지우고 OM 용 체인지로그 공지부터 다시 시작하면 어차피 기존의 체인지로그 정보를 받아올 곳이 없어지기 때문에 문제없음