### PR TITLE
[🎨 Design System] Clean up sync scripts and typography types

### DIFF
--- a/packages/design-system/scripts/sync-tokens/generate-color-ts.mjs
+++ b/packages/design-system/scripts/sync-tokens/generate-color-ts.mjs
@@ -296,7 +296,7 @@ function buildThemeValues(mode) {
 
 const now = new Date().toISOString().slice(0, 19).replace("T", " ");
 const newContent = `\
-// @generated — DO NOT EDIT MANUALLY
+// GENERATED FILE — DO NOT EDIT MANUALLY
 // Last synced: ${now} UTC
 // Source: Figma "Supernova Design System"
 // Run: yarn workspace @keplr-wallet/design-system sync:tokens

--- a/packages/design-system/scripts/sync-tokens/generate-color-ts.mjs
+++ b/packages/design-system/scripts/sync-tokens/generate-color-ts.mjs
@@ -84,6 +84,10 @@ for (const variants of Object.values(alphasByBase)) {
   variants.sort((a, b) => a.alphaPct - b.alphaPct);
 }
 
+// Synthetic primitives — only added if not already present from Figma
+if (!solidColors.black) solidColors.black = { r: 0, g: 0, b: 0 };
+if (!solidColors.white) solidColors.white = { r: 1, g: 1, b: 1 };
+
 function parseField(field) {
   const match = field.match(/^([a-z]+)(\d+)$/);
   return match
@@ -98,12 +102,9 @@ const sortedSolids = Object.keys(solidColors).sort((a, b) => {
     : pa.num - pb.num;
 });
 
-// ── Reverse lookup maps ────────────────────────────────────────────────────────
 const rgbToSolidName = {};
 for (const [field, rgba] of Object.entries(solidColors))
   rgbToSolidName[rgbKey(rgba.r, rgba.g, rgba.b)] = field;
-rgbToSolidName["0,0,0"] = "black";
-rgbToSolidName["255,255,255"] = "white";
 
 const rgbAlphaToName = {};
 for (const { base, alphaPct, rgba } of alphaVariants) {
@@ -119,14 +120,9 @@ for (const { base, alphaPct, rgba } of alphaVariants) {
     ] = variantName;
 }
 
-const droppedTokens = [];
-
 function semPrimRef(tokenKey, mode) {
   const token = figmaData.semantic[tokenKey];
-  if (!token?.[mode]) {
-    if (mode === "dark") droppedTokens.push(tokenKey);
-    return null;
-  }
+  if (!token?.[mode]) return null;
   const { r, g, b, a } = token[mode];
   if (a >= 0.999) return rgbToSolidName[rgbKey(r, g, b)] || null;
   const alphaPct = Math.round(a * 100);
@@ -199,7 +195,11 @@ for (const namespace of Object.keys(semTree)) {
 }
 
 function hasAnyToken(namespace) {
-  if (semTree[namespace].tokens.some((t) => semPrimRef(t.figmaPath, "dark")))
+  if (
+    semTree[namespace].tokens.some(
+      (t) => semPrimRef(t.figmaPath, "dark") || semPrimRef(t.figmaPath, "light")
+    )
+  )
     return true;
   return [...semTree[namespace].children].some((child) => hasAnyToken(child));
 }
@@ -217,59 +217,40 @@ const topNamespaces = Object.keys(semTree)
     );
   });
 
-// ── Generate single color.ts ────────────────────────────────────────────────
-const now = new Date().toISOString().slice(0, 19).replace("T", " ");
-const L = [];
+// ── Code generation ─────────────────────────────────────────────────────────
 
-L.push(`// GENERATED FILE — DO NOT EDIT MANUALLY`);
-L.push(`// Last synced: ${now} UTC`);
-L.push(`// Source: Figma "For Roy: Supernova Design System"`);
-L.push(`// Run: yarn workspace @keplr-wallet/design-system sync:tokens`);
-L.push(``);
-
-// ── DSColor: primitives + semantic var refs ──────────────────────────────────
-L.push(`/**`);
-L.push(` * Unified Design System colors.`);
-L.push(` * Primitive: DSColor.blue400, DSColor.gray10`);
-L.push(` * Semantic:  DSColor.typography.primary, DSColor.fill.neutral.high`);
-L.push(` */`);
-L.push(`export const DSColor = {`);
-
-// Primitives
-L.push(`  // ── Primitives ──`);
 function colorFamily(field) {
   return field.replace(/\d+$/, "");
 }
-let prevFamily = "";
-for (const field of sortedSolids) {
-  const rgba = solidColors[field];
-  const family = colorFamily(field);
-  if (prevFamily && family !== prevFamily) L.push(``);
-  L.push(`  ${field}: '${toHex(rgba.r, rgba.g, rgba.b)}',`);
-  for (const { alphaPct, rgba: aRgba } of alphasByBase[field] || []) {
-    L.push(
-      `  ${field}_${alphaPct}: '${toRgba(
-        aRgba.r,
-        aRgba.g,
-        aRgba.b,
-        alphaPct / 100
-      )}',`
-    );
-  }
-  prevFamily = family;
-}
-L.push(``);
-L.push(`  black: '#000000',`);
-L.push(`  white: '#FFFFFF',`);
-L.push(`  transparent: 'rgba(255, 255, 255, 0)',`);
 
-// Semantic var refs
-L.push(``);
-L.push(`  // ── Semantic (CSS variable refs) ──`);
+function buildPrimitiveLines() {
+  const lines = [];
+  let prevFamily = "";
+  for (const field of sortedSolids) {
+    const rgba = solidColors[field];
+    const family = colorFamily(field);
+    if (prevFamily && family !== prevFamily) lines.push("");
+    lines.push(`  ${field}: '${toHex(rgba.r, rgba.g, rgba.b)}',`);
+    for (const { alphaPct, rgba: aRgba } of alphasByBase[field] || []) {
+      lines.push(
+        `  ${field}_${alphaPct}: '${toRgba(
+          aRgba.r,
+          aRgba.g,
+          aRgba.b,
+          alphaPct / 100
+        )}',`
+      );
+    }
+    prevFamily = family;
+  }
+  return lines.join("\n");
+}
 
 function buildVarTree(namespace, indent) {
   const { tokens, children } = semTree[namespace];
-  const validTokens = tokens.filter((t) => semPrimRef(t.figmaPath, "dark"));
+  const validTokens = tokens.filter(
+    (t) => semPrimRef(t.figmaPath, "dark") || semPrimRef(t.figmaPath, "light")
+  );
   const validChildren = [...children].filter((child) => hasAnyToken(child));
   if (!validTokens.length && !validChildren.length) return null;
 
@@ -278,8 +259,7 @@ function buildVarTree(namespace, indent) {
     lines.push(`${indent}  ${token.jsKey}: 'var(${token.cssVar})' as const,`);
   }
   for (const child of validChildren) {
-    const childParts = child.split("/");
-    const childKey = toJsKey(childParts[childParts.length - 1]);
+    const childKey = toJsKey(child.split("/").pop());
     const childLines = buildVarTree(child, indent + "  ");
     if (childLines) {
       lines.push(`${indent}  ${childKey}: {`);
@@ -290,46 +270,64 @@ function buildVarTree(namespace, indent) {
   return lines.join("\n");
 }
 
-for (const ns of topNamespaces) {
-  if (!hasAnyToken(ns)) continue;
-  const nsKey = toJsKey(ns);
-  const inner = buildVarTree(ns, "  ");
-  if (inner) {
-    L.push(`  ${nsKey}: {`);
-    L.push(inner);
-    L.push(`  },`);
+function buildSemanticLines() {
+  const lines = [];
+  for (const ns of topNamespaces) {
+    if (!hasAnyToken(ns)) continue;
+    const inner = buildVarTree(ns, "  ");
+    if (inner) {
+      lines.push(`  ${toJsKey(ns)}: {`);
+      lines.push(inner);
+      lines.push(`  },`);
+    }
   }
+  return lines.join("\n");
 }
 
-L.push(`} as const;`);
-L.push(``);
-
-// ── Theme values ──────────────────────────────────────────────────────────────
 function buildThemeValues(mode) {
-  const entries = [];
+  const lines = [];
   for (const key of Object.keys(figmaData.semantic)) {
     const primRef = semPrimRef(key, mode);
     if (!primRef) continue;
-    const cssVar = toCssVarName(key);
-    entries.push(`  '${cssVar}': DSColor.${primRef},`);
+    lines.push(`  '${toCssVarName(key)}': DSColor.${primRef},`);
   }
-  return entries;
+  return lines.join("\n");
 }
 
-L.push(`/** Dark theme CSS variable values */`);
-L.push(`export const darkThemeValues: Record<string, string> = {`);
-for (const line of buildThemeValues("dark")) L.push(line);
-L.push(`};`);
-L.push(``);
+const now = new Date().toISOString().slice(0, 19).replace("T", " ");
+const newContent = `\
+// @generated — DO NOT EDIT MANUALLY
+// Last synced: ${now} UTC
+// Source: Figma "Supernova Design System"
+// Run: yarn workspace @keplr-wallet/design-system sync:tokens
 
-L.push(`/** Light theme CSS variable values */`);
-L.push(`export const lightThemeValues: Record<string, string> = {`);
-for (const line of buildThemeValues("light")) L.push(line);
-L.push(`};`);
-L.push(``);
+/**
+ * Unified Design System colors.
+ * Primitive: DSColor.blue400, DSColor.gray10
+ * Semantic:  DSColor.typography.primary, DSColor.fill.neutral.high
+ */
+export const DSColor = {
+  // ── Primitives ──
+${buildPrimitiveLines()}
+
+  transparent: 'rgba(255, 255, 255, 0)',
+
+  // ── Semantic (CSS variable refs) ──
+${buildSemanticLines()}
+} as const;
+
+/** Dark theme CSS variable values */
+export const darkThemeValues: Record<string, string> = {
+${buildThemeValues("dark")}
+};
+
+/** Light theme CSS variable values */
+export const lightThemeValues: Record<string, string> = {
+${buildThemeValues("light")}
+};
+`;
 
 // ── Field deletion guard ───────────────────────────────────────────────────────
-const newContent = L.join("\n");
 if (fs.existsSync(outputPath)) {
   const existing = fs.readFileSync(outputPath, "utf8");
   const existingFields = [...existing.matchAll(/^\s+(\w+):/gm)].map(
@@ -366,7 +364,10 @@ console.log(
   `  Primitives: ${sortedSolids.length} solids + ${alphaCount} alpha`
 );
 console.log(`  Semantics:  ${semCount} tokens`);
+const droppedTokens = Object.keys(figmaData.semantic).filter(
+  (k) => !semPrimRef(k, "dark") && !semPrimRef(k, "light")
+);
 if (droppedTokens.length > 0)
   console.warn(
-    `  ⚠ ${droppedTokens.length} semantic token(s) skipped — no dark mode value`
+    `  ⚠ ${droppedTokens.length} semantic token(s) skipped — no resolved value in either mode`
   );

--- a/packages/design-system/scripts/sync-tokens/generate-typography-ts.mjs
+++ b/packages/design-system/scripts/sync-tokens/generate-typography-ts.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Figma text style JSON → generate typography.ts
+// Figma text style JSON → generate typography-tokens.ts
 // Input: /tmp/figma-typography.json (generated after running sync-typography.mjs)
 
 import fs from "fs";
@@ -26,7 +26,7 @@ if (Object.keys(figmaStyles).length === 0) {
 }
 
 // ── Style parsing ──────────────────────────────────────────────────────────────
-function sizeToDartField(sizeName) {
+function sizeToTsField(sizeName) {
   // "Display xl" → "displayXl", "Text xxs" → "textXxs"
   const parts = sizeName.trim().split(/\s+/);
   return (
@@ -59,7 +59,7 @@ for (const [styleName, style] of Object.entries(figmaStyles)) {
   if (isDeprecatedVariant(variantName)) continue;
   if (isTestArtifact(sizeName)) continue;
 
-  const tsField = sizeToDartField(sizeName);
+  const tsField = sizeToTsField(sizeName);
   if (!tsField || sizeMap[tsField]) continue;
 
   sizeMap[tsField] = {
@@ -70,55 +70,56 @@ for (const [styleName, style] of Object.entries(figmaStyles)) {
   fieldOrder.push(tsField);
 }
 
-// ── TypeScript file generation ────────────────────────────────────────────────
-const now = new Date().toISOString().slice(0, 19).replace("T", " ");
-const lines = [];
+// ── Code generation ─────────────────────────────────────────────────────────────
 
-lines.push(`// GENERATED FILE — DO NOT EDIT MANUALLY`);
-lines.push(`// Last synced: ${now} UTC`);
-lines.push(`// Source: Figma "Supernova Design System" text styles`);
-lines.push(`// Run: yarn workspace @keplr-wallet/design-system sync:tokens`);
-lines.push(``);
-lines.push(`import type { CSSProperties } from 'react';`);
-lines.push(``);
-lines.push(`export interface TypographyStyle {`);
-lines.push(`  readonly fontSize: number;`);
-lines.push(`  readonly lineHeight: number;`);
-lines.push(`  readonly letterSpacing: number;`);
-lines.push(`  readonly semibold: CSSProperties;`);
-lines.push(`  readonly medium: CSSProperties;`);
-lines.push(`  readonly regular: CSSProperties;`);
-lines.push(`}`);
-lines.push(``);
-lines.push(
-  `function createStyle(fontSize: number, lineHeight: number, letterSpacing: number): TypographyStyle {`
-);
-lines.push(`  const base = { fontSize, lineHeight, letterSpacing };`);
-lines.push(`  return {`);
-lines.push(`    ...base,`);
-lines.push(`    semibold: { ...base, fontWeight: 600 },`);
-lines.push(`    medium: { ...base, fontWeight: 500 },`);
-lines.push(`    regular: { ...base, fontWeight: 400 },`);
-lines.push(`  };`);
-lines.push(`}`);
-lines.push(``);
-lines.push(`/// Supernova Design System Typography`);
-lines.push(`///`);
-lines.push(`/// Usage: dsTypographyTokens.textMd.semibold`);
-lines.push(`export const dsTypographyTokens = {`);
-for (const tsField of fieldOrder) {
-  const { fontSize, lineHeight, letterSpacing } = sizeMap[tsField];
-  lines.push(
-    `  ${tsField}: createStyle(${fontSize}, ${lineHeight}, ${letterSpacing}),`
-  );
+function buildTokenEntries() {
+  return fieldOrder
+    .map((tsField) => {
+      const { fontSize, lineHeight, letterSpacing } = sizeMap[tsField];
+      return `  ${tsField}: createStyle(${fontSize}, ${lineHeight}, ${letterSpacing}),`;
+    })
+    .join("\n");
 }
-lines.push(`} as const;`);
-lines.push(``);
-lines.push(`export type DSTypographySize = keyof typeof dsTypographyTokens;`);
-lines.push(``);
+
+const now = new Date().toISOString().slice(0, 19).replace("T", " ");
+const newContent = `\
+// GENERATED FILE — DO NOT EDIT MANUALLY
+// Last synced: ${now} UTC
+// Source: Figma "Supernova Design System" text styles
+// Run: yarn workspace @keplr-wallet/design-system sync:tokens
+
+import type { CSSProperties } from 'react';
+
+export interface TypographyStyle {
+  readonly fontSize: number;
+  readonly lineHeight: number;
+  readonly letterSpacing: number;
+  readonly semibold: CSSProperties;
+  readonly medium: CSSProperties;
+  readonly regular: CSSProperties;
+}
+
+function createStyle(fontSize: number, lineHeight: number, letterSpacing: number): TypographyStyle {
+  const base = { fontSize, lineHeight, letterSpacing };
+  return {
+    ...base,
+    semibold: { ...base, fontWeight: 600 },
+    medium: { ...base, fontWeight: 500 },
+    regular: { ...base, fontWeight: 400 },
+  };
+}
+
+/// Supernova Design System Typography
+///
+/// Usage: dsTypographyTokens.textMd.semibold
+export const dsTypographyTokens = {
+${buildTokenEntries()}
+} as const;
+
+export type DSTypographySize = keyof typeof dsTypographyTokens;
+`;
 
 // ── Field deletion guard ───────────────────────────────────────────────────────
-const newContent = lines.join("\n");
 if (fs.existsSync(outputPath)) {
   const existingContent = fs.readFileSync(outputPath, "utf8");
   const existingFields = [

--- a/packages/design-system/scripts/sync-tokens/generate-typography-ts.mjs
+++ b/packages/design-system/scripts/sync-tokens/generate-typography-ts.mjs
@@ -76,7 +76,7 @@ const lines = [];
 
 lines.push(`// GENERATED FILE — DO NOT EDIT MANUALLY`);
 lines.push(`// Last synced: ${now} UTC`);
-lines.push(`// Source: Figma "For Roy: Supernova Design System" text styles`);
+lines.push(`// Source: Figma "Supernova Design System" text styles`);
 lines.push(`// Run: yarn workspace @keplr-wallet/design-system sync:tokens`);
 lines.push(``);
 lines.push(`import type { CSSProperties } from 'react';`);
@@ -114,9 +114,7 @@ for (const tsField of fieldOrder) {
 }
 lines.push(`} as const;`);
 lines.push(``);
-lines.push(
-  `export type DSTypographyTokensKey = keyof typeof dsTypographyTokens;`
-);
+lines.push(`export type DSTypographySize = keyof typeof dsTypographyTokens;`);
 lines.push(``);
 
 // ── Field deletion guard ───────────────────────────────────────────────────────

--- a/packages/design-system/src/foundation/color/color.ts
+++ b/packages/design-system/src/foundation/color/color.ts
@@ -1,5 +1,5 @@
-// @generated — DO NOT EDIT MANUALLY
-// Last synced: 2026-03-30 05:06:17 UTC
+// GENERATED FILE — DO NOT EDIT MANUALLY
+// Last synced: 2026-03-30 05:42:12 UTC
 // Source: Figma "Supernova Design System"
 // Run: yarn workspace @keplr-wallet/design-system sync:tokens
 

--- a/packages/design-system/src/foundation/color/color.ts
+++ b/packages/design-system/src/foundation/color/color.ts
@@ -1,6 +1,6 @@
-// GENERATED FILE — DO NOT EDIT MANUALLY
-// Last synced: 2026-03-26 09:09:00 UTC
-// Source: Figma "For Roy: Supernova Design System"
+// @generated — DO NOT EDIT MANUALLY
+// Last synced: 2026-03-30 05:06:17 UTC
+// Source: Figma "Supernova Design System"
 // Run: yarn workspace @keplr-wallet/design-system sync:tokens
 
 /**
@@ -10,6 +10,8 @@
  */
 export const DSColor = {
   // ── Primitives ──
+  black: "#000000",
+
   blue200: "#78D9FF",
   blue300: "#35C6FF",
   blue400: "#14AFEB",
@@ -68,6 +70,8 @@ export const DSColor = {
   purple300: "#A095FF",
   purple400: "#7B6BFF",
 
+  white: "#FFFFFF",
+
   yellow200: "#EDD18A",
   yellow400: "#F0B622",
   yellow400_10: "rgba(240, 182, 34, 0.1)",
@@ -75,12 +79,13 @@ export const DSColor = {
   yellow600: "#A67B0C",
   yellow800: "#2F2611",
 
-  black: "#000000",
-  white: "#FFFFFF",
   transparent: "rgba(255, 255, 255, 0)",
 
   // ── Semantic (CSS variable refs) ──
   fill: {
+    accent: {
+      purple: "var(--ds-fill-accent-purple)" as const,
+    },
     neutral: {
       high: "var(--ds-fill-neutral-high)" as const,
       strong: "var(--ds-fill-neutral-strong)" as const,
@@ -89,9 +94,6 @@ export const DSColor = {
       high_7: "var(--ds-fill-neutral-alpha-high-7)" as const,
       high_10: "var(--ds-fill-neutral-alpha-high-10)" as const,
       high_50: "var(--ds-fill-neutral-alpha-high-50)" as const,
-    },
-    accent: {
-      purple: "var(--ds-fill-accent-purple)" as const,
     },
     alert: {
       medium: "var(--ds-fill-alert-medium)" as const,
@@ -116,6 +118,14 @@ export const DSColor = {
       medium_10: "var(--ds-fill-warning-alpha-medium-10)" as const,
     },
   },
+  background: {
+    surface: {
+      elevated: "var(--ds-background-surface-elevated)" as const,
+      surface: "var(--ds-background-surface-surface)" as const,
+      scrim: "var(--ds-background-surface-scrim)" as const,
+      ground: "var(--ds-background-surface-ground)" as const,
+    },
+  },
   stroke: {
     separator: {
       primary: "var(--ds-stroke-separator-primary)" as const,
@@ -127,14 +137,6 @@ export const DSColor = {
       strong: "var(--ds-stroke-input-strong)" as const,
     },
   },
-  background: {
-    surface: {
-      elevated: "var(--ds-background-surface-elevated)" as const,
-      surface: "var(--ds-background-surface-surface)" as const,
-      scrim: "var(--ds-background-surface-scrim)" as const,
-      ground: "var(--ds-background-surface-ground)" as const,
-    },
-  },
   typography: {
     brand: "var(--ds-typography-brand)" as const,
     primary: "var(--ds-typography-primary)" as const,
@@ -142,13 +144,13 @@ export const DSColor = {
     secondary: "var(--ds-typography-secondary)" as const,
     tertiary: "var(--ds-typography-tertiary)" as const,
     disabled: "var(--ds-typography-disabled)" as const,
-    accent: {
-      purple: "var(--ds-typography-accent-purple)" as const,
-    },
     warning: {
       light: "var(--ds-typography-warning-light)" as const,
       medium: "var(--ds-typography-warning-medium)" as const,
       strong: "var(--ds-typography-warning-strong)" as const,
+    },
+    accent: {
+      purple: "var(--ds-typography-accent-purple)" as const,
     },
     alert: {
       light: "var(--ds-typography-alert-light)" as const,
@@ -181,8 +183,8 @@ export const DSColor = {
 
 /** Dark theme CSS variable values */
 export const darkThemeValues: Record<string, string> = {
-  "--ds-fill-neutral-high": DSColor.gray10,
   "--ds-fill-accent-purple": DSColor.purple400,
+  "--ds-fill-neutral-high": DSColor.gray10,
   "--ds-fill-neutral-strong": DSColor.gray200,
   "--ds-fill-neutral-medium": DSColor.gray400,
   "--ds-fill-neutral-low": DSColor.gray600,
@@ -201,8 +203,8 @@ export const darkThemeValues: Record<string, string> = {
   "--ds-fill-brand-medium": DSColor.blue600,
   "--ds-fill-brand-low": DSColor.blue800,
   "--ds-fill-positive-low": DSColor.green800,
-  "--ds-stroke-separator-primary": DSColor.gray10_15,
   "--ds-background-surface-elevated": DSColor.gray600,
+  "--ds-stroke-separator-primary": DSColor.gray10_15,
   "--ds-background-surface-surface": DSColor.gray650,
   "--ds-background-surface-scrim": DSColor.gray700_60,
   "--ds-background-surface-ground": DSColor.gray700,
@@ -213,8 +215,8 @@ export const darkThemeValues: Record<string, string> = {
   "--ds-typography-secondary": DSColor.gray200,
   "--ds-typography-tertiary": DSColor.gray300,
   "--ds-typography-disabled": DSColor.gray300,
-  "--ds-typography-accent-purple": DSColor.purple300,
   "--ds-typography-warning-light": DSColor.yellow200,
+  "--ds-typography-accent-purple": DSColor.purple300,
   "--ds-typography-warning-medium": DSColor.yellow400,
   "--ds-typography-warning-strong": DSColor.yellow800,
   "--ds-typography-alert-light": DSColor.orange100,
@@ -241,8 +243,8 @@ export const darkThemeValues: Record<string, string> = {
 
 /** Light theme CSS variable values */
 export const lightThemeValues: Record<string, string> = {
-  "--ds-fill-neutral-high": DSColor.gray600,
   "--ds-fill-accent-purple": DSColor.purple400,
+  "--ds-fill-neutral-high": DSColor.gray600,
   "--ds-fill-neutral-strong": DSColor.gray300,
   "--ds-fill-neutral-medium": DSColor.gray200,
   "--ds-fill-neutral-low": DSColor.gray10,
@@ -261,8 +263,8 @@ export const lightThemeValues: Record<string, string> = {
   "--ds-fill-brand-medium": DSColor.blue600,
   "--ds-fill-brand-low": DSColor.blue200,
   "--ds-fill-positive-low": DSColor.green200,
-  "--ds-stroke-separator-primary": DSColor.gray10_15,
   "--ds-background-surface-elevated": DSColor.gray600,
+  "--ds-stroke-separator-primary": DSColor.gray10_15,
   "--ds-background-surface-surface": DSColor.gray650,
   "--ds-background-surface-scrim": DSColor.gray700_80,
   "--ds-background-surface-ground": DSColor.gray10,
@@ -273,8 +275,8 @@ export const lightThemeValues: Record<string, string> = {
   "--ds-typography-secondary": DSColor.gray200,
   "--ds-typography-tertiary": DSColor.gray300,
   "--ds-typography-disabled": DSColor.gray300,
-  "--ds-typography-accent-purple": DSColor.purple300,
   "--ds-typography-warning-light": DSColor.yellow200,
+  "--ds-typography-accent-purple": DSColor.purple300,
   "--ds-typography-warning-medium": DSColor.yellow400,
   "--ds-typography-warning-strong": DSColor.yellow600,
   "--ds-typography-alert-light": DSColor.orange100,

--- a/packages/design-system/src/foundation/typography/index.ts
+++ b/packages/design-system/src/foundation/typography/index.ts
@@ -1,7 +1,4 @@
 export { dsTypographyTokens } from "./typography-tokens";
-export type {
-  TypographyStyle,
-  DSTypographyTokensKey,
-} from "./typography-tokens";
+export type { TypographyStyle, DSTypographySize } from "./typography-tokens";
 export { DSTypography } from "./typography";
 export type { DSTypographyProps } from "./typography";

--- a/packages/design-system/src/foundation/typography/typography-tokens.ts
+++ b/packages/design-system/src/foundation/typography/typography-tokens.ts
@@ -1,5 +1,5 @@
 // GENERATED FILE — DO NOT EDIT MANUALLY
-// Last synced: 2026-03-30 05:06:17 UTC
+// Last synced: 2026-03-30 05:42:12 UTC
 // Source: Figma "Supernova Design System" text styles
 // Run: yarn workspace @keplr-wallet/design-system sync:tokens
 

--- a/packages/design-system/src/foundation/typography/typography-tokens.ts
+++ b/packages/design-system/src/foundation/typography/typography-tokens.ts
@@ -1,6 +1,6 @@
 // GENERATED FILE — DO NOT EDIT MANUALLY
-// Last synced: 2026-03-26 09:20:57 UTC
-// Source: Figma "For Roy: Supernova Design System" text styles
+// Last synced: 2026-03-30 05:06:17 UTC
+// Source: Figma "Supernova Design System" text styles
 // Run: yarn workspace @keplr-wallet/design-system sync:tokens
 
 import type { CSSProperties } from "react";
@@ -46,4 +46,4 @@ export const dsTypographyTokens = {
   displayMd: createStyle(32, 1.4, -0.32),
 } as const;
 
-export type DSTypographyTokensKey = keyof typeof dsTypographyTokens;
+export type DSTypographySize = keyof typeof dsTypographyTokens;

--- a/packages/design-system/src/foundation/typography/typography.tsx
+++ b/packages/design-system/src/foundation/typography/typography.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { dsTypographyTokens } from "./typography-tokens";
-import type { DSTypographyTokensKey } from "./typography-tokens";
+import type { DSTypographySize } from "./typography-tokens";
 
 type Weight = "semibold" | "medium" | "regular";
 
@@ -12,7 +12,7 @@ const WEIGHT_VALUE: Record<Weight, number> = {
 
 export interface DSTypographyProps extends React.HTMLAttributes<HTMLElement> {
   /** Size token: `displayXl` · `displayLg` · `displayMd` · `displaySm` · `displayXs` · `displayXxs` · `textXl` · `textLg` · `textMd` · `textSm` · `textXs` · `textXxs` */
-  size?: DSTypographyTokensKey;
+  size?: DSTypographySize;
   /** Font weight: `semibold` (600) · `medium` (500) · `regular` (400) */
   weight?: Weight;
   /** Override token font size (px) */


### PR DESCRIPTION
## Summary

### 1. generate-color-ts 스크립트 개선
- dark/light 중 하나라도 값이 있으면 토큰 포함 (기존: dark 없으면 전체 누락)
- `black`/`white` 하드코딩 제거 → Figma에서 가져오거나 synthetic fallback
- `L.push()` → 템플릿 리터럴로 전환

### 2. DSTypographyTokensKey → DSTypographySize
- size prop 타입이므로 의미에 맞게 리네이밍

### 3. 토큰 재생성
- 변경된 스크립트로 Figma 연동 재생성, 파일명 주석 수정

### 4. generate-typography-ts 스크립트 개선
- `lines.push()` → 템플릿 리터럴 전환, `sizeToDartField` → `sizeToTsField` 리네이밍, 생성 파일 헤더 `GENERATED FILE`로 통일

## Test plan
- [x] `sync:tokens` 전체 파이프라인 통과
- [x] `typecheck` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)