### PR TITLE
fix: Show staking info for only native & whitelisted kcr chains in token detail

### DIFF
--- a/apps/extension/src/hooks/use-kcr-staking-urls.ts
+++ b/apps/extension/src/hooks/use-kcr-staking-urls.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useStore } from "../../../stores";
+import { useStore } from "../stores";
 import { ChainInfo } from "@keplr-wallet/types";
 import { ChainIdHelper } from "@keplr-wallet/cosmos";
 

--- a/apps/extension/src/pages/main/token-detail/modal.tsx
+++ b/apps/extension/src/pages/main/token-detail/modal.tsx
@@ -42,7 +42,7 @@ import { Button } from "../../../components/button";
 import { FormattedMessage } from "react-intl";
 import { NOBLE_CHAIN_ID } from "../../../config.ui";
 import { MintPhotonButton } from "./mint-photon-button";
-import Joi from "joi";
+import { useKcrStakingUrls } from "../../../hooks/use-kcr-staking-urls";
 
 const Styles = {
   Container: styled.div`
@@ -92,6 +92,7 @@ export const TokenDetailModal: FunctionComponent<{
   } = useStore();
 
   const theme = useTheme();
+  const { hasKcrStakingUrl } = useKcrStakingUrls();
 
   const account = accountStore.getAccount(chainId);
   const modularChainInfo = chainStore.getModularChain(chainId);
@@ -625,13 +626,16 @@ export const TokenDetailModal: FunctionComponent<{
                 return <EarnApyBanner chainId={NOBLE_CHAIN_ID} />;
               }
 
+              const isStakeCurrency =
+                chainInfo.stakeCurrency?.coinMinimalDenom ===
+                currency.coinMinimalDenom;
+              const hasNativeStaking =
+                chainInfo.embedded.embedded &&
+                chainInfo.embedded.walletUrlForStaking;
+
               if (
-                chainInfo.stakeCurrency &&
-                chainInfo.stakeCurrency.coinMinimalDenom ===
-                  currency.coinMinimalDenom &&
-                chainInfo.walletUrlForStaking &&
-                !Joi.string().uri().validate(chainInfo.walletUrlForStaking)
-                  .error
+                isStakeCurrency &&
+                (hasNativeStaking || hasKcrStakingUrl(chainId))
               ) {
                 return (
                   <React.Fragment>

--- a/apps/extension/src/pages/stake/explore.tsx
+++ b/apps/extension/src/pages/stake/explore.tsx
@@ -32,7 +32,7 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { IconProps } from "../../components/icon/types";
 import { ChainIdHelper } from "@keplr-wallet/cosmos";
 import { COMMON_HOVER_OPACITY } from "../../styles/constant";
-import { useKcrStakingUrls } from "./hooks/use-kcr-staking-urls";
+import { useKcrStakingUrls } from "../../hooks/use-kcr-staking-urls";
 
 const priority = (chainId: string) => {
   const id = ChainIdHelper.parse(chainId).identifier;

--- a/apps/extension/src/pages/stake/hooks/use-stakable-tokens.ts
+++ b/apps/extension/src/pages/stake/hooks/use-stakable-tokens.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { useStore } from "../../../stores";
-import { useKcrStakingUrls } from "./use-kcr-staking-urls";
+import { useKcrStakingUrls } from "../../../hooks/use-kcr-staking-urls";
 import { Dec } from "@keplr-wallet/unit";
 import { ViewToken } from "../../main";
 
@@ -17,6 +17,9 @@ export const useStakableTokens = () => {
           return false;
         }
         if ("starknet" in token.chainInfo) {
+          if (token.chainInfo.chainId === "starknet:SN_SEPOLIA") {
+            return false;
+          }
           return true;
         }
         if ("bitcoin" in token.chainInfo) {


### PR DESCRIPTION
<img width="379" height="670" alt="image" src="https://github.com/user-attachments/assets/0ccfb648-b095-4166-a4c3-f5bebb3ad273" />

<img width="379" height="670" alt="image" src="https://github.com/user-attachments/assets/f40a459d-e5c9-439c-b1f9-834136d7cf02" />

