### PR TITLE
fix: Handle optional rewards/total fields and collect all reward denoms

### DIFF
--- a/packages/stores/src/query/cosmos/staking/rewards.ts
+++ b/packages/stores/src/query/cosmos/staking/rewards.ts
@@ -250,8 +250,23 @@ export class ObservableQueryRewardsInner extends ObservableChainQuery<Rewards> {
   ) {
     super.onReceiveResponse(response);
 
+    const denoms: Set<string> = new Set();
     const chainInfo = this.chainGetter.getChain(this.chainId);
-    const denoms = response.data.total.map((coin) => coin.denom);
+    if (response.data.total) {
+      response.data.total.forEach((coin) => {
+        denoms.add(coin.denom);
+      });
+    }
+    if (response.data.rewards) {
+      response.data.rewards.forEach((reward) => {
+        if (reward.reward) {
+          reward.reward.forEach((r) => {
+            denoms.add(r.denom);
+          });
+        }
+      });
+    }
+
     chainInfo.addUnknownDenoms(...denoms);
   }
 }

--- a/packages/stores/src/query/cosmos/staking/types.ts
+++ b/packages/stores/src/query/cosmos/staking/types.ts
@@ -2,8 +2,8 @@ import { Coin } from "@keplr-wallet/types";
 import { CoinPrimitive } from "../../../common";
 
 export type Rewards = {
-  rewards: DelegatorReward[] | null;
-  total: CoinPrimitive[];
+  rewards?: DelegatorReward[] | null;
+  total?: CoinPrimitive[];
 };
 
 export type DelegatorReward = {


### PR DESCRIPTION
Make `rewards` and `total` fields optional in the Rewards type to handle responses that may omit them. Also collect unknown denoms from individual reward entries, not just from the total.

https://linear.app/keplrwallet/issue/KEPLR-1900