### PR TITLE
fix: include method name in Unsupported Method error

### DIFF
--- a/packages/background/src/keyring-ethereum/service.ts
+++ b/packages/background/src/keyring-ethereum/service.ts
@@ -1315,7 +1315,10 @@ export class KeyRingEthereumService {
           ).data.result;
         }
         default: {
-          throw new EthereumProviderRpcError(4200, `Unsupported Method`);
+          throw new EthereumProviderRpcError(
+            4200,
+            `Unsupported Method ${method}`
+          );
         }
       }
     })()) as T;


### PR DESCRIPTION
## Summary
- `keyring-ethereum` 서비스에서 지원하지 않는 메서드 호출 시 에러 메시지에 메서드명이 포함되지 않아 Bugsnag에서 어떤 메서드가 호출되었는지 파악이 불가능했음
- `Unsupported Method` → `Unsupported Method ${method}`로 변경하여 디버깅 가능하도록 개선

## Test plan
- [ ] 지원하지 않는 Ethereum 메서드 호출 시 에러 메시지에 메서드명이 포함되는지 확인

Resolves KEPLR-2072