### PR TITLE
fix: Guard against undefined balances in cosmos bank query responses

### DIFF
--- a/packages/stores/src/query/cosmos/balance/balances.ts
+++ b/packages/stores/src/query/cosmos/balance/balances.ts
@@ -48,7 +48,8 @@ export class ObservableQueryCosmosBalancesImplParent extends ObservableChainQuer
     super.onReceiveResponse(response);
 
     const chainInfo = this.chainGetter.getChain(this.chainId);
-    const denoms = response.data.balances.map((coin) => coin.denom);
+    const balances = response.data.balances ?? [];
+    const denoms = balances.map((coin) => coin.denom);
     chainInfo.addUnknownDenoms(...denoms);
   }
 }
@@ -75,7 +76,7 @@ export class ObservableQueryCosmosBalancesImpl
 
     return StoreUtils.getBalanceFromCurrency(
       currency,
-      this.response.data.balances
+      this.response.data.balances ?? []
     );
   }
 

--- a/packages/stores/src/query/cosmos/balance/spendable.ts
+++ b/packages/stores/src/query/cosmos/balance/spendable.ts
@@ -33,7 +33,8 @@ export class ObservableChainQuerySpendableBalances extends ObservableChainQuery<
 
     const chainInfo = this.chainGetter.getChain(this.chainId);
 
-    for (const bal of this.response.data.balances) {
+    const balances = this.response.data.balances ?? [];
+    for (const bal of balances) {
       const currency = chainInfo.findCurrency(bal.denom);
       if (currency) {
         res.push(new CoinPretty(currency, bal.amount));

--- a/packages/stores/src/query/cosmos/balance/types.ts
+++ b/packages/stores/src/query/cosmos/balance/types.ts
@@ -1,13 +1,13 @@
 import { CoinPrimitive } from "../../../common";
 
 export type Balances = {
-  balances: CoinPrimitive[];
+  balances?: CoinPrimitive[];
   // TODO: Handle pagination?
   // pagination: {};
 };
 
 export type SpendableBalances = {
-  balances: CoinPrimitive[];
+  balances?: CoinPrimitive[];
   // TODO: Handle pagination?
   // pagination: {};
 };


### PR DESCRIPTION
[Some chains may return responses without the `balances` field, causing TypeError on `.map()` / `for..of`. Add nullish coalescing fallback to empty array and mark the type as optional.](https://app.bugsnag.com/keplr-1/keplr-js-1/errors/6984ddd517ff228a2ef46694?filters[error.status]=open&filters[event.since]=30d&filters[release.seen_in]=2.1.163)