### PR TITLE
fix: Correct swap analytics duration measurement

### DIFF
--- a/apps/extension/src/pages/ibc-swap/hooks/use-swap-analytics.ts
+++ b/apps/extension/src/pages/ibc-swap/hooks/use-swap-analytics.ts
@@ -337,8 +337,6 @@ export const useSwapAnalytics = ({
     const durationMs = requestStartedAtRef.current
       ? performance.now() - requestStartedAtRef.current
       : undefined;
-    requestStartedAtRef.current = undefined;
-
     logEvent("swap_quote_received", {
       quote_id: quoteId,
       duration_ms: durationMs,
@@ -357,6 +355,7 @@ export const useSwapAnalytics = ({
       route_duration_estimate_sec: estimated_time,
       swap_venues: swapVenues,
     });
+    requestStartedAtRef.current = undefined;
     quoteIdRef.current = quoteId;
     prevRouteKeyRef.current = currentKey;
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
- `total_duration_ms`가 `swap_quote_received` 시점부터만 측정되어 quote 요청 구간(`swap_quote_requested` → `swap_quote_received`)이 누락되는 버그 수정. `durationRef` 초기화 시 `requestStartedAtRef.current`를 first로 사용
- fetching 중 파라미터 변경 시 `queryRouteForLog` 객체가 교체되어도 `isFetching`이 true → true로 effect가 재실행되지 않아 `requestStartedAtRef`가 갱신되지 않는 버그 수정. `queryRouteForLog` 객체 참조 변경도 감지하도록 dependency 추가