### PR TITLE
refactor indexed db kv store

### DIFF
--- a/packages/common/src/kv-store/indexed-db.ts
+++ b/packages/common/src/kv-store/indexed-db.ts
@@ -1,7 +1,7 @@
 import { KVStore } from "./interface";
 
 export class IndexedDBKVStore implements KVStore {
-  protected cachedDBPromise?: Promise<IDBDatabase>;
+  protected static dbPromiseMap = new Map<string, Promise<IDBDatabase>>();
 
   constructor(protected readonly _prefix: string) {}
 
@@ -85,19 +85,21 @@ export class IndexedDBKVStore implements KVStore {
   }
 
   protected async getDB(): Promise<IDBDatabase> {
-    if (!this.cachedDBPromise) {
-      this.cachedDBPromise = this.openDB();
+    const prefix = this.prefix();
+    if (!IndexedDBKVStore.dbPromiseMap.has(prefix)) {
+      IndexedDBKVStore.dbPromiseMap.set(prefix, this.openDB());
     }
 
-    return this.cachedDBPromise;
+    return IndexedDBKVStore.dbPromiseMap.get(prefix)!;
   }
 
   protected openDB(): Promise<IDBDatabase> {
+    const prefix = this.prefix();
     return new Promise((resolve, reject) => {
-      const request = window.indexedDB.open(this.prefix());
+      const request = window.indexedDB.open(prefix);
       request.onerror = (event) => {
         event.stopPropagation();
-        this.cachedDBPromise = undefined;
+        IndexedDBKVStore.dbPromiseMap.delete(prefix);
         reject(event.target);
       };
 
@@ -106,18 +108,18 @@ export class IndexedDBKVStore implements KVStore {
         // @ts-ignore
         const db = event.target.result;
 
-        db.createObjectStore(this.prefix(), { keyPath: "key" });
+        db.createObjectStore(prefix, { keyPath: "key" });
       };
 
       request.onsuccess = () => {
         const db = request.result;
 
         db.onclose = () => {
-          this.cachedDBPromise = undefined;
+          IndexedDBKVStore.dbPromiseMap.delete(prefix);
         };
         db.onversionchange = () => {
           db.close();
-          this.cachedDBPromise = undefined;
+          IndexedDBKVStore.dbPromiseMap.delete(prefix);
         };
 
         resolve(db);


### PR DESCRIPTION
  1. Stale connection & race condition 수정 — cachedDB (IDBDatabase 인스턴스)를 cachedDBPromise로 변경하여 동시 호출 시 indexedDB.open()이
   중복 실행되는 race condition을 해결하고, onclose/onversionchange 이벤트 핸들러를 추가하여 커넥션이 닫힐 때 캐시를 무효화 ("The database
   connection is closing" 에러 방지)                                                                                                      
  2. getAllKeys() 메서드 추가 — object store의 모든 key를 string[]로 반환
  3. Static cache로 리팩터링 — 인스턴스 필드였던 cachedDBPromise를 static dbPromiseMap(Map<string, Promise<IDBDatabase>>)으로 변경하여,
  같은 prefix를 가진 여러 IndexedDBKVStore 인스턴스가 하나의 DB 커넥션을 공유
  
  extension이랑은 상관없고 mobile 쪽을 개선하기 위해서...