### PR TITLE
fix(hooks): hide fee topup UI when send amount exceeds balance

### DIFF
--- a/packages/hooks/src/tx/fee.ts
+++ b/packages/hooks/src/tx/fee.ts
@@ -14,7 +14,11 @@ import { CoinPretty, Dec, DecUtils, Int } from "@keplr-wallet/unit";
 import { Currency, FeeCurrency, StdFee } from "@keplr-wallet/types";
 import { computedFn } from "mobx-utils";
 import { useState } from "react";
-import { InsufficientFeeError, ShouldTopUpWarning } from "./errors";
+import {
+  InsufficientFeeError,
+  InsufficientAmountError,
+  ShouldTopUpWarning,
+} from "./errors";
 import { QueriesStore } from "./internal";
 import { DenomHelper } from "@keplr-wallet/common";
 import { EthereumQueriesImpl } from "@keplr-wallet/stores-eth";
@@ -1300,6 +1304,14 @@ export class FeeConfig extends TxChainSetter implements IFeeConfig {
 
       // 모든 fee currency가 부족할 경우에만 topup 사용이 가능
       const shouldTopUp = (() => {
+        // amount 자체가 잔액을 초과하는 경우는 topup 대상이 아님
+        if (
+          this.amountConfig.uiProperties.error instanceof
+          InsufficientAmountError
+        ) {
+          return false;
+        }
+
         const queryBalances = this.queriesStore
           .get(this.chainId)
           .queryBalances.getQueryBech32Address(this.senderConfig.sender);


### PR DESCRIPTION
## Summary

- Cosmos 생태계 fee topup 요청 시, 전송 amount가 balance를 초과해도 topup UI가 표시되는 버그 수정
- `getTopUpStatus()`의 `shouldTopUp` 계산 시 `InsufficientAmountError` 존재 여부를 먼저 체크해 topup 전환 차단
- `_uiProperties`의 기존 fee 에러(다른 denom fee 부족 등)는 그대로 보존

## Root Cause

`getTopUpStatus()`가 `totalNeed = fee + amount`를 계산해 잔액과 비교하는데, amount > balance인 경우에도 `shouldTopUp = true`를 반환. 이로 인해 `uiProperties`가 `InsufficientFeeError`를 `ShouldTopUpWarning`으로 교체해 topup UI가 표시됨.

## Fix

`getTopUpStatus()` 내부 `shouldTopUp` IIFE 앞에 guard 추가:

```typescript
if (this.amountConfig.uiProperties.error instanceof InsufficientAmountError) {
  return false; // amount > balance → topup 대상 아님
}
```

## Behavior

| 케이스 | 변경 전 | 변경 후 |
|--------|---------|---------|
| `amount > balance` | topup UI 표시 ❌ | 기존 fee 에러 표시, topup UI 숨김 ✅ |
| `amount <= balance`, fee 부족 | topup UI 표시 ✅ | topup UI 표시 ✅ (유지) |

## Test plan

- [ ] 잔액보다 큰 amount 입력 시 topup UI 미표시, 기존 에러 표시 확인 (send, ibc-transfer, ibc-swap, sign/cosmos)
- [ ] 잔액 이하 amount 입력 + fee 부족 시 topup UI 정상 표시 확인

Closes KEPLR-1941

🤖 Generated with [Claude Code](https://claude.com/claude-code)