### PR TITLE
fix: Reset EIP-6963 provider state on wallet_revokePermissions

### DIFF
--- a/packages/provider-extension/src/keplr.ts
+++ b/packages/provider-extension/src/keplr.ts
@@ -1031,10 +1031,12 @@ class EthereumProvider extends EventEmitter implements IEthereumProvider {
       });
 
       this._isConnected = false;
+      this._currentChainId = null;
       this.chainId = null;
       this.selectedAddress = null;
       this.networkVersion = null;
 
+      this.emit("accountsChanged", []);
       this.emit("disconnect");
     }
   }
@@ -1082,12 +1084,23 @@ class EthereumProvider extends EventEmitter implements IEthereumProvider {
       await this._initProviderState();
     }
 
-    return await EthereumProvider.requestMethod("request", {
+    const result = await EthereumProvider.requestMethod<T>("request", {
       method,
       params,
       providerId: this.eip6963ProviderInfo?.uuid,
       chainId,
     });
+
+    if (method === "wallet_revokePermissions") {
+      this._isConnected = false;
+      this._currentChainId = null;
+      this.chainId = null;
+      this.selectedAddress = null;
+      this.networkVersion = null;
+      this.emit("accountsChanged", []);
+    }
+
+    return result;
   }
 
   async enable(): Promise<string[]> {

--- a/packages/provider/src/inject.ts
+++ b/packages/provider/src/inject.ts
@@ -1409,10 +1409,12 @@ class EthereumProvider extends EventEmitter implements IEthereumProvider {
       });
 
       this._isConnected = false;
+      this._currentChainId = null;
       this.chainId = null;
       this.selectedAddress = null;
       this.networkVersion = null;
 
+      this.emit("accountsChanged", []);
       this.emit("disconnect");
     }
   };
@@ -1460,12 +1462,25 @@ class EthereumProvider extends EventEmitter implements IEthereumProvider {
       await this._initProviderState();
     }
 
-    return await this._requestMethod<T>("request", {
+    const result = await this._requestMethod<T>("request", {
       method,
       params,
       providerId: this.eip6963ProviderInfo?.uuid,
       chainId,
     });
+
+    // Clear provider state after revoking permissions to prevent
+    // phantom connections from keplr_keystorechange events
+    if (method === "wallet_revokePermissions") {
+      this._isConnected = false;
+      this._currentChainId = null;
+      this.chainId = null;
+      this.selectedAddress = null;
+      this.networkVersion = null;
+      this.emit("accountsChanged", []);
+    }
+
+    return result;
   };
 
   enable = async (): Promise<string[]> => {


### PR DESCRIPTION
## Summary
- `wallet_revokePermissions` 호출 시 provider-side 상태(`_isConnected`, `_currentChainId`, `selectedAddress` 등) 미초기화 → disconnect 후 계정 스위치 시 phantom connection 발생 → refresh 시 연결 끊김
- `request()` 메서드에서 `wallet_revokePermissions` 응답 후 provider 상태 초기화 + `accountsChanged: []` emit (MetaMask/Rabby 동일 동작)
- `_handleDisconnect()`에서 `_currentChainId` 초기화 + `accountsChanged: []` emit 추가
- `provider`, `provider-extension` 양쪽 동일 수정

## Reproduction (Initia team report)
1. Connect Keplr, refresh → OK ✅
2. Disconnect wallet, switch Keplr address, approve popup ⚠️
3. Connect wallet again → OK ✅
4. Refresh → wallet becomes unconnected ❌

## Root Cause
`wallet_revokePermissions`가 백그라운드 퍼미션만 제거하고 provider 상태를 안 지워서, `keplr_keystorechange` 핸들러가 `getKey()` → permission popup → phantom connection 생성. 재연결 시 `ensureEnabledForEVM`에서 이미 basic access가 있으므로 `currentChainIdForEVMByOriginMap` 미설정 → refresh 시 `keplr_initProviderState`가 null 반환.

## Test plan
- [ ] dApp(interwovenkit.pages.dev)에서 위 reproduction steps 재현 후 수정 검증
- [ ] Connect → disconnect → account switch → 퍼미션 팝업이 뜨지 않는지 확인
- [ ] Connect → disconnect → reconnect → refresh → 연결 유지 확인
- [ ] 기존 connect/disconnect 플로우 regression 없는지 확인

Resolves KEPLR-1982

🤖 Generated with [Claude Code](https://claude.com/claude-code)