### PR TITLE
fix: update addressMap when new account is added for ICNS display

### DIFF
--- a/apps/extension/src/pages/main/components/account-switch-float-modal/index.tsx
+++ b/apps/extension/src/pages/main/components/account-switch-float-modal/index.tsx
@@ -79,7 +79,13 @@ export const AccountSwitchFloatModal = observer(
           setAddressMap(addressMap);
         }
       })();
-    }, [chainStore, uiConfigStore.addressBookConfig, uiConfigStore.icnsInfo]);
+    }, [
+      chainStore,
+      uiConfigStore.addressBookConfig,
+      uiConfigStore.icnsInfo,
+      // 새로 추가된 계정의 bech32Address를 포함하도록
+      keyRingStore.keyInfos.length,
+    ]);
 
     const handleAccountSelect = async (keyInfo: KeyInfo) => {
       if (keyInfo.id === keyRingStore.selectedKeyInfo?.id) {


### PR DESCRIPTION
#### 문제
계정 추가 직후 ICNS가 표시되지 않음
  - addressMap이 keyRingStore.keyInfos 변경에 반응하지 않아 새 계정의 bech32Address가 포함되지 않음

#### 해결
addressMap 업데이트 useEffect의 dependency에 keyRingStore.keyInfos.length 추가



https://github.com/user-attachments/assets/e1ba5149-a5f6-4935-a089-62d8df997ac9

