### PR TITLE
fix(ibc-swap): pass full context on swap milestone events + fix debounce closure

### DIFF
--- a/apps/extension/src/pages/ibc-swap/hooks/use-swap-analytics.ts
+++ b/apps/extension/src/pages/ibc-swap/hooks/use-swap-analytics.ts
@@ -123,7 +123,9 @@ export const useSwapAnalytics = ({
               eventName === "swap_tx_success" ||
               eventName === "swap_tx_failed"
             ) {
-              delete aggregatedPropsRef.current[id];
+              // Read from payload: closure captures `id` from the first
+              // call that created this debounced fn, not the current quote.
+              delete aggregatedPropsRef.current[p["quote_id"]];
             }
           },
           100

--- a/apps/extension/src/pages/ibc-swap/index.tsx
+++ b/apps/extension/src/pages/ibc-swap/index.tsx
@@ -592,6 +592,29 @@ export const IBCSwapPage: FunctionComponent = observer(() => {
         let squidQuoteId: string | undefined;
         let requiresMultipleTxBundles: boolean = false;
 
+        // Direct context for swap milestone events. The analytics hook also
+        // merges from aggregatedPropsRef keyed by quote_id, but that cache
+        // can be empty on duplicate-route reuse — pass essentials directly.
+        const buildSwapMilestoneBaseProps = (): Record<string, any> => {
+          const formatChainIdentifier = (chainId: string): string => {
+            const id = ChainIdHelper.parse(chainId).identifier;
+            return Number.isNaN(parseInt(id, 10)) ? id : `eip155:${id}`;
+          };
+          const inAmount = swapConfigs.amountConfig.amount[0];
+          const inAmountUsd = inAmount
+            ? priceStore.calculatePrice(inAmount, "usd")?.toDec().toString()
+            : undefined;
+          return {
+            in_chain_identifier: formatChainIdentifier(inChainId),
+            in_coin_denom: inCurrency.coinDenom,
+            out_chain_identifier: formatChainIdentifier(outChainId),
+            out_coin_denom: outCurrency.coinDenom,
+            in_amount_raw: inAmount?.toCoin().amount.toString(),
+            in_amount_usd: inAmountUsd,
+            provider,
+          };
+        };
+
         uiConfigStore.ibcSwapConfig.setIsSwapExecuting(true, swapLoadingKey);
 
         const normalizeChainId = (chainId: string): string => {
@@ -1227,6 +1250,7 @@ export const IBCSwapPage: FunctionComponent = observer(() => {
             logEvent("swap_tx_submitted", {
               quote_id: quoteIdRef.current,
               is_hold_to_swap: holdToSwapEnabled,
+              ...buildSwapMilestoneBaseProps(),
             });
           }
 
@@ -1288,6 +1312,7 @@ export const IBCSwapPage: FunctionComponent = observer(() => {
           if (isSwap) {
             logEvent("swap_tx_success", {
               quote_id: quoteIdRef.current,
+              ...buildSwapMilestoneBaseProps(),
             });
           }
 
@@ -1386,6 +1411,7 @@ export const IBCSwapPage: FunctionComponent = observer(() => {
             if (isSwap) {
               logEvent("swap_sign_canceled", {
                 quote_id: quoteIdRef.current,
+                ...buildSwapMilestoneBaseProps(),
               });
             }
 
@@ -1396,6 +1422,7 @@ export const IBCSwapPage: FunctionComponent = observer(() => {
             logEvent("swap_tx_failed", {
               quote_id: quoteIdRef.current,
               error_message: e?.message,
+              ...buildSwapMilestoneBaseProps(),
             });
           }
 

--- a/apps/extension/src/pages/ibc-swap/index.tsx
+++ b/apps/extension/src/pages/ibc-swap/index.tsx
@@ -595,6 +595,7 @@ export const IBCSwapPage: FunctionComponent = observer(() => {
         // Direct context for swap milestone events. The analytics hook also
         // merges from aggregatedPropsRef keyed by quote_id, but that cache
         // can be empty on duplicate-route reuse — pass essentials directly.
+        // Omit undefined keys so aggregation fills them in when available.
         const buildSwapMilestoneBaseProps = (): Record<string, any> => {
           const formatChainIdentifier = (chainId: string): string => {
             const id = ChainIdHelper.parse(chainId).identifier;
@@ -604,15 +605,18 @@ export const IBCSwapPage: FunctionComponent = observer(() => {
           const inAmountUsd = inAmount
             ? priceStore.calculatePrice(inAmount, "usd")?.toDec().toString()
             : undefined;
-          return {
+          const props: Record<string, any> = {
             in_chain_identifier: formatChainIdentifier(inChainId),
             in_coin_denom: inCurrency.coinDenom,
             out_chain_identifier: formatChainIdentifier(outChainId),
             out_coin_denom: outCurrency.coinDenom,
-            in_amount_raw: inAmount?.toCoin().amount.toString(),
-            in_amount_usd: inAmountUsd,
-            provider,
           };
+          if (inAmount) {
+            props["in_amount_raw"] = inAmount.toCoin().amount.toString();
+          }
+          if (inAmountUsd !== undefined) props["in_amount_usd"] = inAmountUsd;
+          if (provider !== undefined) props["provider"] = provider;
+          return props;
         };
 
         uiConfigStore.ibcSwapConfig.setIsSwapExecuting(true, swapLoadingKey);

--- a/apps/extension/src/pages/ibc-swap/index.tsx
+++ b/apps/extension/src/pages/ibc-swap/index.tsx
@@ -592,32 +592,35 @@ export const IBCSwapPage: FunctionComponent = observer(() => {
         let squidQuoteId: string | undefined;
         let requiresMultipleTxBundles: boolean = false;
 
-        // Direct context for swap milestone events. The analytics hook also
-        // merges from aggregatedPropsRef keyed by quote_id, but that cache
-        // can be empty on duplicate-route reuse — pass essentials directly.
-        // Omit undefined keys so aggregation fills them in when available.
-        const buildSwapMilestoneBaseProps = (): Record<string, any> => {
-          const formatChainIdentifier = (chainId: string): string => {
-            const id = ChainIdHelper.parse(chainId).identifier;
-            return Number.isNaN(parseInt(id, 10)) ? id : `eip155:${id}`;
-          };
-          const inAmount = swapConfigs.amountConfig.amount[0];
-          const inAmountUsd = inAmount
-            ? priceStore.calculatePrice(inAmount, "usd")?.toDec().toString()
-            : undefined;
-          const props: Record<string, any> = {
-            in_chain_identifier: formatChainIdentifier(inChainId),
-            in_coin_denom: inCurrency.coinDenom,
-            out_chain_identifier: formatChainIdentifier(outChainId),
-            out_coin_denom: outCurrency.coinDenom,
-          };
-          if (inAmount) {
-            props["in_amount_raw"] = inAmount.toCoin().amount.toString();
-          }
-          if (inAmountUsd !== undefined) props["in_amount_usd"] = inAmountUsd;
-          if (provider !== undefined) props["provider"] = provider;
-          return props;
+        // Snapshot context at submit time so every milestone event for this
+        // submit attempt carries the same values (priceStore may refresh
+        // between submitted and success otherwise). `provider` is added in
+        // the try block once the quote response is read.
+        const formatChainIdentifier = (chainId: string): string => {
+          const id = ChainIdHelper.parse(chainId).identifier;
+          return Number.isNaN(parseInt(id, 10)) ? id : `eip155:${id}`;
         };
+        const inAmountAtSubmit = swapConfigs.amountConfig.amount[0];
+        const inAmountUsdAtSubmit = inAmountAtSubmit
+          ? priceStore
+              .calculatePrice(inAmountAtSubmit, "usd")
+              ?.toDec()
+              .toString()
+          : undefined;
+        const swapMilestoneBase: Record<string, any> = {
+          in_chain_identifier: formatChainIdentifier(inChainId),
+          in_coin_denom: inCurrency.coinDenom,
+          out_chain_identifier: formatChainIdentifier(outChainId),
+          out_coin_denom: outCurrency.coinDenom,
+        };
+        if (inAmountAtSubmit) {
+          swapMilestoneBase["in_amount_raw"] = inAmountAtSubmit
+            .toCoin()
+            .amount.toString();
+        }
+        if (inAmountUsdAtSubmit !== undefined) {
+          swapMilestoneBase["in_amount_usd"] = inAmountUsdAtSubmit;
+        }
 
         uiConfigStore.ibcSwapConfig.setIsSwapExecuting(true, swapLoadingKey);
 
@@ -697,6 +700,7 @@ export const IBCSwapPage: FunctionComponent = observer(() => {
           }
 
           provider = queryRoute.response.data.provider;
+          swapMilestoneBase["provider"] = provider;
           routeDurationSeconds = queryRoute.response.data.estimated_time;
 
           for (const chainId of requiredChainIds) {
@@ -1254,7 +1258,7 @@ export const IBCSwapPage: FunctionComponent = observer(() => {
             logEvent("swap_tx_submitted", {
               quote_id: quoteIdRef.current,
               is_hold_to_swap: holdToSwapEnabled,
-              ...buildSwapMilestoneBaseProps(),
+              ...swapMilestoneBase,
             });
           }
 
@@ -1316,7 +1320,7 @@ export const IBCSwapPage: FunctionComponent = observer(() => {
           if (isSwap) {
             logEvent("swap_tx_success", {
               quote_id: quoteIdRef.current,
-              ...buildSwapMilestoneBaseProps(),
+              ...swapMilestoneBase,
             });
           }
 
@@ -1415,7 +1419,7 @@ export const IBCSwapPage: FunctionComponent = observer(() => {
             if (isSwap) {
               logEvent("swap_sign_canceled", {
                 quote_id: quoteIdRef.current,
-                ...buildSwapMilestoneBaseProps(),
+                ...swapMilestoneBase,
               });
             }
 
@@ -1426,7 +1430,7 @@ export const IBCSwapPage: FunctionComponent = observer(() => {
             logEvent("swap_tx_failed", {
               quote_id: quoteIdRef.current,
               error_message: e?.message,
-              ...buildSwapMilestoneBaseProps(),
+              ...swapMilestoneBase,
             });
           }
 


### PR DESCRIPTION
## Summary

Swap milestone 이벤트(`swap_tx_submitted / success / canceled / failed`)에서 chain/denom/provider/amount 프로퍼티가 일부 비어 기록되는 이슈 수정. 같은 submit 안의 여러 이벤트가 서로 다른 값(특히 USD 가격)으로 기록되던 것도 함께 해결.

## Root Cause

1. Call site는 `{quote_id, error_message}`만 넘기고 나머지는 analytics 훅의 aggregation 캐시 병합에 의존. duplicate-route 가드 경로에서 `quote_id`가 재사용되면 캐시가 비어 병합 불가.
2. Debounce cleanup이 closure에 캡처된 `id`로 aggregation을 삭제 — 이후 호출 시 다른 quote의 캐시를 잘못 지움 (mobile은 이미 수정됨).
3. Call site에서 함수로 chain info를 매번 재계산하면, submitted/success 사이 priceStore refresh로 `in_amount_usd`가 달라질 수 있음 (멱등성 없음).

## Changes

- `use-swap-analytics.ts`: debounce cleanup이 payload의 `quote_id`를 사용하도록 수정.
- `index.tsx`:
  - submit 시작 시점에 `swapMilestoneBase` 지역 const로 chain/denom/amount/amount_usd 스냅샷. `provider`는 quote 응답 읽은 직후 동일 객체에 주입.
  - 4개 milestone call site 모두 동일 참조를 spread → 같은 submit 내 값 일관성 보장.
  - `provider` 등 undefined일 수 있는 필드는 객체에서 제외해 aggregation이 채울 여지를 남김.

## Test plan

- [ ] Cosmos 스왑 실패 — 이벤트에 chain/denom/provider 기록 확인
- [ ] EVM 스왑 실패 — 동일 확인
- [ ] 동일 pair 반복 스왑 — 두 번째 시도에서도 정상 기록
- [ ] 사용자 거부(Request rejected) — \`swap_sign_canceled\`에 기록 확인
- [ ] 같은 submit의 submitted / success 이벤트에서 \`in_amount_usd\` 일치 확인