### PR TITLE
fix: Optimize destination asset search with dedup, pagination, and server-order rendering

### DIFF
--- a/apps/extension/src/pages/ibc-swap/select-asset/index.tsx
+++ b/apps/extension/src/pages/ibc-swap/select-asset/index.tsx
@@ -618,6 +618,9 @@ const TokenListItem = ({
   if (data.hasSearch) {
     // 검색어가 있을 때: 서버 순서 그대로, ownedTokensMap으로 보유 여부 확인
     const entry = data.filteredTargetEntries[index];
+    if (!entry) {
+      return null;
+    }
     const key = `${ChainIdHelper.parse(entry.chainInfo.chainId).identifier}/${
       entry.currency.coinMinimalDenom
     }`;
@@ -633,9 +636,13 @@ const TokenListItem = ({
   } else {
     // 검색어가 없을 때: 보유 자산 먼저, 그 다음 나머지
     isOwned = index < data.filteredTokens.length;
-    item = isOwned
+    const resolved = isOwned
       ? data.filteredTokens[index]
       : data.filteredRemaining[index - data.filteredTokens.length];
+    if (!resolved) {
+      return null;
+    }
+    item = resolved;
   }
 
   const isFindingCurrency =


### PR DESCRIPTION
## Summary

Destination asset 검색 시 발생하던 여러 문제를 수정합니다.

### 1. 중복 엔트리 방지

**문제**: 페이지네이션으로 여러 페이지를 로드할 때, 서버 응답 간 동일한 토큰이 중복으로 `targetEntriesInternal`에 push 될 수 있었습니다. 기존 코드에 `// CHECK: duplicated entries are possible` 주석으로 문제가 인지되어 있었으나 처리되지 않은 상태였습니다.

**해결**: `existingKeys` Set을 생성하여 `chainIdentifier/coinMinimalDenom` 키 기준으로 중복 여부를 확인한 후 push합니다.

### 2. 페이지네이션 감지 개선

**문제**: `onItemsRendered`에서 다음 페이지 로드 시점을 판단하는 threshold가 `3`으로 하드코딩되어 있어, 화면 크기에 따라 로딩 전 빈 영역이 보일 수 있었습니다. 또한 `isFetchingItems` 중복 검사와 `totalCount`에 로더 아이템까지 포함하는 등 불필요한 로직이 있었습니다.

**해결**:
- 동적 threshold: `Math.max(5, Math.ceil(visibleCount * 0.5))` 로 가시 영역 기반으로 계산
- `isFetchingItems || !state.hasNextPage` 조기 반환으로 조건문 정리
- `totalCount`에서 로더 아이템 제외

### 3. 검색 시 서버 순서 유지 (클라이언트 재정렬 제거)

**문제**: 검색어가 있을 때 `useSearch` 훅으로 클라이언트에서 검색 점수순 재정렬을 수행하고 있었습니다. 그러나 서버가 이미 검색 결과를 정렬해서 응답하므로, 클라이언트 재정렬은 서버의 정렬 순서를 깨뜨릴 뿐 아니라 새로운 페이지가 로드될 때마다 기존 아이템의 위치가 바뀌는 UX 문제를 유발했습니다.

**해결**:
- `useSearch` 훅 및 관련 `searchFields` 정의를 제거
- 검색어 없을 때: 기존대로 보유 자산 우선 표시 → 나머지 서버 순서
- 검색어 있을 때: `targetEntries`를 서버 순서 그대로 렌더링하되, `ownedTokensMap`으로 보유 자산 여부만 확인하여 잔액 표시

> 페이지 캐싱은 첫 번째 페이지가 기본으로 캐싱되게 이미 설정되어 있으므로 추가하지 않음.

## Test plan

- [ ] 검색어 없이 스크롤하여 다음 페이지 로드 → 중복 토큰 없는지 확인
- [ ] 검색어 입력 시 서버 순서대로 결과가 표시되는지 확인
- [ ] 검색어 초기화 후 다시 검색 시 캐시된 결과가 잘 보이는지 확인
- [ ] 빠른 스크롤 시 로딩 전 빈 영역 없는지 확인
- [ ] 보유 자산에 잔액이 표시되는지 확인 (검색어 유무 모두)

🤖 Generated with [Claude Code](https://claude.com/claude-code)