### PR TITLE
Remove legacy Terra chain message type overrides

### DIFF
--- a/apps/extension/src/stores/root.tsx
+++ b/apps/extension/src/stores/root.tsx
@@ -480,23 +480,6 @@ export class RootStore {
             };
           }
 
-          // For terra related chains
-          if (
-            chainId.startsWith("bombay-") ||
-            chainId.startsWith("columbus-")
-          ) {
-            return {
-              send: {
-                native: {
-                  type: "bank/MsgSend",
-                },
-              },
-              withdrawRewards: {
-                type: "distribution/MsgWithdrawDelegationReward",
-              },
-            };
-          }
-
           if (chainId.startsWith("evmos_") || chainId.startsWith("planq_")) {
             return {
               send: {


### PR DESCRIPTION
## Summary
- Drop `bombay-`/`columbus-` (Terra Classic) chain ID handling in `RootStore` msg opts
- These networks are no longer supported, so the per-chain overrides are dead code

## Test plan
- [ ] Typecheck passes: `yarn workspace @keplr-wallet/extension typecheck`
- [ ] Verify no other references to `bombay-`/`columbus-` remain in UI code paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)