### PR TITLE
fix: update starknet ledger error message to guide app open/update

### DIFF
--- a/apps/extension/src/pages/sign/utils/handle-starknet-sign.ts
+++ b/apps/extension/src/pages/sign/utils/handle-starknet-sign.ts
@@ -298,7 +298,7 @@ function handleLedgerResponse<R>(
       throw new KeplrError(
         ErrModuleLedgerSign,
         ErrFailedGetPublicKey,
-        "Failed to get public key"
+        "Open the Starknet app on Ledger,\nor update it to the latest version."
       );
     case LedgerError.UserRejected:
       throw new KeplrError(


### PR DESCRIPTION
#### Starknet Ledger 에러 메시지 개선
Ledger에서 Starknet 앱이 열려있지 않거나 버전이 오래된 경우 BadCla/BadIns 에러가 발생함

- 기존: Failed to get public key
- 변경: Open the Starknet app on Ledger, or update it to the latest version. — 사용자가 직접 해결할 수 있도록 안내
