### PR TITLE
fix: Unify stakable token filtering to prevent empty list

### DIFF
--- a/apps/extension/src/pages/stake/explore.tsx
+++ b/apps/extension/src/pages/stake/explore.tsx
@@ -32,7 +32,7 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { IconProps } from "../../components/icon/types";
 import { ChainIdHelper } from "@keplr-wallet/cosmos";
 import { COMMON_HOVER_OPACITY } from "../../styles/constant";
-import { useKcrStakingUrls } from "../../hooks/use-kcr-staking-urls";
+import { useKcrStakingUrls } from "./hooks/use-kcr-staking-urls";
 
 const priority = (chainId: string) => {
   const id = ChainIdHelper.parse(chainId).identifier;

--- a/apps/extension/src/pages/stake/hooks/use-kcr-staking-urls.ts
+++ b/apps/extension/src/pages/stake/hooks/use-kcr-staking-urls.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useStore } from "../stores";
+import { useStore } from "../../../stores";
 import { ChainInfo } from "@keplr-wallet/types";
 import { ChainIdHelper } from "@keplr-wallet/cosmos";
 

--- a/apps/extension/src/pages/stake/hooks/use-stakable-tokens.ts
+++ b/apps/extension/src/pages/stake/hooks/use-stakable-tokens.ts
@@ -1,0 +1,57 @@
+import { useMemo } from "react";
+import { useStore } from "../../../stores";
+import { useKcrStakingUrls } from "./use-kcr-staking-urls";
+import { Dec } from "@keplr-wallet/unit";
+import { ViewToken } from "../../main";
+
+const zeroDec = new Dec(0);
+
+export const useStakableTokens = () => {
+  const { chainStore, hugeQueriesStore, priceStore } = useStore();
+  const { getKcrStakingUrl, hasKcrStakingUrl } = useKcrStakingUrls();
+
+  const stakableTokens = useMemo(() => {
+    return hugeQueriesStore.stakables
+      .filter((token) => {
+        if (!token.token.toDec().gt(zeroDec)) {
+          return false;
+        }
+        if ("starknet" in token.chainInfo) {
+          return true;
+        }
+        if ("bitcoin" in token.chainInfo) {
+          return false;
+        }
+        const chainInfo = chainStore.getChain(token.chainInfo.chainId);
+        const hasNativeUrl =
+          !!chainInfo.embedded.embedded &&
+          !!chainInfo.embedded.walletUrlForStaking;
+        return hasNativeUrl || hasKcrStakingUrl(token.chainInfo.chainId);
+      })
+      .sort((a, b) => {
+        const aPrice = priceStore.calculatePrice(a.token)?.toDec() ?? zeroDec;
+        const bPrice = priceStore.calculatePrice(b.token)?.toDec() ?? zeroDec;
+
+        if (aPrice.equals(bPrice)) {
+          return 0;
+        }
+        return aPrice.gt(bPrice) ? -1 : 1;
+      });
+  }, [chainStore, hugeQueriesStore.stakables, priceStore, hasKcrStakingUrl]);
+
+  const getStakingUrl = (viewToken: ViewToken): string | undefined => {
+    if ("starknet" in viewToken.chainInfo) {
+      return "https://dashboard.endur.fi/stake";
+    }
+    const chainInfo = chainStore.getChain(viewToken.chainInfo.chainId);
+    return (
+      chainInfo.embedded.walletUrlForStaking ||
+      getKcrStakingUrl(viewToken.chainInfo.chainId)
+    );
+  };
+
+  return {
+    stakableTokens,
+    getStakingUrl,
+  };
+};

--- a/apps/extension/src/pages/stake/index.tsx
+++ b/apps/extension/src/pages/stake/index.tsx
@@ -18,6 +18,7 @@ import { TextButton } from "../../components/button-text";
 import { ViewStakedToken, ViewUnbondingToken } from "../../stores/huge-queries";
 import { useIntl } from "react-intl";
 import { Dec, PricePretty } from "@keplr-wallet/unit";
+import { useStakableTokens } from "./hooks/use-stakable-tokens";
 import { CollapsibleList } from "../../components/collapsible-list";
 import { Stack } from "../../components/stack";
 import { TokenItem, TokenTitleView } from "../main/components";
@@ -32,16 +33,13 @@ import styled from "styled-components";
 import { COMMON_HOVER_OPACITY } from "../../styles/constant";
 import debounce from "lodash.debounce";
 
-const zeroDec = new Dec(0);
-
 export const StakePage: FunctionComponent = observer(() => {
   const intl = useIntl();
   const navigate = useNavigate();
   const [params] = useSearchParams();
   const initialExpand = params.get("intitialExpand") === "true";
 
-  const { uiConfigStore, hugeQueriesStore, analyticsAmplitudeStore } =
-    useStore();
+  const { uiConfigStore, analyticsAmplitudeStore } = useStore();
   const isNotReady = useIsNotReady();
 
   const animatedPrivacyModeHover = useSpringValue(0, {
@@ -78,11 +76,7 @@ export const StakePage: FunctionComponent = observer(() => {
     };
   }, [delegations.length, isNotReady, debouncedLogEvent, unbondings.length]);
 
-  const hasAnyStakableAsset = useMemo(() => {
-    return hugeQueriesStore.stakables.some((token) =>
-      token.token.toDec().gt(zeroDec)
-    );
-  }, [hugeQueriesStore.stakables]);
+  const { stakableTokens } = useStakableTokens();
 
   const TokenViewData: {
     title: string;
@@ -121,11 +115,11 @@ export const StakePage: FunctionComponent = observer(() => {
     },
   ];
 
-  if (!hasAnyStakableAsset) {
-    return <StakeExplorePage />;
-  }
-
   if (delegations.length === 0 && unbondings.length === 0) {
+    if (stakableTokens.length === 0) {
+      return <StakeExplorePage />;
+    }
+
     return <StakeEmptyPage />;
   }
 


### PR DESCRIPTION
- `useKcrStakingUrls` 정의된 파일 위치를 `apps/extension/src/pages/stake/hooks 로 `이동
- empty / explore 중에 보여줄 페이지를 결정하는 로직과 empty에서 보여줄 토큰들을 필터링하는 로직을 통일하여, empty 페이지에서 빈 토큰 리스트가 보여지는 경우가 있는 문제를 해결합니다. (재현방법: 계정이 다른 토큰은 없고 sei만 있게 세팅)

https://github.com/user-attachments/assets/79ec2eb8-13d6-4c9b-a593-56b7b8d1e637

