### PR TITLE
fetch erc20 balance supported on kcr but not on alchemy

### DIFF
--- a/apps/extension/src/stores/root.tsx
+++ b/apps/extension/src/stores/root.tsx
@@ -396,10 +396,20 @@ export class RootStore {
         coingeckoAPIURI: CoinGeckoCoinDataByTokenAddress,
         forceNativeERC20Query: (
           chainId,
-          _chainGetter,
+          chainGetter,
           _address,
           minimalDenom
         ) => {
+          // chain info에는 등록되어 있지만, alchemy에서 지원하지 않는 token
+          // 또는 custom token balance를 조회해야 함
+          const chainInfo = chainGetter.getChain(chainId);
+          const currency = chainInfo.currencies.find(
+            (c) => c.coinMinimalDenom === minimalDenom
+          );
+          if (currency) {
+            return true;
+          }
+
           return this.tokensStore.tokenIsRegistered(chainId, minimalDenom);
         },
       }),


### PR DESCRIPTION
- chain info에는 등록되어 있는데 alchemy에서 지원되지 않는 토큰의 경우는 잔액을 가져오지 않던 문제 해결
- ~하는 김에 json rpc 2.0 배치 쿼리 기능을 활용해 erc20 balance 배치 조회~
    - 개별 쿼리로 실행하면 많이 발생할 줄 알았는데 dev 계정에서도 체인별로 3~5개 정도만 실행하고 있어서 우선 다음에 하는 걸로