### PR TITLE
fix: guard against undefined Bitcoin entry in Ledger vault lookup

### DIFF
--- a/packages/background/src/keyring-ledger/service.ts
+++ b/packages/background/src/keyring-ledger/service.ts
@@ -136,13 +136,19 @@ export class KeyRingLedgerService {
     const accountPath = `${purpose}'/${coinType}'/${account}'`;
     const additionalPath = `${change}/${addressIndex}`;
 
+    const bitcoinKey = coinType === 0 ? "Bitcoin" : "Bitcoin Test";
+    const bitcoinEntry = vault.insensitive[bitcoinKey];
+    if (!bitcoinEntry) {
+      throw new KeplrError(
+        "keyring",
+        901,
+        "No Bitcoin extended public key. Initialize Bitcoin app on Ledger by selecting the chain in the extension"
+      );
+    }
+
     const descriptor =
-      (vault.insensitive[coinType === 0 ? "Bitcoin" : "Bitcoin Test"] as any)[
-        accountPath
-      ] ||
-      (vault.insensitive[coinType === 0 ? "Bitcoin" : "Bitcoin Test"] as any)[
-        `m/${accountPath}`
-      ];
+      (bitcoinEntry as any)[accountPath] ||
+      (bitcoinEntry as any)[`m/${accountPath}`];
 
     if (!descriptor) {
       throw new KeplrError(


### PR DESCRIPTION
## Summary
- Ledger vault의 `getPubKeyBitcoin`에서 `vault.insensitive["Bitcoin"]`이 undefined일 때 TypeError 크래시 수정
- Bitcoin 앱 미초기화 상태의 Ledger 계정에서 Bitcoin 공개키 요청 시 발생
- 기존 Cosmos/Ethereum 앱과 동일한 nil-check 패턴 적용

## Root Cause
`vault.insensitive["Bitcoin"]` (또는 `"Bitcoin Test"`)는 `appendLedgerExtendedKeyRings` 호출 시에만 생성됨. 초기화 전에는 해당 키가 없어서 double-subscript `vault.insensitive["Bitcoin"][accountPath]`에서 TypeError 발생.

## Changes
- `keyring-ledger/service.ts`: lookup을 분리하여 먼저 undefined 체크 후 없으면 KeplrError throw

Fixes KEPLR-2076

## Test plan
- [ ] Ledger 계정에서 Bitcoin 앱 미초기화 상태로 Bitcoin 주소 요청 시 TypeError 대신 의미 있는 에러 메시지 표시 확인