### PR TITLE
fix: center-align balance text on token detail modal

### DIFF
--- a/apps/extension/src/pages/main/token-detail/modal.tsx
+++ b/apps/extension/src/pages/main/token-detail/modal.tsx
@@ -71,6 +71,7 @@ const Styles = {
     font-weight: 500;
     font-size: 1.75rem;
     line-height: 2.125rem;
+    text-align: center;
   `,
 };
 


### PR DESCRIPTION
토큰 상세페이지 > balance 가운데 정렬(textAlign: center)되도록 수정