### PR TITLE
Remove LSM currency registrar usage from extension

### DIFF
--- a/apps/extension/src/error-boundary.tsx
+++ b/apps/extension/src/error-boundary.tsx
@@ -61,7 +61,7 @@ const ErrorBoundaryView: FunctionComponent = observer(() => {
         "store_queries/",
         "store_prices/",
         "store_ibc_curreny_registrar/",
-        "store_lsm_currency_registrar/",
+        "store_lsm_currency_registrar/", // TODO: LSM registrar removed — keep for legacy cache cleanup, remove later
         "store_gravity_bridge_currency_registrar/",
         "store_axelar_evm_bridge_currency_registrar/",
       ];

--- a/apps/extension/src/index.tsx
+++ b/apps/extension/src/index.tsx
@@ -144,7 +144,6 @@ const RoutesAfterReady: FunctionComponent = observer(() => {
     tokenFactoryRegistrar,
     erc20CurrencyRegistrar,
     ibcCurrencyRegistrar,
-    lsmCurrencyRegistrar,
     ibcChannelStore,
     gravityBridgeCurrencyRegistrar,
     axelarEVMBridgeCurrencyRegistrar,
@@ -215,10 +214,6 @@ const RoutesAfterReady: FunctionComponent = observer(() => {
       return false;
     }
 
-    if (!lsmCurrencyRegistrar.isInitialized) {
-      return false;
-    }
-
     if (!priceStore.isInitialized) {
       return false;
     }
@@ -261,7 +256,6 @@ const RoutesAfterReady: FunctionComponent = observer(() => {
     chainStore.modularChainInfos,
     tokenFactoryRegistrar.isInitialized,
     ibcCurrencyRegistrar.isInitialized,
-    lsmCurrencyRegistrar.isInitialized,
     priceStore.isInitialized,
     price24HChangesStore.isInitialized,
     uiConfigStore.isInitialized,

--- a/apps/extension/src/stores/root.tsx
+++ b/apps/extension/src/stores/root.tsx
@@ -32,7 +32,6 @@ import {
   SecretQueries,
   ICNSQueries,
   AgoricQueries,
-  LSMCurrencyRegistrar,
   TokenFactoryCurrencyRegistrar,
   NobleQueries,
   NobleAccount,
@@ -185,7 +184,6 @@ export class RootStore {
 
   public readonly tokenFactoryRegistrar: TokenFactoryCurrencyRegistrar;
   public readonly ibcCurrencyRegistrar: IBCCurrencyRegistrar;
-  public readonly lsmCurrencyRegistrar: LSMCurrencyRegistrar;
   public readonly gravityBridgeCurrencyRegistrar: GravityBridgeCurrencyRegistrar;
   public readonly axelarEVMBridgeCurrencyRegistrar: AxelarEVMBridgeCurrencyRegistrar;
   public readonly erc20CurrencyRegistrar: ERC20CurrencyRegistrar;
@@ -669,12 +667,6 @@ export class RootStore {
       undefined,
       process.env["KEPLR_EXT_TX_HISTORY_BASE_URL"] || "",
       "/chain-registry/yacar/cw20/{chainId}/cw20:{contractAddress}"
-    );
-    this.lsmCurrencyRegistrar = new LSMCurrencyRegistrar(
-      new ExtensionKVStore("store_lsm_currency_registrar"),
-      24 * 3600 * 1000,
-      this.chainStore,
-      this.queriesStore
     );
     this.gravityBridgeCurrencyRegistrar = new GravityBridgeCurrencyRegistrar(
       new ExtensionKVStore("store_gravity_bridge_currency_registrar"),


### PR DESCRIPTION
## Summary
- Extension에서 LSM currency registrar 인스턴스 생성, 초기화 체크, import 제거
- `packages/stores/src/lsm/` 코드 자체는 유지

## Test plan
- [ ] Extension typecheck 통과 확인 (완료)
- [ ] Extension 빌드 정상 확인
- [ ] LSM 토큰 미보유 계정에서 정상 동작 확인