### PR TITLE
styled simplebar layout refactor

### DIFF
--- a/apps/extension/src/hooks/page-simplebar/provider.tsx
+++ b/apps/extension/src/hooks/page-simplebar/provider.tsx
@@ -1,6 +1,7 @@
 import React, {
   FunctionComponent,
   PropsWithChildren,
+  useEffect,
   useMemo,
   useRef,
 } from "react";
@@ -11,32 +12,54 @@ import styled, { css } from "styled-components";
 
 const StyledSimpleBar = styled(SimpleBar)<{
   $fillHeight?: boolean;
-  $displayFlex?: boolean;
 }>`
-  & .simplebar-content {
-    ${({ $fillHeight }) =>
-      $fillHeight &&
-      css`
-        min-height: 100%;
-      `}
-    ${({ $displayFlex }) =>
-      $displayFlex &&
-      css`
-        display: flex;
-        flex-direction: column;
-      `}
-  }
+  ${({ $fillHeight }) =>
+    $fillHeight &&
+    css`
+      & .simplebar-content:not(.simplebar-content .simplebar-content) {
+        height: 100%;
+      }
+    `}
 `;
 
 export const PageSimpleBarProvider: FunctionComponent<
   PropsWithChildren<{
     style: React.CSSProperties;
     fillHeight?: boolean;
-    displayFlex?: boolean;
   }>
-> = ({ children, style, fillHeight, displayFlex }) => {
+> = ({ children, style, fillHeight }) => {
   const ref = useRef<SimpleBarCore | null>(null);
   const refHandlers = useRef<((ref: SimpleBarCore | null) => void)[]>([]);
+
+  // CSS 애니메이션(VerticalCollapseTransition 등)에 의한 자식 크기 변화를 감지하여 스크롤 바의 크기를 실시간으로 업데이트
+  useEffect(() => {
+    const simpleBar = ref.current;
+    const contentEl = simpleBar?.contentEl;
+    if (!contentEl) {
+      return;
+    }
+
+    const ro = new ResizeObserver(() => {
+      simpleBar?.recalculate();
+    });
+
+    const observeChildren = () => {
+      ro.disconnect();
+      Array.from(contentEl.children).forEach((child) => ro.observe(child));
+    };
+
+    observeChildren();
+
+    const mo = new MutationObserver(() => {
+      observeChildren();
+    });
+    mo.observe(contentEl, { childList: true });
+
+    return () => {
+      ro.disconnect();
+      mo.disconnect();
+    };
+  }, []);
 
   return (
     <PageSimpleBarContext.Provider
@@ -61,7 +84,6 @@ export const PageSimpleBarProvider: FunctionComponent<
     >
       <StyledSimpleBar
         $fillHeight={fillHeight}
-        $displayFlex={displayFlex}
         style={style}
         ref={(r) => {
           ref.current = r;

--- a/apps/extension/src/layouts/header/header.tsx
+++ b/apps/extension/src/layouts/header/header.tsx
@@ -263,7 +263,6 @@ export const HeaderLayout: FunctionComponent<
         <PageSimpleBarProvider
           style={{ height: "100%" }}
           fillHeight={fillHeight !== false}
-          displayFlex={displayFlex}
         >
           <HeaderBorderScrollHandler
             onShowBorderBottomChange={handleShowBorderBottomChange}

--- a/apps/extension/src/pages/bitcoin/components/unfiltered-utxo-warning.tsx
+++ b/apps/extension/src/pages/bitcoin/components/unfiltered-utxo-warning.tsx
@@ -22,6 +22,7 @@ export const UnfilteredUtxoWarning: FunctionComponent<{
 
   return (
     <VerticalCollapseTransition collapsed={isLoading || !apiError}>
+      <Gutter size="0.75rem" />
       <GuideBox
         color="warning"
         hideInformationIcon={true}

--- a/apps/extension/src/pages/bitcoin/send/index.tsx
+++ b/apps/extension/src/pages/bitcoin/send/index.tsx
@@ -565,12 +565,7 @@ export const BitcoinSendPage: FunctionComponent = observer(() => {
         }
       }}
     >
-      <Box
-        paddingX="0.75rem"
-        style={{
-          flex: 1,
-        }}
-      >
+      <Box paddingX="0.75rem" minHeight="100%">
         <Stack gutter="0.75rem" flex={1}>
           <YAxis>
             <Subtitle3>
@@ -615,18 +610,20 @@ export const BitcoinSendPage: FunctionComponent = observer(() => {
           <Styles.Flex1 />
           <Gutter size="0" />
 
-          <FeeControl
-            senderConfig={sendConfigs.senderConfig}
-            feeConfig={sendConfigs.feeConfig}
-            feeRateConfig={sendConfigs.feeRateConfig}
-            psbtSimulator={psbtSimulator}
-          />
-          <UnfilteredUtxoWarning
-            isLoading={isFetchingAvailableUTXOs}
-            apiError={availableUTXOsApiError}
-            allowUnfilteredOnApiError={allowUnfilteredOnApiError}
-            setAllowUnfilteredOnApiError={setAllowUnfilteredOnApiError}
-          />
+          <Box>
+            <FeeControl
+              senderConfig={sendConfigs.senderConfig}
+              feeConfig={sendConfigs.feeConfig}
+              feeRateConfig={sendConfigs.feeRateConfig}
+              psbtSimulator={psbtSimulator}
+            />
+            <UnfilteredUtxoWarning
+              isLoading={isFetchingAvailableUTXOs}
+              apiError={availableUTXOsApiError}
+              allowUnfilteredOnApiError={allowUnfilteredOnApiError}
+              setAllowUnfilteredOnApiError={setAllowUnfilteredOnApiError}
+            />
+          </Box>
         </Stack>
       </Box>
     </HeaderLayout>

--- a/apps/extension/src/pages/earn/confirm-usdn-estimation/index.tsx
+++ b/apps/extension/src/pages/earn/confirm-usdn-estimation/index.tsx
@@ -240,7 +240,7 @@ export const EarnConfirmUsdnEstimationPage: FunctionComponent = observer(() => {
         }
       }}
     >
-      <Box paddingX="1.25rem" paddingTop="1.75rem" height="100%">
+      <Box paddingX="1.25rem" paddingTop="1.75rem" minHeight="100%">
         <H2>
           <FormattedMessage
             id="page.earn.estimation-confirm.usdc-to-usdn.title"

--- a/apps/extension/src/pages/ibc-swap/select-asset/index.tsx
+++ b/apps/extension/src/pages/ibc-swap/select-asset/index.tsx
@@ -291,7 +291,7 @@ class IBCSwapDestinationState {
 
 const Styles = {
   Container: styled(Stack)`
-    flex: 1;
+    height: 100%;
     min-height: 0;
     padding: 0.75rem;
   `,
@@ -465,7 +465,7 @@ export const IBCSwapDestinationSelectAssetPage: FunctionComponent = observer(
         title={intl.formatMessage({ id: "page.send.select-asset.title" })}
         left={<BackButton />}
         fillHeight
-        displayFlex
+        displayFlex={true}
       >
         <Styles.Container gutter="0.5rem">
           <SearchTextInput

--- a/apps/extension/src/pages/ibc-transfer/index.tsx
+++ b/apps/extension/src/pages/ibc-transfer/index.tsx
@@ -281,7 +281,7 @@ export const IBCTransferPage: FunctionComponent = observer(() => {
         },
       ]}
     >
-      <Box height="100%">
+      <Box minHeight="100%">
         {isSelectChannelPhase ? (
           <IBCTransferSelectChannelView
             historyType={historyType}

--- a/apps/extension/src/pages/permission/basic-access-for-bitcoin/index.tsx
+++ b/apps/extension/src/pages/permission/basic-access-for-bitcoin/index.tsx
@@ -150,7 +150,7 @@ export const PermissionBasicAccessForBitcoinPage: FunctionComponent<{
         );
       }}
     >
-      <Box height="100%" padding="0.75rem" paddingBottom="0">
+      <Box minHeight="100%" padding="0.75rem" paddingBottom="0">
         <Box alignX="center">
           <Image
             alt="Keplr Logo Image"

--- a/apps/extension/src/pages/permission/basic-access-for-evm/index.tsx
+++ b/apps/extension/src/pages/permission/basic-access-for-evm/index.tsx
@@ -119,7 +119,7 @@ export const PermissionBasicAccessForEVMPage: FunctionComponent<{
         );
       }}
     >
-      <Box height="100%" padding="0.75rem" paddingBottom="0">
+      <Box minHeight="100%" padding="0.75rem" paddingBottom="0">
         <Box alignX="center">
           <Image
             alt="Keplr Logo Image"

--- a/apps/extension/src/pages/permission/basic-access-for-starknet/index.tsx
+++ b/apps/extension/src/pages/permission/basic-access-for-starknet/index.tsx
@@ -118,7 +118,7 @@ export const PermissionBasicAccessForStarknetPage: FunctionComponent<{
         );
       }}
     >
-      <Box height="100%" padding="0.75rem" paddingBottom="0">
+      <Box minHeight="100%" padding="0.75rem" paddingBottom="0">
         <Box alignX="center">
           <Image
             alt="Keplr Logo Image"

--- a/apps/extension/src/pages/send/amount/index.tsx
+++ b/apps/extension/src/pages/send/amount/index.tsx
@@ -2067,12 +2067,7 @@ export const SendAmountPage: FunctionComponent = observer(() => {
         }
       }}
     >
-      <Box
-        paddingX="0.75rem"
-        style={{
-          flex: 1,
-        }}
-      >
+      <Box paddingX="0.75rem" minHeight="100%">
         <Stack gutter="0.75rem" flex={1}>
           <YAxis>
             <Subtitle3>

--- a/apps/extension/src/pages/sign/cosmos/tx/view.tsx
+++ b/apps/extension/src/pages/sign/cosmos/tx/view.tsx
@@ -737,7 +737,8 @@ export const CosmosTxView: FunctionComponent<{
           style={{
             display: "flex",
             flexDirection: "column",
-            flex: !isViewData ? "0 1 auto" : 1,
+            flex: isViewData ? "0 1 auto" : "0 0 auto",
+            minHeight: isViewData ? "8rem" : undefined,
             overflow: "auto",
             opacity: isLedgerAndDirect ? 0.5 : undefined,
             borderRadius: "0.375rem",
@@ -807,24 +808,18 @@ export const CosmosTxView: FunctionComponent<{
           }}
         >
           {preferNoSetMemo ? (
-            <React.Fragment>
-              <ReadonlyMemo memo={memoConfig.memo} />
-              <Gutter size="0.75rem" />
-            </React.Fragment>
+            <ReadonlyMemo memo={memoConfig.memo} />
           ) : (
-            <React.Fragment>
-              <MemoInput
-                memoConfig={memoConfig}
-                placeholder={intl.formatMessage({
-                  id: "components.input.memo-input.optional-placeholder",
-                })}
-              />
-              <Gutter size="0.75rem" />
-            </React.Fragment>
+            <MemoInput
+              memoConfig={memoConfig}
+              placeholder={intl.formatMessage({
+                id: "components.input.memo-input.optional-placeholder",
+              })}
+            />
           )}
         </Box>
 
-        {!isViewData ? <div style={{ flex: 1 }} /> : null}
+        <div style={{ flex: 1, marginTop: "0.75rem" }} />
 
         {isLavaEndpoint ? (
           <React.Fragment>

--- a/apps/extension/src/pages/sign/ethereum/views/sign-tx-view.tsx
+++ b/apps/extension/src/pages/sign/ethereum/views/sign-tx-view.tsx
@@ -778,7 +778,8 @@ export const EthereumSignTxView: FunctionComponent<{
           style={{
             display: "flex",
             flexDirection: "column",
-            flex: !isViewData ? "0 1 auto" : 1,
+            flex: isViewData ? "0 1 auto" : "0 0 auto",
+            minHeight: isViewData ? "8rem" : undefined,
             overflowY: "auto",
             overflowX: "hidden",
             borderRadius: "0.375rem",
@@ -866,9 +867,7 @@ export const EthereumSignTxView: FunctionComponent<{
           )}
         </DelayedScrollBarSimpleBar>
 
-        <Box height="0" minHeight="0.75rem" />
-
-        {!isViewData ? <div style={{ flex: 1 }} /> : null}
+        <div style={{ flex: 1, marginTop: "0.75rem" }} />
 
         {(() => {
           if (interactionData.isInternal) {

--- a/apps/extension/src/pages/starknet/send/index.tsx
+++ b/apps/extension/src/pages/starknet/send/index.tsx
@@ -538,12 +538,7 @@ export const StarknetSendPage: FunctionComponent = observer(() => {
         }
       }}
     >
-      <Box
-        paddingX="0.75rem"
-        style={{
-          flex: 1,
-        }}
-      >
+      <Box paddingX="0.75rem" minHeight="100%">
         <Stack gutter="0.75rem" flex={1}>
           <YAxis>
             <Subtitle3>

--- a/apps/extension/src/pages/wallet/show-sensitive/index.tsx
+++ b/apps/extension/src/pages/wallet/show-sensitive/index.tsx
@@ -138,7 +138,7 @@ export const WalletShowSensitivePage: FunctionComponent = observer(() => {
         padding="0.75rem"
         paddingTop="0.5rem"
         paddingBottom="0"
-        height="100%"
+        minHeight="100%"
       >
         {sensitive === "" ? (
           <React.Fragment>


### PR DESCRIPTION
1. StyledSimpleBar의 content height를 100%로 고정하고 `displayFlex` 속성을 제거. 자식 요소의 크기 변화를 감지하여 스크롤바 높이가 실시간으로 갱신되도록 useEffect 처리 추가 (ResizeObserver 기반)
2. `min-height: 100%`로 설정하면 Send/서명 페이지에서 Fee Control·Summary가 하단 버튼에 붙지 않는 문제가 있어 `height: 100%`로 결정
3. `.simplebar-content`에 스타일을 직접 부여하면 페이지 내 모든 SimpleBar에 영향을 주므로, 페이지 스크롤용 최상위 SimpleBar의 content height만 100%로 고정되도록 제한
4. 조건부로 높이가 변하는 페이지에서는 `flex: 1`로는 대응이 어렵고, `height: 100%` 고정 시 동적 높이 변화를 감지하지 못해 스크롤바가 표시되지 않는 문제가 있어 `min-height: 100%`로 변경
5. 기타 minor UI 이슈 수정
6. Swap Destination Asset 페이지 infinite scroll 정상 동작 확인

~하나 건드리면 다른 페이지 박살나고 개복잡해가지고 일단 내일 오전에 더 qa 돌려보고 버전업할 예정.~
popup/sidepanel 체크 완료...