### PR TITLE
[Extension] Remove Bostrom from native chain list

### DIFF
--- a/apps/extension/src/config.ts
+++ b/apps/extension/src/config.ts
@@ -512,69 +512,6 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
     features: ["ibc-go"],
   },
   {
-    rpc: "https://rpc-cyber.keplr.app",
-    rest: "https://lcd-cyber.keplr.app",
-    chainId: "bostrom",
-    chainName: "Bostrom",
-    stakeCurrency: {
-      coinDenom: "BOOT",
-      coinMinimalDenom: "boot",
-      coinDecimals: 0,
-    },
-    walletUrl:
-      process.env.NODE_ENV === "production"
-        ? "https://wallet.keplr.app/chains/bostrom"
-        : "http://localhost:8080/chains/bostrom",
-    walletUrlForStaking:
-      process.env.NODE_ENV === "production"
-        ? "https://wallet.keplr.app/chains/bostrom?modal=staking&chain=bostrom&step_id=2"
-        : "http://localhost:8080/chains/bostrom?modal=staking&chain=bostrom&step_id=2",
-    bip44: {
-      coinType: 118,
-    },
-    bech32Config: Bech32Address.defaultBech32Config("bostrom"),
-    currencies: [
-      {
-        coinDenom: "BOOT",
-        coinMinimalDenom: "boot",
-        coinDecimals: 0,
-      },
-      {
-        coinDenom: "H",
-        coinMinimalDenom: "hydrogen",
-        coinDecimals: 0,
-      },
-      {
-        coinDenom: "V",
-        coinMinimalDenom: "millivolt",
-        coinDecimals: 3,
-      },
-      {
-        coinDenom: "A",
-        coinMinimalDenom: "milliampere",
-        coinDecimals: 3,
-      },
-      {
-        coinDenom: "TOCYB",
-        coinMinimalDenom: "tocyb",
-        coinDecimals: 0,
-      },
-    ],
-    feeCurrencies: [
-      {
-        coinDenom: "BOOT",
-        coinMinimalDenom: "boot",
-        coinDecimals: 0,
-        gasPriceStep: {
-          low: 0,
-          average: 0,
-          high: 0.01,
-        },
-      },
-    ],
-    features: ["ibc-transfer", "cosmwasm", "ibc-go"],
-  },
-  {
     rpc: "https://rpc-juno.keplr.app",
     rest: "https://lcd-juno.keplr.app",
     chainId: "juno-1",

--- a/packages/stores-etc/src/tx-msg-decoder/get-tx-interpreter-url-prefix.ts
+++ b/packages/stores-etc/src/tx-msg-decoder/get-tx-interpreter-url-prefix.ts
@@ -4,7 +4,6 @@ const TX_INTERPRETER_URL_PREFIX_BY_BECH32_PREFIX: Record<string, string> = {
   akash: "akash",
   axelar: "axelar",
   babylon: "babylon",
-  bostrom: "bostrom",
   celestia: "celestia",
   chihuahua: "chihuahua",
   cosmos: "cosmoshub",


### PR DESCRIPTION
### Motivation
- Convert Bostrom from an embedded/native chain to a non-native/community chain so it is no longer included in the extension's default native chain list as part of the native→non-native transition.

### Description
- Removed the `bostrom` chain object from the `EmbedChainInfos` array in `apps/extension/src/config.ts` (approximately 60 lines) so Bostrom is no longer treated as an embedded chain in the extension.
- Removed the `bostrom` bech32 mapping from `TX_INTERPRETER_URL_PREFIX_BY_BECH32_PREFIX` in `packages/stores-etc/src/tx-msg-decoder/get-tx-interpreter-url-prefix.ts` to stop using the native URL prefix mapping for Bostrom.
- Changes are localized to the two files and do not modify other `EmbedChainInfos` entries or URL-prefix mappings.

### Testing
- Pre-commit checks including `eslint` and `prettier` passed in the environment where the change was staged. 
- Ran `yarn workspace @keplr-wallet/extension typecheck` which failed in this environment due to missing `@keplr-wallet/proto-types/*` modules. 
- Ran `yarn workspace @keplr-wallet/stores-etc typecheck` which also failed in this environment due to missing `@keplr-wallet/proto-types/*` modules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc6e1a3c548331bbf48a92a8555f9b)