### PR TITLE
fix: add missing fieldMatchScores comparison to token group sorting

### DIFF
--- a/apps/extension/src/hooks/use-grouped-tokens-map.ts
+++ b/apps/extension/src/hooks/use-grouped-tokens-map.ts
@@ -70,11 +70,17 @@ export function useGroupedTokensMap(search: string) {
       groupedTokensSearchFields
     );
 
-    const entriesWithScores = [];
+    const entriesWithScores: {
+      groupKey: string;
+      tokens: ViewToken[];
+      score: number;
+      fieldMatchScores: number[];
+    }[] = [];
 
     for (const {
       item: [groupKey, tokens],
       score,
+      fieldMatchScores,
     } of searchedWithScores) {
       const searchResults = performSearch(
         tokens,
@@ -83,13 +89,25 @@ export function useGroupedTokensMap(search: string) {
         sortByPrice
       );
       if (searchResults.length > 0) {
-        entriesWithScores.push({ groupKey, tokens: searchResults, score });
+        entriesWithScores.push({
+          groupKey,
+          tokens: searchResults,
+          score,
+          fieldMatchScores,
+        });
       }
     }
 
     entriesWithScores.sort((a, b) => {
       if (a.score !== b.score) {
         return b.score - a.score;
+      }
+      for (let i = 0; i < groupedTokensSearchFields.length; i++) {
+        const scoreA = a.fieldMatchScores[i] ?? -Infinity;
+        const scoreB = b.fieldMatchScores[i] ?? -Infinity;
+        if (scoreA !== scoreB) {
+          return scoreB - scoreA;
+        }
       }
       return sortTokenGroups(a.tokens, b.tokens);
     });

--- a/apps/extension/src/hooks/use-search.ts
+++ b/apps/extension/src/hooks/use-search.ts
@@ -94,10 +94,10 @@ function performSearchSorted<T>(
   query: string,
   fields: SearchField<T>[],
   tiebreaker?: (a: T, b: T) => number
-): { item: T; maxScore: number }[] {
+): { item: T; maxScore: number; fieldMatchScores: number[] }[] {
   const queryLower = query.toLowerCase().trim();
   if (!queryLower) {
-    return data.map((item) => ({ item, maxScore: 0 }));
+    return data.map((item) => ({ item, maxScore: 0, fieldMatchScores: [] }));
   }
 
   const matchedItems = data
@@ -184,11 +184,14 @@ export function performSearchWithScore<T>(
   data: T[],
   query: string,
   fields: SearchField<T>[]
-): { item: T; score: number }[] {
-  return performSearchSorted(data, query, fields).map(({ item, maxScore }) => ({
-    item,
-    score: maxScore,
-  }));
+): { item: T; score: number; fieldMatchScores: number[] }[] {
+  return performSearchSorted(data, query, fields).map(
+    ({ item, maxScore, fieldMatchScores }) => ({
+      item,
+      score: maxScore,
+      fieldMatchScores,
+    })
+  );
 }
 
 export function useSearch<T>(

--- a/apps/extension/src/utils/token-sort.ts
+++ b/apps/extension/src/utils/token-sort.ts
@@ -27,9 +27,14 @@ export function sortByPrice(
   return aPrice.gt(bPrice) ? -1 : 1;
 }
 
+type ViewTokenWithOptionalPrice = {
+  token: CoinPretty;
+  price?: PricePretty | undefined;
+};
+
 export function sortTokenGroups(
-  tokensA: ViewTokenWithPrice[],
-  tokensB: ViewTokenWithPrice[]
+  tokensA: ViewTokenWithOptionalPrice[],
+  tokensB: ViewTokenWithOptionalPrice[]
 ): number {
   let valueA = new Dec(0);
   let valueB = new Dec(0);


### PR DESCRIPTION
- https://github.com/chainapsis/keplr-wallet/pull/1727 작업 과정에서 `performSearchWithScore` 에 빠뜨린 `fieldMatchScores` 기준 정렬을 추가합니다.

| 변경 전 | 변경 후 |
|---|---|
| <img width="379" height="631" alt="스크린샷 2025-12-31 오후 9 20 17" src="https://github.com/user-attachments/assets/77196273-b6d1-4ba6-a6f7-58a57f9d3a0f" /> | <img width="379" height="631" alt="스크린샷 2025-12-31 오후 9 21 41" src="https://github.com/user-attachments/assets/71bc1527-add0-4efc-b90c-cfa57a90f836" /> |