### PR TITLE
fix: Hide top-up UI when server top-up is unavailable

### DIFF
--- a/packages/hooks/src/tx/fee.ts
+++ b/packages/hooks/src/tx/fee.ts
@@ -1267,7 +1267,10 @@ export class FeeConfig extends TxChainSetter implements IFeeConfig {
       this._uiProperties.error instanceof InsufficientFeeError
     ) {
       const topUpStatus = this.getTopUpStatus();
-      if (topUpStatus.shouldTopUp) {
+      if (
+        topUpStatus.shouldTopUp &&
+        (topUpStatus.isTopUpAvailable || topUpStatus.remainingTimeMs != null)
+      ) {
         return {
           warning: new ShouldTopUpWarning("Should top up"),
         };


### PR DESCRIPTION
<img width="1624" height="979" alt="스크린샷 2026-02-23 오후 6 49 27" src="https://github.com/user-attachments/assets/08e56503-0d2f-4f19-b8c7-7d326f38af59" />

<img width="1624" height="979" alt="스크린샷 2026-02-23 오후 7 45 14" src="https://github.com/user-attachments/assets/cad7c593-b262-4a12-90d0-b7b6a17e758b" />
