### PR TITLE
fix: Reject with proper Error objects in IndexedDB and handle DebounceActionTimer rejections

### DIFF
--- a/packages/common/src/kv-store/indexed-db.ts
+++ b/packages/common/src/kv-store/indexed-db.ts
@@ -14,7 +14,8 @@ export class IndexedDBKVStore implements KVStore {
       request.onerror = (event) => {
         event.stopPropagation();
 
-        reject(event.target);
+        const error = (event.target as IDBRequest).error;
+        reject(new Error(error?.message ?? "Unknown IndexedDB error on get"));
       };
       request.onsuccess = () => {
         if (!request.result) {
@@ -36,7 +37,10 @@ export class IndexedDBKVStore implements KVStore {
         request.onerror = (event) => {
           event.stopPropagation();
 
-          reject(event.target);
+          const error = (event.target as IDBRequest).error;
+          reject(
+            new Error(error?.message ?? "Unknown IndexedDB error on delete")
+          );
         };
         request.onsuccess = () => {
           resolve();
@@ -54,7 +58,8 @@ export class IndexedDBKVStore implements KVStore {
         request.onerror = (event) => {
           event.stopPropagation();
 
-          reject(event.target);
+          const error = (event.target as IDBRequest).error;
+          reject(new Error(error?.message ?? "Unknown IndexedDB error on put"));
         };
         request.onsuccess = () => {
           resolve();
@@ -72,7 +77,10 @@ export class IndexedDBKVStore implements KVStore {
       request.onerror = (event) => {
         event.stopPropagation();
 
-        reject(event.target);
+        const error = (event.target as IDBRequest).error;
+        reject(
+          new Error(error?.message ?? "Unknown IndexedDB error on getAllKeys")
+        );
       };
       request.onsuccess = () => {
         resolve(request.result as string[]);
@@ -100,7 +108,10 @@ export class IndexedDBKVStore implements KVStore {
       request.onerror = (event) => {
         event.stopPropagation();
         IndexedDBKVStore.dbPromiseMap.delete(prefix);
-        reject(event.target);
+        const error = (event.target as IDBRequest).error;
+        reject(
+          new Error(error?.message ?? "Unknown IndexedDB error on openDB")
+        );
       };
 
       request.onupgradeneeded = (event) => {

--- a/packages/mobx-utils/src/mobx/debounce.ts
+++ b/packages/mobx-utils/src/mobx/debounce.ts
@@ -36,9 +36,20 @@ export class DebounceActionTimer<ARGS, R> {
       const requests = this.requests.slice();
       const responses = this.handler(requests);
       if (typeof responses === "object" && "then" in responses) {
-        Promise.resolve(responses).then((responses) => {
-          this.handleResponses(requests, responses);
-        });
+        Promise.resolve(responses)
+          .then((responses) => {
+            this.handleResponses(requests, responses);
+          })
+          .catch((e) => {
+            console.error("DebounceActionTimer handler failed", e);
+            this.handleResponses(
+              requests,
+              requests.map(() => ({
+                status: "rejected" as const,
+                reason: e,
+              }))
+            );
+          });
       } else {
         this.handleResponses(requests, responses);
       }


### PR DESCRIPTION
## Summary
- `IndexedDBKVStore`의 5개 `onerror` 핸들러가 `reject(event.target)` (IDBRequest DOM 객체)으로 reject하여 BugSnag에서 `InvalidError: non-error parameter {}` 발생 → `reject(new Error(...))` 로 수정
- `DebounceActionTimer`에서 async handler의 `.catch()` 누락으로 unhandled rejection 발생 및 pending Promise가 영원히 resolve되지 않는 버그 → `.catch()` 추가하여 `{ status: "rejected" }` 로 정상 처리

## Why `develop` (not `develop-mobile`)
BugSnag 리포트는 97% iOS WKWebView에서 발생하지만, 변경 대상이 공유 패키지(`packages/common`, `packages/mobx-utils`)이고 익스텐션에 side effect가 없는 안전한 수정이므로 `develop`에 먼저 머지 후 `develop-mobile`에 cherry-pick.

## Test plan
- [x] TypeScript typecheck 통과
- [x] lint-test 통과
- [x] build 통과
- [x] 기존 테스트 통과
- [ ] 배포 후 BugSnag `InvalidError` 발생 빈도 감소 확인

## Follow-up
- [ ] `develop-mobile`에 cherry-pick
- [ ] Mobile repo에서 submodule commit hash update

🤖 Generated with [Claude Code](https://claude.ai/code)