### PR TITLE
fix: improve swap error handling and resilience

### DIFF
--- a/apps/extension/src/pages/ibc-swap/index.tsx
+++ b/apps/extension/src/pages/ibc-swap/index.tsx
@@ -353,34 +353,6 @@ export const IBCSwapPage: FunctionComponent = observer(() => {
     }
   );
 
-  const currentFeeCurrencyCoinMinimalDenom =
-    swapConfigs.feeConfig.fees[0]?.currency.coinMinimalDenom;
-
-  // feemarket 체인은 simulate 결과가 실제보다 낮게 나오므로 gasAdjustment를 높여서 보정.
-  // 비네이티브 fee currency일 때 2.0인 이유는 fee denom 변환 과정에서 추가 gas 필요.
-  // (send 페이지와 동일 로직)
-  useEffect(() => {
-    const u2 = chainStore.getModularChain(inChainId).unwrapped;
-    const hasFeemarketFeature =
-      (u2.type === "cosmos" || u2.type === "ethermint") &&
-      u2.cosmos.features?.includes("feemarket");
-    if (hasFeemarketFeature) {
-      if (
-        currentFeeCurrencyCoinMinimalDenom !==
-        (u2.type === "cosmos" || u2.type === "ethermint"
-          ? u2.cosmos.currencies[0].coinMinimalDenom
-          : "")
-      ) {
-        gasSimulator.setGasAdjustmentValue("2");
-      } else {
-        gasSimulator.setGasAdjustmentValue("1.6");
-      }
-    } else {
-      // 소스 체인이 변경될 수 있으므로 feemarket이 아닌 체인으로 전환 시 기본값 복원
-      gasSimulator.setGasAdjustmentValue("1.3");
-    }
-  }, [inChainId, chainStore, gasSimulator, currentFeeCurrencyCoinMinimalDenom]);
-
   const txConfigsValidate = useTxConfigsValidate({
     ...swapConfigs,
     gasSimulator,

--- a/apps/extension/src/pages/ibc-swap/index.tsx
+++ b/apps/extension/src/pages/ibc-swap/index.tsx
@@ -353,6 +353,34 @@ export const IBCSwapPage: FunctionComponent = observer(() => {
     }
   );
 
+  const currentFeeCurrencyCoinMinimalDenom =
+    swapConfigs.feeConfig.fees[0]?.currency.coinMinimalDenom;
+
+  // feemarket 체인은 simulate 결과가 실제보다 낮게 나오므로 gasAdjustment를 높여서 보정.
+  // 비네이티브 fee currency일 때 2.0인 이유는 fee denom 변환 과정에서 추가 gas 필요.
+  // (send 페이지와 동일 로직)
+  useEffect(() => {
+    const u2 = chainStore.getModularChain(inChainId).unwrapped;
+    const hasFeemarketFeature =
+      (u2.type === "cosmos" || u2.type === "ethermint") &&
+      u2.cosmos.features?.includes("feemarket");
+    if (hasFeemarketFeature) {
+      if (
+        currentFeeCurrencyCoinMinimalDenom !==
+        (u2.type === "cosmos" || u2.type === "ethermint"
+          ? u2.cosmos.currencies[0].coinMinimalDenom
+          : "")
+      ) {
+        gasSimulator.setGasAdjustmentValue("2");
+      } else {
+        gasSimulator.setGasAdjustmentValue("1.6");
+      }
+    } else {
+      // 소스 체인이 변경될 수 있으므로 feemarket이 아닌 체인으로 전환 시 기본값 복원
+      gasSimulator.setGasAdjustmentValue("1.3");
+    }
+  }, [inChainId, chainStore, gasSimulator, currentFeeCurrencyCoinMinimalDenom]);
+
   const txConfigsValidate = useTxConfigsValidate({
     ...swapConfigs,
     gasSimulator,

--- a/apps/extension/src/pages/ibc-swap/index.tsx
+++ b/apps/extension/src/pages/ibc-swap/index.tsx
@@ -1243,7 +1243,7 @@ export const IBCSwapPage: FunctionComponent = observer(() => {
             executeTxMsg
           );
           if (result.status === TxExecutionStatus.FAILED) {
-            throw new Error(result.error ?? "Transaction execution failed");
+            throw new Error(result.error || "Transaction execution failed");
           }
 
           if (!chainStore.isEnabledChain(swapConfigs.amountConfig.outChainId)) {

--- a/packages/background/src/tx-ethereum/service.ts
+++ b/packages/background/src/tx-ethereum/service.ts
@@ -99,7 +99,7 @@ export class BackgroundTxEthereumService {
               resolve();
             }
 
-            reject();
+            reject(new Error("Failed to get transaction receipt"));
           });
         },
         {

--- a/packages/background/src/tx-executor/service.ts
+++ b/packages/background/src/tx-executor/service.ts
@@ -48,6 +48,7 @@ import {
   prepareSignDocForDirectSigning,
 } from "./utils/cosmos";
 import { fillUnsignedEVMTx } from "./utils/evm";
+import { fetchWithRetry } from "./utils/fetch";
 import { EventBusSubscriber } from "@keplr-wallet/common";
 import { TxExecutionEvent } from "./types";
 
@@ -861,10 +862,19 @@ export class BackgroundTxExecutorService {
       throw new KeplrError("direct-tx-executor", 133, "Tx hash not found");
     }
 
-    const txResult = await this.backgroundTxService.traceTx(
-      tx.chainId,
-      tx.txHash
-    );
+    let txResult: any;
+    try {
+      txResult = await this.backgroundTxService.traceTx(tx.chainId, tx.txHash);
+    } catch {
+      // WS retry 모두 실패 — REST fallback 시도
+    }
+
+    // WS에서 결과를 못 받은 경우, REST로 tx 존재 여부 확인
+    // (tx가 온체인 성공했는데 WS 불안정으로 확인 못한 false positive 대응)
+    if (!txResult) {
+      txResult = await this.queryTxByRestFallback(tx.chainId, tx.txHash);
+    }
+
     if (!txResult) {
       return false;
     }
@@ -876,6 +886,21 @@ export class BackgroundTxExecutorService {
     }
 
     return true;
+  }
+
+  private async queryTxByRestFallback(
+    chainId: string,
+    txHash: string
+  ): Promise<{ code?: number } | undefined> {
+    try {
+      const chainInfo = this.chainsService.getChainInfoOrThrow(chainId);
+      const { data } = await fetchWithRetry<{
+        tx_response?: { code?: number; txhash?: string };
+      }>(chainInfo.rest, `/cosmos/tx/v1beta1/txs/${txHash}`);
+      return data.tx_response;
+    } catch {
+      return undefined;
+    }
   }
 
   /**

--- a/packages/background/src/tx-executor/service.ts
+++ b/packages/background/src/tx-executor/service.ts
@@ -505,7 +505,7 @@ export class BackgroundTxExecutorService {
         return {
           status: BackgroundTxStatus.FAILED,
           txHash,
-          error: e.message ?? "Transaction signing failed",
+          error: e?.message || "Transaction signing failed",
         };
       }
     }
@@ -522,7 +522,7 @@ export class BackgroundTxExecutorService {
         return {
           status: BackgroundTxStatus.FAILED,
           txHash,
-          error: e.message ?? "Transaction broadcasting failed",
+          error: e?.message || "Transaction broadcasting failed",
         };
       }
     }
@@ -546,7 +546,7 @@ export class BackgroundTxExecutorService {
       return {
         status: BackgroundTxStatus.FAILED,
         txHash,
-        error: e.message ?? "Transaction confirmation failed",
+        error: e?.message || "Transaction confirmation failed",
       };
     }
   }

--- a/packages/background/src/tx-executor/utils/cosmos.ts
+++ b/packages/background/src/tx-executor/utils/cosmos.ts
@@ -23,9 +23,9 @@ import {
 import { ExtensionOptionsWeb3Tx } from "@keplr-wallet/proto-types/ethermint/types/v1/web3";
 import { PubKey } from "@keplr-wallet/proto-types/cosmos/crypto/secp256k1/keys";
 import { SignMode } from "@keplr-wallet/proto-types/cosmos/tx/signing/v1beta1/signing";
-import { simpleFetch } from "@keplr-wallet/simple-fetch";
 import { Dec } from "@keplr-wallet/unit";
 import { BackgroundTxFeeType } from "../types";
+import { fetchWithRetry } from "./fetch";
 
 // TODO: move helper functions to proper packages
 
@@ -342,7 +342,7 @@ export async function simulateCosmosTx(
     signatures: [new Uint8Array(64)],
   }).finish();
 
-  const result = await simpleFetch<{
+  const result = await fetchWithRetry<{
     gas_info: {
       gas_used: string;
     };
@@ -371,7 +371,7 @@ export async function fetchCosmosSpendableBalances(
   bech32Address: string,
   limit = 1000
 ): Promise<{ balances: Coin[] }> {
-  const { data } = await simpleFetch<{ balances: Coin[] }>(
+  const { data } = await fetchWithRetry<{ balances: Coin[] }>(
     baseURL,
     `/cosmos/bank/v1beta1/spendable_balances/${bech32Address}?pagination.limit=${limit}`
   );
@@ -509,7 +509,7 @@ async function getOsmosisBaseFeeCurrency(
   }
 
   // Fetch multiplication factors from remote config
-  const remoteConfig = await simpleFetch<{
+  const remoteConfig = await fetchWithRetry<{
     low?: number;
     average?: number;
     high?: number;
@@ -517,7 +517,7 @@ async function getOsmosisBaseFeeCurrency(
     "https://gjsttg7mkgtqhjpt3mv5aeuszi0zblbb.lambda-url.us-west-2.on.aws/osmosis/osmosis-base-fee-beta.json"
   ).catch(() => ({ data: {} as Record<BackgroundTxFeeType, number> }));
 
-  const { data: baseFeeResponse } = await simpleFetch<{ base_fee: string }>(
+  const { data: baseFeeResponse } = await fetchWithRetry<{ base_fee: string }>(
     chainInfo.rest,
     "/osmosis/txfees/v1beta1/cur_eip_base_fee"
   );
@@ -540,7 +540,7 @@ async function getOsmosisTxFeesGasPrice(
   feeType: BackgroundTxFeeType
 ): Promise<Dec | null> {
   // Check if it's a fee token
-  const { data: feeTokensResponse } = await simpleFetch<{
+  const { data: feeTokensResponse } = await fetchWithRetry<{
     fee_tokens: Array<{ denom: string; poolID: string }>;
   }>(chainInfo.rest, "/osmosis/txfees/v1beta1/fee_tokens");
 
@@ -553,7 +553,9 @@ async function getOsmosisTxFeesGasPrice(
   }
 
   // Get spot price
-  const { data: spotPriceResponse } = await simpleFetch<{ spot_price: string }>(
+  const { data: spotPriceResponse } = await fetchWithRetry<{
+    spot_price: string;
+  }>(
     chainInfo.rest,
     `/osmosis/txfees/v1beta1/spot_price_by_denom?denom=${feeCurrency.coinMinimalDenom}`
   );
@@ -574,7 +576,7 @@ async function getFeeMarketGasPrice(
   feeType: BackgroundTxFeeType
 ): Promise<Dec | null> {
   try {
-    const gasPricesResponse = await simpleFetch<{
+    const gasPricesResponse = await fetchWithRetry<{
       prices: Array<{ denom: string; amount: string }>;
     }>(chainInfo.rest, "/feemarket/v1/gas_prices");
 
@@ -587,7 +589,7 @@ async function getFeeMarketGasPrice(
     }
 
     // Fetch multiplication config
-    const multiplicationConfig = await simpleFetch<{
+    const multiplicationConfig = await fetchWithRetry<{
       [chainId: string]: {
         low: number;
         average: number;
@@ -637,7 +639,7 @@ async function getInitiaDynamicFeeGasPrice(
   feeType: BackgroundTxFeeType
 ): Promise<Dec | null> {
   try {
-    const dynamicFeeResponse = await simpleFetch<{
+    const dynamicFeeResponse = await fetchWithRetry<{
       params: {
         base_gas_price: string;
       };
@@ -650,7 +652,7 @@ async function getInitiaDynamicFeeGasPrice(
     const baseGasPrice = new Dec(dynamicFeeResponse.data.params.base_gas_price);
 
     // Fetch multiplication config
-    const multiplicationConfig = await simpleFetch<{
+    const multiplicationConfig = await fetchWithRetry<{
       [str: string]: {
         low: number;
         average: number;
@@ -700,7 +702,7 @@ async function getEIP1559GasPrice(
 ): Promise<Dec | null> {
   try {
     // Get latest block for base fee
-    const blockResponse = await simpleFetch<{
+    const blockResponse = await fetchWithRetry<{
       result: {
         baseFeePerGas: string;
       };

--- a/packages/background/src/tx-executor/utils/evm.ts
+++ b/packages/background/src/tx-executor/utils/evm.ts
@@ -1,9 +1,9 @@
 import { EVMInfo } from "@keplr-wallet/types";
-import { simpleFetch } from "@keplr-wallet/simple-fetch";
 import { UnsignedTransaction } from "@ethersproject/transactions";
 import { Dec } from "@keplr-wallet/unit";
 import { BackgroundTxFeeType, EVMBackgroundTxFeeType } from "../types";
 import { JsonRpcResponse } from "@keplr-wallet/types";
+import { fetchWithRetry } from "./fetch";
 
 const ETH_FEE_HISTORY_REWARD_PERCENTILES = [20, 40, 60];
 const ETH_FEE_SETTINGS_BY_FEE_TYPE: Record<
@@ -135,7 +135,7 @@ export async function fillUnsignedEVMTx(
     getGasPriceRequest,
   ];
 
-  const { data: rpcResponses } = await simpleFetch<
+  const { data: rpcResponses } = await fetchWithRetry<
     Array<JsonRpcResponse<unknown>>
   >(evmInfo.rpc, {
     method: "POST",

--- a/packages/background/src/tx-executor/utils/fetch.ts
+++ b/packages/background/src/tx-executor/utils/fetch.ts
@@ -1,0 +1,28 @@
+import {
+  simpleFetch,
+  SimpleFetchRequestOptions,
+  SimpleFetchResponse,
+} from "@keplr-wallet/simple-fetch";
+import { retry } from "@keplr-wallet/common";
+
+// simpleFetch with 1 retry on failure (500ms delay).
+// Background tx-executor의 모든 RPC/LCD 호출에 사용.
+export function fetchWithRetry<T>(
+  baseURL: string,
+  options?: SimpleFetchRequestOptions
+): Promise<SimpleFetchResponse<T>>;
+export function fetchWithRetry<T>(
+  baseURL: string,
+  url?: string,
+  options?: SimpleFetchRequestOptions
+): Promise<SimpleFetchResponse<T>>;
+export function fetchWithRetry<T>(
+  baseURL: string,
+  urlOrOptions?: string | SimpleFetchRequestOptions,
+  options?: SimpleFetchRequestOptions
+): Promise<SimpleFetchResponse<T>> {
+  return retry(() => simpleFetch<T>(baseURL, urlOrOptions as string, options), {
+    maxRetries: 1,
+    waitMsAfterError: 500,
+  });
+}

--- a/packages/background/src/tx/service.ts
+++ b/packages/background/src/tx/service.ts
@@ -121,11 +121,11 @@ export class BackgroundTxService {
                 // trace 이후 로직은 동기적인 로직밖에 없기 때문에 문제될 게 없다.
                 // 문제될게 없다.
                 setTimeout(() => {
-                  reject();
+                  reject(new Error("WebSocket closed"));
                 }, 500);
               });
               txTracer.addEventListener("error", () => {
-                reject();
+                reject(new Error("WebSocket error"));
               });
               txTracer.traceTx(txHash).then((tx) => {
                 txTracer.close();

--- a/packages/stores-eth/src/account/base.ts
+++ b/packages/stores-eth/src/account/base.ts
@@ -550,13 +550,16 @@ export class EthereumAccountBase {
       EthSignType.TRANSACTION
     );
 
+    // requiredErc20Approvals는 서명/nonce 계산에만 사용되고 serialize에는 불필요.
+    // ethers.js serialize()에 전달되면 "invalid object key" 에러 발생.
+    const { requiredErc20Approvals: _, ...txToSerialize } = unsignedTx;
     const isEIP1559 =
-      !!unsignedTx.maxFeePerGas || !!unsignedTx.maxPriorityFeePerGas;
+      !!txToSerialize.maxFeePerGas || !!txToSerialize.maxPriorityFeePerGas;
     if (isEIP1559) {
-      unsignedTx.type = TransactionTypes.eip1559;
+      txToSerialize.type = TransactionTypes.eip1559;
     }
 
-    return serialize(unsignedTx, signature);
+    return serialize(txToSerialize, signature);
   }
 
   async sendEthereumTx(

--- a/packages/stores/src/account/cosmwasm.ts
+++ b/packages/stores/src/account/cosmwasm.ts
@@ -12,6 +12,35 @@ import deepmerge from "deepmerge";
 import { CosmosAccount } from "./cosmos";
 import { Bech32Address } from "@keplr-wallet/cosmos";
 
+// Injective MsgExecuteContractCompat: 모든 필드가 string이라 수동 protobuf 인코딩.
+function encodeMsgExecuteContractCompat(params: {
+  sender: string;
+  contract: string;
+  msg: string;
+  funds: string;
+}): Uint8Array {
+  const encodeString = (fieldNumber: number, value: string): Buffer => {
+    if (!value) return Buffer.alloc(0);
+    const encoded = Buffer.from(value);
+    const tag = (fieldNumber << 3) | 2;
+    const lenBytes: number[] = [];
+    let len = encoded.length;
+    while (len > 0x7f) {
+      lenBytes.push((len & 0x7f) | 0x80);
+      len >>>= 7;
+    }
+    lenBytes.push(len);
+    return Buffer.concat([Buffer.from([tag]), Buffer.from(lenBytes), encoded]);
+  };
+
+  return Buffer.concat([
+    encodeString(1, params.sender),
+    encodeString(2, params.contract),
+    encodeString(3, params.msg),
+    encodeString(4, params.funds),
+  ]);
+}
+
 export interface CosmwasmAccount {
   cosmwasm: CosmwasmAccountImpl;
 }
@@ -175,6 +204,52 @@ export class CosmwasmAccountImpl {
         funds,
       },
     };
+
+    // Injective + Ledger: MsgExecuteContractCompat 사용 (EIP-712 호환)
+    // 표준 MsgExecuteContract의 msg(bytes)는 EIP-712 정적 타입 불가 →
+    // Injective wasmx 모듈의 Compat 버전은 모든 필드가 string.
+    // ref: https://docs.injective.network/developers-native/examples/wasm#msgexecutecontractcompat
+    // ref: https://github.com/InjectiveLabs/injective-ts/blob/master/packages/sdk-ts/src/core/modules/wasm/msgs/MsgExecuteContractCompat.ts
+    if (this.chainId.startsWith("injective") && this.base.isNanoLedger) {
+      const fundsStr = funds.map((f) => `${f.amount}${f.denom}`).join(",");
+
+      return this.base.cosmos.makeTx(
+        type,
+        {
+          aminoMsgs: [
+            {
+              type: "wasmx/MsgExecuteContractCompat",
+              value: {
+                sender: this.base.bech32Address,
+                contract: contractAddress,
+                msg: JSON.stringify(obj),
+                funds: fundsStr,
+              },
+            },
+          ],
+          protoMsgs: [
+            {
+              typeUrl: "/injective.wasmx.v1.MsgExecuteContractCompat",
+              value: encodeMsgExecuteContractCompat({
+                sender: this.base.bech32Address,
+                contract: contractAddress,
+                msg: JSON.stringify(obj),
+                funds: fundsStr,
+              }),
+            },
+          ],
+          rlpTypes: {
+            MsgValue: [
+              { name: "sender", type: "string" },
+              { name: "contract", type: "string" },
+              { name: "msg", type: "string" },
+              { name: "funds", type: "string" },
+            ],
+          },
+        },
+        preOnTxEvents
+      );
+    }
 
     return this.base.cosmos.makeTx(
       type,


### PR DESCRIPTION
## Summary
Swap TX failed 에러 분석(6,108건) 기반 수정. 실패율 14% → 예상 10% 이��.

## Changes
1. **에러 처리**: `reject()` → `reject(new Error(...))`, `e?.message ||` fallback
2. **fetchWithRetry**: background RPC/LCD 1회 재시도 (500ms)
3. **REST fallback**: WS 실패 후 REST로 tx 존재 확인 (false positive 방지)
4. **MsgExecuteContractCompat**: Injective + Ledger CosmWasm 스왑 지원
5. **requiredErc20Approvals strip**: BSC serialize 에러 해결

## Test plan
- [ ] Osmosis OSMO→ATOM 스왑 정상 동작
- [ ] Injective + Ledger NINJA→INJ 스왑
- [ ] BSC USDT→BNB, BNB→ATOM 스왑
- [ ] Ethereum ETH→ATOM, USDT→ATOM 회귀