### PR TITLE
eip712 서명을 extensionOptions을 사용하지 않도록 수정

### DIFF
--- a/packages/background/src/keyring-cosmos/service.ts
+++ b/packages/background/src/keyring-cosmos/service.ts
@@ -1682,7 +1682,8 @@ Salt: ${salt}`;
       !chainId.startsWith("nim_") &&
       !chainId.startsWith("dimension_") &&
       !chainId.startsWith("zetachain_") &&
-      !chainId.startsWith("eip155:")
+      !chainId.startsWith("eip155:") &&
+      !chainId.startsWith("xrplevm_")
     ) {
       throw new KeplrError(
         "keyring",

--- a/packages/stores/src/account/cosmos.ts
+++ b/packages/stores/src/account/cosmos.ts
@@ -542,38 +542,21 @@ export class CosmosAccountImpl {
                 timeoutHeight: signResponse.signed.timeout_height,
                 memo: signResponse.signed.memo,
                 extensionOptions:
-                  eip712Signing && !ethSignPlainJson
+                  eip712Signing && chainIsInjective
                     ? [
                         {
-                          typeUrl: (() => {
-                            if (
-                              chainInfo.hasFeature(
-                                "/cosmos.evm.types.v1.ExtensionOptionsWeb3Tx"
-                              )
-                            ) {
-                              return "/cosmos.evm.types.v1.ExtensionOptionsWeb3Tx";
-                            }
-
-                            if (chainIsInjective) {
-                              return "/injective.types.v1beta1.ExtensionOptionsWeb3Tx";
-                            }
-
-                            return "/ethermint.types.v1.ExtensionOptionsWeb3Tx";
-                          })(),
+                          typeUrl:
+                            "/injective.types.v1beta1.ExtensionOptionsWeb3Tx",
                           value: ExtensionOptionsWeb3Tx.encode(
                             ExtensionOptionsWeb3Tx.fromPartial({
                               typedDataChainId: EthermintChainIdHelper.parse(
                                 this.chainId
                               ).ethChainId.toString(),
-                              feePayer: !chainIsInjective
-                                ? signResponse.signed.fee.feePayer
-                                : undefined,
-                              feePayerSig: !chainIsInjective
-                                ? Buffer.from(
-                                    signResponse.signature.signature,
-                                    "base64"
-                                  )
-                                : undefined,
+                              feePayer: signResponse.signed.fee.feePayer,
+                              feePayerSig: Buffer.from(
+                                signResponse.signature.signature,
+                                "base64"
+                              ),
                             })
                           ).finish(),
                         },
@@ -630,18 +613,11 @@ export class CosmosAccountImpl {
               fee: Fee.fromPartial({
                 amount: signResponse.signed.fee.amount as Coin[],
                 gasLimit: signResponse.signed.fee.gas,
-                payer:
-                  eip712Signing && !chainIsInjective && !ethSignPlainJson
-                    ? // Fee delegation feature not yet supported. But, for eip712 ethermint signing, we must set fee payer.
-                      signResponse.signed.fee.feePayer
-                    : undefined,
               }),
             }).finish(),
-            signatures:
-              // Injective needs the signature in the signatures list even if eip712
-              !eip712Signing || chainIsInjective || ethSignPlainJson
-                ? [Buffer.from(signResponse.signature.signature, "base64")]
-                : [new Uint8Array(0)],
+            signatures: [
+              Buffer.from(signResponse.signature.signature, "base64"),
+            ],
           }).finish(),
           signDoc: signResponse.signed,
         };


### PR DESCRIPTION
작동 확인한 체인들
- injective -> 원래 다른 로직
- initia -> 원래 다른 로직
- evmos
- dymension
- zeta
- xrplevm

작동 안되는 체인
- xpla

xpla는 제 추측으로는 또 걔네들 실수에요…
https://github.com/xpladev/xpla/blob/e571bc0900ba3bc85c2c2ab866a2e34eeb793abe/app/app.go#L209
여기서 다른 cosmos/evm 쓰는 얘들처럼 eip712.SetEncodingConfig(legacyAmino, interfaceRegistry, evmChainId)를 해주긴한다…
https://github.com/xpladev/xpla/blob/e571bc0900ba3bc85c2c2ab866a2e34eeb793abe/app/app.go#L76
하지만 왜인지 xpla는 cosmos/evm의 ethsecp256k1이 아니라 본인들이 복붙한 버전의 ethermintsecp256k1를 사용한다…
https://github.com/xpladev/xpla/blob/e571bc0900ba3bc85c2c2ab866a2e34eeb793abe/legacy/ethermint/ethereum/eip712/encoding.go#L42
그래서 위의 api도 호출했어야 했는데 안했음…
결과적으로 xpla에서 사용하지 않는 cosmos/evm의 eip712 모듈만 init이 되었고 xpla의 legacy/ethermint/ethereum/eip712 모듈은 init이 안되서 작동이 안됨…

injective는 eip712 관련 업그레이드가 없었기 때문에 기존 방식으로만 작동 가능
initia도 왜인지 ethsecp256k1을 자기들이 만든걸 쓰는데 eip712는 빼버렸기 때문에 기존 방식으로만 가능

eip712를 extensionOptions로 하는건 injective 제외 아예 코드를 빼버렸는데 features에 "force-enable-evm-ledger"를 넣으면 강제로 ledger를 사용할 수 있지만 KCR을 기준으로 initia 관련 체인외에는 planq밖에 없는데 planq는 이미 망한 것 같으므로 신경쓰지 않는 것으로...

throwErrorIfEthermintWithLedgerButNotSupported에 xrplevm 추가