### PR TITLE
Alchemy에서 지원되는 체인들의 경우는 수동으로 추가된 erc20 토큰을 무시하는 버그 해결

### DIFF
--- a/apps/extension/src/stores/root.tsx
+++ b/apps/extension/src/stores/root.tsx
@@ -394,6 +394,14 @@ export class RootStore {
       EthereumQueries.use({
         coingeckoAPIBaseURL: CoinGeckoAPIEndPoint,
         coingeckoAPIURI: CoinGeckoCoinDataByTokenAddress,
+        forceNativeERC20Query: (
+          chainId,
+          _chainGetter,
+          _address,
+          minimalDenom
+        ) => {
+          return this.tokensStore.tokenIsRegistered(chainId, minimalDenom);
+        },
       }),
       NobleQueries.use()
     );

--- a/packages/stores-eth/src/queries/erc20-balances.ts
+++ b/packages/stores-eth/src/queries/erc20-balances.ts
@@ -199,7 +199,15 @@ export class ObservableQueryThirdpartyERC20BalanceRegistry
     ObservableQueryThirdpartyERC20BalancesImplParent
   > = new Map();
 
-  constructor(protected readonly sharedContext: QuerySharedContext) {}
+  constructor(
+    protected readonly sharedContext: QuerySharedContext,
+    protected readonly forceNativeERC20Query: (
+      chainId: string,
+      chainGetter: ChainGetter,
+      address: string,
+      minimalDenom: string
+    ) => boolean
+  ) {}
 
   getBalanceImpl(
     chainId: string,
@@ -215,7 +223,8 @@ export class ObservableQueryThirdpartyERC20BalanceRegistry
       !Object.keys(thirdparySupportedChainIdMap).includes(chainId) ||
       denomHelper.type !== "erc20" ||
       !isHexAddress ||
-      !chainInfo.evm
+      !chainInfo.evm ||
+      this.forceNativeERC20Query(chainId, chainGetter, address, minimalDenom)
     ) {
       return;
     }

--- a/packages/stores-eth/src/queries/index.ts
+++ b/packages/stores-eth/src/queries/index.ts
@@ -23,6 +23,12 @@ export const EthereumQueries = {
   use(options: {
     coingeckoAPIBaseURL: string;
     coingeckoAPIURI: string;
+    forceNativeERC20Query: (
+      chainId: string,
+      chainGetter: ChainGetter,
+      address: string,
+      minimalDenom: string
+    ) => boolean;
   }): (
     queriesSetBase: QueriesSetBase,
     sharedContext: QuerySharedContext,
@@ -39,6 +45,7 @@ export const EthereumQueries = {
         ethereum: new EthereumQueriesImpl(
           queriesSetBase,
           sharedContext,
+          options.forceNativeERC20Query,
           chainId,
           chainGetter,
           options.coingeckoAPIBaseURL,
@@ -61,6 +68,12 @@ export class EthereumQueriesImpl {
   constructor(
     base: QueriesSetBase,
     sharedContext: QuerySharedContext,
+    protected readonly forceNativeERC20Query: (
+      chainId: string,
+      chainGetter: ChainGetter,
+      address: string,
+      minimalDenom: string
+    ) => boolean,
     protected chainId: string,
     protected chainGetter: ChainGetter,
     protected coingeckoAPIBaseURL: string,
@@ -70,7 +83,10 @@ export class EthereumQueriesImpl {
       new ObservableQueryEthereumERC20BalanceRegistry(sharedContext)
     );
     base.queryBalances.addBalanceRegistry(
-      new ObservableQueryThirdpartyERC20BalanceRegistry(sharedContext)
+      new ObservableQueryThirdpartyERC20BalanceRegistry(
+        sharedContext,
+        forceNativeERC20Query
+      )
     );
     base.queryBalances.addBalanceRegistry(
       new ObservableQueryEthAccountBalanceRegistry(sharedContext)


### PR DESCRIPTION
단순하게 tokens store에 등록된 토큰의 경우 native erc20 json rpc 쿼리를 하도록 수정
유저가 수동으로 등록된 토큰이 alchemy에서 지원되더라도 ative erc20 json rpc 쿼리를 하는 문제가 있다
유저가 수동으로 등록을 많이 할수록 비효율적인 쿼리를 하게되는 문제가 있다
하지만 요즘에는 유저들이 수동으로 등록을 잘 안하는 것 같아서 패스...

위의 문제를 해결하려면 alchemy에서 지원되는 토큰 리스트를 api로 먼저 받아와야한다.
하지만 문서상으로 볼때 개별 contract address마다 보내야하는데 이러면 오히려 더 비효율적이 된다.
그렇다고 백엔드를 만들어서 유저가 가진 contract addresses를 다 보내보고 지원되는 것만 처리한다고 해도 효율성이 그리 높아보이지 않는다...

일단 간단하게 해결...