### PR TITLE
fix: align EVM low fee multiplier with background tx executor

### DIFF
--- a/packages/hooks-evm/src/tx/evm-fee-utils.ts
+++ b/packages/hooks-evm/src/tx/evm-fee-utils.ts
@@ -17,7 +17,7 @@ export const ETH_FEE_SETTINGS_BY_FEE_TYPE: Record<
 > = {
   low: {
     percentile: ETH_FEE_HISTORY_REWARD_PERCENTILES[0],
-    baseFeePercentageMultiplier: new Dec(1),
+    baseFeePercentageMultiplier: new Dec(1.1),
   },
   average: {
     percentile: ETH_FEE_HISTORY_REWARD_PERCENTILES[1],


### PR DESCRIPTION
## Summary

- `hooks-evm`의 Low fee 옵션이 `baseFeePercentageMultiplier = 1.0` (margin 0)을 사용하던 것을 `1.1`로 상향. `background/tx-executor`는 이미 `1.1`이라 두 위치를 정렬.
- Average (1.25) / High (1.5)는 의도적으로 손대지 않음 — 과거 튜닝이 명확하고 Amplitude상 해당 클래스 fail 0건.

## Why

지난 60일 `swap_tx_failed` 진단:

| Error | Source chain | Count |
|---|---|---:|
| `max fee per gas less than block base fee` | **Arbitrum One** | **23** |
| (same error) | 다른 EVM (Ethereum/Base/Optimism/Polygon/BSC) | **0** |

관측 페이로드 패턴:
```
maxFeePerGas: 20,000,000   baseFee: 20,012,000   (gap 0.06%)
maxFeePerGas: 20,022,000   baseFee: 20,572,000   (gap 2.7%)
maxFeePerGas: 20,128,000   baseFee: 20,446,000   (gap 1.6%)
```

`maxFeePerGas`가 일관되게 **20,000,000 wei = 0.02 gwei** 근처 — Arbitrum의 프로토콜 minimum baseFee floor (2025-11에 0.01→0.02 gwei로 상향). Low의 1.0× multiplier + Arbitrum의 거의 0인 priority fee 조합으로 `maxFeePerGas`가 floor에 수렴 → sign 후 inclusion 사이의 미세 baseFee 변동(보통 0.06~2.7%)에 reject.

다른 EVM에서 같은 에러가 0건인 이유: dynamic baseFee + priority fee headroom으로 작은 변동 흡수.

같은 author가 `background/tx-executor`에서는 이미 1.1로 설정 (commit `0b8165a9d`, 2025-12-01)했으나 `hooks-evm`에 propagate 누락 → swap/EVM transfer가 hooks-evm을 거치므로 1.0이 그대로 남아 있었음.

## 예상 효과

- Amplitude 관측 23건 중 22건(95.7%) 즉시 방지
- 1건 outlier (`baseFee 23,004,000`)는 ArbOS Dia (2026-01) 이전 데이터로 추정. Dia 이후엔 거의 미발생 예상. 재발 시 Low를 1.2로 추가 상향 검토
- **사용자 비용 변화 없음**: EIP-1559 환불 메커니즘 — `maxFeePerGas`의 미사용분은 환불됨
- 다른 EVM 영향 없음 (Average/High 미변경)

## Test plan

- [x] `yarn workspace @keplr-wallet/hooks-evm typecheck` — pass
- [ ] Local 수동: Arbitrum One에서 Low fee 옵션으로 swap 성공 확인
- [ ] 머지 후 모니터링: Amplitude `swap_tx_failed` + `error_message contains "less than block base fee"` 추적 (T+7d, T+14d)
- [ ] Ethereum/Base/Optimism Low-fee swap 정상 동작 회귀 확인

## Follow-up (별 PR)

- `packages/hooks-evm/src/tx/evm-fee-utils.ts`와 `packages/background/src/tx-executor/utils/evm.ts`에 같은 의미의 fee multiplier가 분산. 단일 source-of-truth로 모으는 리팩토링 필요 (이번 회귀의 근본 원인).
- background tx-executor에는 `MAX_PRIORITY_FEE_UPPER_BOUND` + Polygon special-case가 누락됨. hooks-evm과 정렬 필요.
- `apps/extension/.../ibc-history-view/index.tsx`에 EVM fee 상수가 하드코딩 중복. 공통 상수 import로 교체 필요.