### PR TITLE
[🎨 Design System] Integrate DSThemeProvider + add agent rules

### DIFF
--- a/.claude/rules/design-system.md
+++ b/.claude/rules/design-system.md
@@ -1,0 +1,15 @@
+# Design System
+
+- Use `DSColor` semantic tokens for all colors — they switch with dark/light theme automatically
+- Use `DSTypography` component for all text styling
+- Use DS icons from `@keplr-wallet/design-system` for all icons
+- Use DS components when available — check `packages/design-system/src/components/`
+- Use `DSColor` semantic tokens instead of `props.theme.mode` branching for theming
+- Generated files are synced from Figma — update with `yarn workspace @keplr-wallet/design-system sync:tokens`
+
+## Reference Paths
+
+- Colors: `packages/design-system/src/foundation/color/color.ts`
+- Typography: `packages/design-system/src/foundation/typography/typography-tokens.ts`
+- Icons: `packages/design-system/src/foundation/icon/components/`
+- Components: `packages/design-system/src/components/`

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -33,6 +33,7 @@
     "@keplr-wallet/common": "0.13.17",
     "@keplr-wallet/cosmos": "0.13.17",
     "@keplr-wallet/crypto": "0.13.17",
+    "@keplr-wallet/design-system": "0.13.17",
     "@keplr-wallet/hooks": "0.13.17",
     "@keplr-wallet/hooks-bitcoin": "0.13.17",
     "@keplr-wallet/hooks-evm": "0.13.17",

--- a/apps/extension/src/theme/index.tsx
+++ b/apps/extension/src/theme/index.tsx
@@ -9,6 +9,7 @@ import React, {
   useState,
 } from "react";
 import { ThemeProvider } from "styled-components";
+import { DSThemeProvider } from "@keplr-wallet/design-system";
 import { SetThemeOptionMsg } from "@keplr-wallet/background";
 import { BACKGROUND_PORT } from "@keplr-wallet/router";
 
@@ -102,7 +103,10 @@ export const AppThemeProvider: FunctionComponent<PropsWithChildren> = ({
         setTheme,
       }}
     >
-      <ThemeProvider theme={{ mode: displayTheme }}>{children}</ThemeProvider>
+      <DSThemeProvider defaultTheme={displayTheme}>
+        {/* TODO: Remove after DS migration is complete */}
+        <ThemeProvider theme={{ mode: displayTheme }}>{children}</ThemeProvider>
+      </DSThemeProvider>
     </AppThemeContext.Provider>
   );
 };

--- a/packages/design-system/src/theme/ds-theme-provider.tsx
+++ b/packages/design-system/src/theme/ds-theme-provider.tsx
@@ -1,22 +1,14 @@
-import React, {
-  createContext,
-  useEffect,
-  useLayoutEffect,
-  useState,
-} from "react";
+import React, { createContext, useLayoutEffect } from "react";
 import { generateThemeStylesheet } from "./inject-vars";
 
 export type DSTheme = "dark" | "light";
 
 export interface DSThemeContextValue {
   theme: DSTheme;
-  setTheme: (theme: DSTheme) => void;
 }
 
 export const DSThemeContext = createContext<DSThemeContextValue>({
   theme: "dark",
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  setTheme: () => {},
 });
 
 export interface DSThemeProviderProps {
@@ -31,28 +23,21 @@ export const DSThemeProvider: React.FC<DSThemeProviderProps> = ({
   defaultTheme = "dark",
   externalMode = false,
 }) => {
-  const [theme, setTheme] = useState<DSTheme>(defaultTheme);
-
-  useEffect(() => {
-    setTheme(defaultTheme);
-  }, [defaultTheme]);
-
   useLayoutEffect(() => {
     if (!externalMode) {
       const styleId = "ds-theme-vars";
-      let styleEl = document.getElementById(styleId) as HTMLStyleElement | null;
-      if (!styleEl) {
-        styleEl = document.createElement("style");
+      if (!document.getElementById(styleId)) {
+        const styleEl = document.createElement("style");
         styleEl.id = styleId;
+        styleEl.textContent = generateThemeStylesheet();
         document.head.appendChild(styleEl);
       }
-      styleEl.textContent = generateThemeStylesheet();
     }
-    document.documentElement.setAttribute("data-ds-theme", theme);
-  }, [theme, externalMode]);
+    document.documentElement.setAttribute("data-ds-theme", defaultTheme);
+  }, [defaultTheme, externalMode]);
 
   return (
-    <DSThemeContext.Provider value={{ theme, setTheme }}>
+    <DSThemeContext.Provider value={{ theme: defaultTheme }}>
       {children}
     </DSThemeContext.Provider>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -6619,7 +6619,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@keplr-wallet/design-system@workspace:packages/design-system":
+"@keplr-wallet/design-system@0.13.17, @keplr-wallet/design-system@workspace:packages/design-system":
   version: 0.0.0-use.local
   resolution: "@keplr-wallet/design-system@workspace:packages/design-system"
   dependencies:
@@ -6657,6 +6657,7 @@ __metadata:
     "@keplr-wallet/common": 0.13.17
     "@keplr-wallet/cosmos": 0.13.17
     "@keplr-wallet/crypto": 0.13.17
+    "@keplr-wallet/design-system": 0.13.17
     "@keplr-wallet/hooks": 0.13.17
     "@keplr-wallet/hooks-bitcoin": 0.13.17
     "@keplr-wallet/hooks-evm": 0.13.17


### PR DESCRIPTION
## Summary
- DSColor 시맨틱 컬러 사용을 위해 DSThemeProvider를 AppThemeProvider에 통합
- 기존 styled-components ThemeProvider는 마이그레이션 완료까지 공존하며 점진적으로 대체 예정
- DSThemeProvider 단순화: 불필요한 state/effect 제거, single useLayoutEffect
- `.claude/rules/design-system.md` 추가

## 테마 적용 방식 변경

**Before** — `props.theme.mode` 분기로 수동 테마 처리:
```tsx
const Box = styled.div`
  color: ${(props) => props.theme.mode === "light" ? "#09090A" : "#F6F6F9"};
`;
```

**After** — DSColor 시맨틱 토큰으로 dark/light 자동 전환:
```tsx
const Box = styled.div`
  color: ${DSColor.typography.primary};
`;
```

DSColor 시맨틱 토큰은 CSS 변수(`var(--ds-typography-primary)`)로 해석되어 DSThemeProvider가 주입한 테마에 따라 자동으로 전환됩니다.

## Provider 구조
```
AppThemeContext.Provider  ← auto 모드, localStorage, background 싱크 (기존 유지)
  └─ DSThemeProvider      ← DS CSS 변수 주입 (신규)
       └─ ThemeProvider   ← styled-components (점진적 제거 대상)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)