### PR TITLE
decode bytes32 hex strings for ERC20 symbol from CoinGecko API

### DIFF
--- a/packages/stores-eth/package.json
+++ b/packages/stores-eth/package.json
@@ -23,6 +23,7 @@
     "@ethersproject/abi": "^5.7.0",
     "@ethersproject/address": "^5.7.0",
     "@ethersproject/bytes": "^5.7.0",
+    "@ethersproject/strings": "^5.7.0",
     "@ethersproject/transactions": "^5.7.0",
     "@ethersproject/units": "^5.7.0",
     "@keplr-wallet/common": "0.12.308",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6590,6 +6590,7 @@ __metadata:
     "@ethersproject/abi": ^5.7.0
     "@ethersproject/address": ^5.7.0
     "@ethersproject/bytes": ^5.7.0
+    "@ethersproject/strings": ^5.7.0
     "@ethersproject/transactions": ^5.7.0
     "@ethersproject/units": ^5.7.0
     "@keplr-wallet/common": 0.12.308


### PR DESCRIPTION
- MKR 토큰의 심볼이 bytes32 hex string으로 반환되므로 문자열로 변환해주도록 로직 추가
- bytes32 hex string이 아니더라도 symbol 길이가 64일 가능성이 있지만 이 정도는 낙관적으로 넘어갈 수 있다고 생각