### PR TITLE
fix: Narrow claim-all button hover/click area to text only

### DIFF
--- a/apps/extension/src/pages/main/components/rewards-card/index.tsx
+++ b/apps/extension/src/pages/main/components/rewards-card/index.tsx
@@ -323,28 +323,12 @@ const ClaimAllButton: FunctionComponent<ClaimAllButtonProps> = ({
   }, []);
 
   return (
-    <Box
-      onHoverStateChange={(hovered) => {
-        if (claimAllDisabled) {
-          return;
-        }
-        if (!hovered) {
-          setIsPressed(false);
-        }
-        setIsHover(hovered);
-      }}
-      cursor={claimAllDisabled ? "not-allowed" : "pointer"}
-      opacity={shouldDimClaimAllButton ? COMMON_HOVER_OPACITY : undefined}
-      onMouseDown={() => {
-        if (claimAllDisabled) {
-          return;
-        }
-        setIsPressed(true);
-      }}
-      onClick={handleClick}
-    >
+    <Box opacity={shouldDimClaimAllButton ? COMMON_HOVER_OPACITY : undefined}>
       <XAxis alignY="center">
-        <SlidingIconContainer $isActive={!claimAllDisabled && isHover}>
+        <SlidingIconContainer
+          $isActive={!claimAllDisabled && isHover}
+          style={{ pointerEvents: "none" }}
+        >
           <Box padding="0.125rem">
             <CheckIcon
               width="0.75rem"
@@ -359,25 +343,47 @@ const ClaimAllButton: FunctionComponent<ClaimAllButtonProps> = ({
             />
           </Box>
         </SlidingIconContainer>
-        <Gutter size="0.25rem" />
-        <Subtitle3
-          color={
-            claimAllDisabled
-              ? ColorPalette["gray-300"]
-              : theme.mode === "light"
-              ? ColorPalette["blue-400"]
-              : ColorPalette["blue-300"]
-          }
+        <div style={{ pointerEvents: "none" }}>
+          <Gutter size="0.25rem" />
+        </div>
+        <Box
+          onHoverStateChange={(hovered) => {
+            if (claimAllDisabled) {
+              return;
+            }
+            if (!hovered) {
+              setIsPressed(false);
+            }
+            setIsHover(hovered);
+          }}
+          cursor={claimAllDisabled ? "not-allowed" : "pointer"}
+          onMouseDown={() => {
+            if (claimAllDisabled) {
+              return;
+            }
+            setIsPressed(true);
+          }}
+          onClick={handleClick}
         >
-          <ClaimTextWrapper $width={labelWidth}>
-            <ClaimAllText ref={claimTextRef} $visible={!isHover}>
-              {claimLabel}
-            </ClaimAllText>
-            <ApproveText ref={approveTextRef} $visible={isHover}>
-              {approveLabel}
-            </ApproveText>
-          </ClaimTextWrapper>
-        </Subtitle3>
+          <Subtitle3
+            color={
+              claimAllDisabled
+                ? ColorPalette["gray-300"]
+                : theme.mode === "light"
+                ? ColorPalette["blue-400"]
+                : ColorPalette["blue-300"]
+            }
+          >
+            <ClaimTextWrapper $width={labelWidth}>
+              <ClaimAllText ref={claimTextRef} $visible={!isHover}>
+                {claimLabel}
+              </ClaimAllText>
+              <ApproveText ref={approveTextRef} $visible={isHover}>
+                {approveLabel}
+              </ApproveText>
+            </ClaimTextWrapper>
+          </Subtitle3>
+        </Box>
       </XAxis>
     </Box>
   );


### PR DESCRIPTION
## Summary
- Move event handlers (hover, click, mousedown) from the outer Box to an inner Box wrapping only the text label in the rewards card claim-all button
- Add `pointer-events: none` to `SlidingIconContainer` and `Gutter` so they no longer extend the interactive area
- Fixes oversized touch target where CheckIcon and Gutter were part of the clickable area
- Fixes hover flicker caused by layout shifts when hovering near the button boundary

## Test plan
- [ ] Hover over the claim-all button edge — no more rapid flickering between "Claim All" and "Approve" labels
- [ ] Click area matches only the visible text, not the icon/gutter space
- [ ] CheckIcon slide-in animation still works on hover
- [ ] Claim all functionality works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)