### PR TITLE
fix: use flexible width for stake explore cards

### DIFF
--- a/apps/extension/src/pages/stake/explore.tsx
+++ b/apps/extension/src/pages/stake/explore.tsx
@@ -362,12 +362,11 @@ const Styles = {
   AssetCard: styled.div`
     display: flex;
     flex-direction: column;
-    width: 9.875rem;
+    width: 100%;
     height: 8rem;
     padding: 0.75rem 1rem;
     align-items: flex-start;
     justify-content: center;
-    flex-shrink: 0;
     border-radius: 1.25rem;
     border: 1px solid
       ${(props) =>


### PR DESCRIPTION
#### AS-IS

https://github.com/user-attachments/assets/63b48c92-2c9b-4588-9e59-561ae37b4c3f



#### TO-BE

https://github.com/user-attachments/assets/3a709b96-ccf9-44c5-a36c-28d7907ff837

