### PR TITLE
feat: shadow Injective EVM USD when Cosmos Injective is enabled

### DIFF
--- a/apps/extension/src/config.ts
+++ b/apps/extension/src/config.ts
@@ -3709,3 +3709,19 @@ export const CommunityChainInfoRepo = {
 };
 
 export const TokenContractListURL = "https://kcr-token-lambda.keplr.app";
+
+// Mirror chain rules: when `primary` is enabled, listed `denoms` on the key
+// chain can be excluded from duplicate USD display/aggregation. Non-listed
+// denoms (EVM-only assets) keep their prices.
+export const USD_AGGREGATION_SHADOWED_BY: Record<
+  string,
+  {
+    primary: { chainId: string; coinMinimalDenom: string };
+    denoms: ReadonlySet<string>;
+  }
+> = {
+  "eip155:1776": {
+    primary: { chainId: "injective-1", coinMinimalDenom: "inj" },
+    denoms: new Set(["injective-native"]),
+  },
+};

--- a/apps/extension/src/hooks/use-spendable-total-price.ts
+++ b/apps/extension/src/hooks/use-spendable-total-price.ts
@@ -2,9 +2,16 @@ import { useMemo } from "react";
 import { useStore } from "../stores";
 import { PricePretty } from "@keplr-wallet/unit";
 import { ChainIdHelper } from "@keplr-wallet/cosmos";
+import { isUsdAggregationShadowedByVisiblePrimaryAsset } from "../utils/is-usd-aggregation-shadowed-by-visible-primary-asset";
 
 export function useSpendablePrice() {
-  const { hugeQueriesStore, uiConfigStore, keyRingStore } = useStore();
+  const {
+    chainStore,
+    hugeQueriesStore,
+    keyRingStore,
+    priceStore,
+    uiConfigStore,
+  } = useStore();
 
   const disabledViewAssetTokenMap =
     uiConfigStore.manageViewAssetTokenConfig.getViewAssetTokenMapByVaultId(
@@ -18,19 +25,37 @@ export function useSpendablePrice() {
         ChainIdHelper.parse(bal.chainInfo.chainId).identifier
       );
 
+      if (disabledCoinSet?.has(bal.token.currency.coinMinimalDenom)) {
+        continue;
+      }
+
       if (
-        bal.price &&
-        !disabledCoinSet?.has(bal.token.currency.coinMinimalDenom)
+        isUsdAggregationShadowedByVisiblePrimaryAsset(
+          chainStore,
+          disabledViewAssetTokenMap,
+          bal.chainInfo.chainId,
+          bal.token.currency.coinMinimalDenom
+        )
       ) {
+        continue;
+      }
+
+      const price = bal.price ?? priceStore.calculatePrice(bal.token);
+      if (price) {
         if (!result) {
-          result = bal.price;
+          result = price;
         } else {
-          result = result.add(bal.price);
+          result = result.add(price);
         }
       }
     }
     return result;
-  }, [hugeQueriesStore.allKnownBalances, disabledViewAssetTokenMap]);
+  }, [
+    chainStore,
+    hugeQueriesStore.allKnownBalances,
+    disabledViewAssetTokenMap,
+    priceStore,
+  ]);
 
   return {
     spendableTotalPrice,

--- a/apps/extension/src/pages/main/components/token/grouped.tsx
+++ b/apps/extension/src/pages/main/components/token/grouped.tsx
@@ -27,6 +27,7 @@ import { useCopyAddress } from "../../../../hooks/use-copy-address";
 import { CoinPretty, PricePretty } from "@keplr-wallet/unit";
 import { Tooltip } from "../../../../components/tooltip";
 import { EarnBox } from "./earn-box";
+import { isUsdAggregationShadowedByVisiblePrimaryAsset } from "../../../../utils/is-usd-aggregation-shadowed-by-visible-primary-asset";
 
 const NestedTokenItemContainer = styled.div<{ tagPosition: string }>`
   background-color: transparent;
@@ -52,13 +53,25 @@ const NestedTokenItem: FunctionComponent<{
   viewToken: ViewToken;
   onClick?: () => void;
 }> = observer(({ viewToken, onClick }) => {
-  const { priceStore, uiConfigStore } = useStore();
+  const { chainStore, keyRingStore, priceStore, uiConfigStore } = useStore();
   const theme = useTheme();
   const [isHover, setIsHover] = useState(false);
 
   const copyAddress = useCopyAddress(viewToken);
 
-  const pricePretty = priceStore.calculatePrice(viewToken.token);
+  const disabledViewAssetTokenMap =
+    uiConfigStore.manageViewAssetTokenConfig.getViewAssetTokenMapByVaultId(
+      keyRingStore.selectedKeyInfo?.id ?? ""
+    );
+  const shouldHidePrice = isUsdAggregationShadowedByVisiblePrimaryAsset(
+    chainStore,
+    disabledViewAssetTokenMap,
+    viewToken.chainInfo.chainId,
+    viewToken.token.currency.coinMinimalDenom
+  );
+  const pricePretty = shouldHidePrice
+    ? undefined
+    : viewToken.price ?? priceStore.calculatePrice(viewToken.token);
 
   const tag = useTokenTag(viewToken);
 
@@ -338,22 +351,25 @@ export const GroupedTokenItem: FunctionComponent<{
     onTokenClick,
   }) => {
     const [isOpen, setIsOpen] = useState(!!alwaysOpen);
-    const { priceStore } = useStore();
+    const { priceStore, chainStore } = useStore();
     const [, setSearchParams] = useSearchParams();
 
-    const mainToken = tokens[0];
-
-    const totalBalance = useMemo(() => {
-      let sum = tokens[0].token.clone();
-      for (let i = 1; i < tokens.length; i++) {
-        sum = sum.addDifferentDenoms(tokens[i].token);
-      }
-      return sum;
-    }, [tokens]);
-
-    const totalPrice = useMemo(() => {
-      return priceStore.calculatePrice(totalBalance);
-    }, [priceStore, totalBalance]);
+    const aggregatable = tokens.filter(
+      (t) =>
+        !chainStore.isUsdAggregationShadowed(
+          t.chainInfo.chainId,
+          t.token.currency.coinMinimalDenom
+        )
+    );
+    // aggregatable이 비는 케이스는 도달 불가: shadow rule의 primary chain이
+    // enabled여야 shadow가 트리거되는데, primary chain의 token은 shadow되지 않음.
+    const mainToken = aggregatable[0] ?? tokens[0];
+    const base = aggregatable.length > 0 ? aggregatable : tokens;
+    let totalBalance = base[0].token.clone();
+    for (let i = 1; i < base.length; i++) {
+      totalBalance = totalBalance.addDifferentDenoms(base[i].token);
+    }
+    const totalPrice = priceStore.calculatePrice(totalBalance);
 
     const uniqueChainIds = useMemo(() => {
       return [...new Set(tokens.map((token) => token.chainInfo.chainId))];
@@ -430,6 +446,7 @@ export const GroupedTokenItem: FunctionComponent<{
           earnedAssetPrice={earnedAssetPrice}
           showPrice24HChange={showPrice24HChange}
           copyAddress={copyAddress}
+          hideUsdAggregationShadowPrice
         />
       );
     }

--- a/apps/extension/src/pages/main/components/token/index.tsx
+++ b/apps/extension/src/pages/main/components/token/index.tsx
@@ -40,6 +40,7 @@ import { PriceChangeTag } from "./price-change-tag";
 import { TokenTag } from "./token-tag";
 import { CopyAddressButton } from "./copy-address-button";
 import { EarnBox } from "./earn-box";
+import { isUsdAggregationShadowedByVisiblePrimaryAsset } from "../../../../utils/is-usd-aggregation-shadowed-by-visible-primary-asset";
 
 export const TokenTitleView: FunctionComponent<{
   title: string;
@@ -109,6 +110,7 @@ interface TokenItemProps {
   showPrice24HChange?: boolean;
   disableHoverStyle?: boolean;
   right?: React.ReactElement;
+  hideUsdAggregationShadowPrice?: boolean;
 
   bottomTagType?: BottomTagType;
   earnedAssetPrice?: string;
@@ -134,20 +136,36 @@ export const TokenItem: FunctionComponent<TokenItemProps> = observer(
     showPrice24HChange,
     disableHoverStyle,
     right,
+    hideUsdAggregationShadowPrice,
     bottomTagType,
     earnedAssetPrice,
     noTokenTag,
     isLoading,
     stakingApr,
   }) => {
-    const { priceStore, uiConfigStore } = useStore();
+    const { chainStore, keyRingStore, priceStore, uiConfigStore } = useStore();
     const navigate = useNavigate();
     const intl = useIntl();
     const theme = useTheme();
 
     const [isHover, setIsHover] = useState(false);
 
-    const pricePretty = priceStore.calculatePrice(viewToken.token);
+    const disabledViewAssetTokenMap =
+      uiConfigStore.manageViewAssetTokenConfig.getViewAssetTokenMapByVaultId(
+        keyRingStore.selectedKeyInfo?.id ?? ""
+      );
+    const shouldHidePrice =
+      hideUsdAggregationShadowPrice &&
+      isUsdAggregationShadowedByVisiblePrimaryAsset(
+        chainStore,
+        disabledViewAssetTokenMap,
+        viewToken.chainInfo.chainId,
+        viewToken.token.currency.coinMinimalDenom
+      );
+
+    const pricePretty = shouldHidePrice
+      ? undefined
+      : viewToken.price ?? priceStore.calculatePrice(viewToken.token);
 
     const isIBC = useMemo(() => {
       return viewToken.token.currency.coinMinimalDenom.startsWith("ibc/");

--- a/apps/extension/src/pages/main/index.tsx
+++ b/apps/extension/src/pages/main/index.tsx
@@ -18,6 +18,7 @@ import {
 } from "./components";
 import { Stack } from "../../components/stack";
 import { CoinPretty, Dec, PricePretty } from "@keplr-wallet/unit";
+import { ChainIdHelper } from "@keplr-wallet/cosmos";
 import { EyeIcon, EyeSlashIcon, RightArrowIcon } from "../../components/icon";
 import { Box } from "../../components/box";
 import { Modal } from "../../components/modal";
@@ -50,10 +51,12 @@ import { EmptyStateButtonRow } from "./components/empty-state-button-row";
 import { useNavigate } from "react-router";
 import { useTotalPrices } from "../../hooks/use-total-prices";
 import SimpleBarCore from "simplebar-core";
+import { isUsdAggregationShadowedByVisiblePrimaryAsset } from "../../utils/is-usd-aggregation-shadowed-by-visible-primary-asset";
 
 export interface ViewToken {
   token: CoinPretty;
   chainInfo: IModularChainInfoImpl;
+  price?: PricePretty;
   isFetching: boolean;
   error: QueryError<any> | undefined;
 }
@@ -113,6 +116,7 @@ export const MainPage: FunctionComponent<{
 }> = observer(({ setIsNotReady }) => {
   const {
     hugeQueriesStore,
+    chainStore,
     uiConfigStore,
     keyRingStore,
     priceStore,
@@ -128,25 +132,52 @@ export const MainPage: FunctionComponent<{
     setIsNotReadyRef.current(isNotReady);
   }, [isNotReady]);
 
+  const disabledViewAssetTokenMap =
+    uiConfigStore.manageViewAssetTokenConfig.getViewAssetTokenMapByVaultId(
+      keyRingStore.selectedKeyInfo?.id ?? ""
+    );
+
   const availableTotalPriceEmbedOnlyUSD = useMemo(() => {
     let result: PricePretty | undefined;
     for (const bal of hugeQueriesStore.allKnownBalances) {
       if (!bal.chainInfo.embedded.isBuiltInChain) {
         continue;
       }
-      if (bal.price) {
-        const price = priceStore.calculatePrice(bal.token, "usd");
-        if (price) {
-          if (!result) {
-            result = price;
-          } else {
-            result = result.add(price);
-          }
+
+      const disabledCoinSet = disabledViewAssetTokenMap.get(
+        ChainIdHelper.parse(bal.chainInfo.chainId).identifier
+      );
+      if (disabledCoinSet?.has(bal.token.currency.coinMinimalDenom)) {
+        continue;
+      }
+
+      if (
+        isUsdAggregationShadowedByVisiblePrimaryAsset(
+          chainStore,
+          disabledViewAssetTokenMap,
+          bal.chainInfo.chainId,
+          bal.token.currency.coinMinimalDenom
+        )
+      ) {
+        continue;
+      }
+
+      const price = priceStore.calculatePrice(bal.token, "usd");
+      if (price) {
+        if (!result) {
+          result = price;
+        } else {
+          result = result.add(price);
         }
       }
     }
     return result;
-  }, [hugeQueriesStore.allKnownBalances, priceStore]);
+  }, [
+    chainStore,
+    disabledViewAssetTokenMap,
+    hugeQueriesStore.allKnownBalances,
+    priceStore,
+  ]);
 
   const {
     spendableTotalPrice,

--- a/apps/extension/src/pages/main/spendable.tsx
+++ b/apps/extension/src/pages/main/spendable.tsx
@@ -274,6 +274,7 @@ const TokenItemWithCopyAddress: FunctionComponent<{
         onClick={onClick}
         copyAddress={copyAddress}
         showPrice24HChange={showPrice24HChange}
+        hideUsdAggregationShadowPrice
       />
     );
   }

--- a/apps/extension/src/pages/manage-chains/components/nested-token-item.tsx
+++ b/apps/extension/src/pages/manage-chains/components/nested-token-item.tsx
@@ -13,6 +13,7 @@ import { CurrencyImageFallback } from "../../../components/image";
 import { ColorPalette } from "../../../styles";
 import { useTokenTag } from "../../../hooks/use-token-tag";
 import { TokenTag } from "../../main/components/token/token-tag";
+import { isUsdAggregationShadowedByVisiblePrimaryAsset } from "../../../utils/is-usd-aggregation-shadowed-by-visible-primary-asset";
 
 const Container = styled.div`
   background-color: transparent;
@@ -26,7 +27,7 @@ interface NestedTokenItemProps {
 
 export const NestedTokenItem: FunctionComponent<NestedTokenItemProps> =
   observer(({ viewToken }) => {
-    const { uiConfigStore, priceStore } = useStore();
+    const { chainStore, keyRingStore, priceStore, uiConfigStore } = useStore();
     const theme = useTheme();
 
     const tag = useTokenTag(viewToken);
@@ -43,7 +44,19 @@ export const NestedTokenItem: FunctionComponent<NestedTokenItemProps> =
       );
     }, [uiConfigStore, viewToken.token]);
 
-    const pricePretty = priceStore.calculatePrice(viewToken.token);
+    const disabledViewAssetTokenMap =
+      uiConfigStore.manageViewAssetTokenConfig.getViewAssetTokenMapByVaultId(
+        keyRingStore.selectedKeyInfo?.id ?? ""
+      );
+    const shouldHidePrice = isUsdAggregationShadowedByVisiblePrimaryAsset(
+      chainStore,
+      disabledViewAssetTokenMap,
+      viewToken.chainInfo.chainId,
+      viewToken.token.currency.coinMinimalDenom
+    );
+    const pricePretty = shouldHidePrice
+      ? undefined
+      : viewToken.price ?? priceStore.calculatePrice(viewToken.token);
 
     const priceText = useMemo(() => {
       return uiConfigStore.hideStringIfPrivacyMode(

--- a/apps/extension/src/pages/manage-chains/index.tsx
+++ b/apps/extension/src/pages/manage-chains/index.tsx
@@ -44,6 +44,7 @@ import {
 import { determineLedgerApp } from "../../utils/determine-ledger-app";
 import { COMMON_HOVER_OPACITY } from "../../styles/constant";
 import { isChainSupportedByKeyType } from "../../utils/is-chain-supported-by-key-type";
+import { isUsdAggregationShadowedByVisiblePrimaryAsset } from "../../utils/is-usd-aggregation-shadowed-by-visible-primary-asset";
 
 export const Ecosystem = {
   All: "All",
@@ -62,7 +63,13 @@ const HideEnabledText = styled(Subtitle4)`
 `;
 
 export const ManageChainsPage: FunctionComponent = observer(() => {
-  const { chainStore, hugeQueriesStore, keyRingStore, priceStore } = useStore();
+  const {
+    chainStore,
+    hugeQueriesStore,
+    keyRingStore,
+    priceStore,
+    uiConfigStore,
+  } = useStore();
   const intl = useIntl();
   const [searchParams] = useSearchParams();
   const initialSearchValue = searchParams.get("initialSearchValue") ?? "";
@@ -232,13 +239,29 @@ export const ManageChainsPage: FunctionComponent = observer(() => {
   );
 
   const tokensByIdentifier = hugeQueriesStore.allTokenMapByChainIdentifier;
+  const disabledViewAssetTokenMap =
+    uiConfigStore.manageViewAssetTokenConfig.getViewAssetTokenMapByVaultId(
+      keyRingStore.selectedKeyInfo?.id ?? ""
+    );
 
   const totalPriceByIdentifier = useMemo(() => {
     const map = new Map<string, Dec>();
 
     tokensByIdentifier.forEach((tokens, identifier) => {
       const total = tokens.reduce((sum, viewToken) => {
-        const price = priceStore.calculatePrice(viewToken.token);
+        if (
+          isUsdAggregationShadowedByVisiblePrimaryAsset(
+            chainStore,
+            disabledViewAssetTokenMap,
+            viewToken.chainInfo.chainId,
+            viewToken.token.currency.coinMinimalDenom
+          )
+        ) {
+          return sum;
+        }
+
+        const price =
+          viewToken.price ?? priceStore.calculatePrice(viewToken.token);
         return price ? sum.add(price.toDec()) : sum;
       }, new Dec(0));
 
@@ -246,7 +269,7 @@ export const ManageChainsPage: FunctionComponent = observer(() => {
     });
 
     return map;
-  }, [tokensByIdentifier, priceStore]);
+  }, [chainStore, disabledViewAssetTokenMap, priceStore, tokensByIdentifier]);
 
   const sortPriorityChainIdentifierMap = useMemo(() => {
     const m = new Map<string, boolean>();

--- a/apps/extension/src/pages/manage-view-asset-token-list/index.tsx
+++ b/apps/extension/src/pages/manage-view-asset-token-list/index.tsx
@@ -29,6 +29,7 @@ import { useSearch } from "../../hooks/use-search";
 import { ViewToken } from "../main";
 import { CoinPretty } from "@keplr-wallet/unit";
 import { sortByPrice } from "../../utils/token-sort";
+import { isUsdAggregationShadowedByVisiblePrimaryAsset } from "../../utils/is-usd-aggregation-shadowed-by-visible-primary-asset";
 
 const searchFields = [
   {
@@ -47,8 +48,13 @@ const searchFields = [
 ];
 
 export const ManageViewAssetTokenListPage: FunctionComponent = observer(() => {
-  const { hugeQueriesStore, keyRingStore, uiConfigStore, chainStore } =
-    useStore();
+  const {
+    hugeQueriesStore,
+    keyRingStore,
+    uiConfigStore,
+    chainStore,
+    priceStore,
+  } = useStore();
   const intl = useIntl();
   const [sortMode, setSortMode] = useState<"asc" | "desc" | undefined>(
     undefined
@@ -82,23 +88,43 @@ export const ManageViewAssetTokenListPage: FunctionComponent = observer(() => {
     allowIBCToken: true,
     enableFilterDisabledAssetToken: false,
   });
-  const [search, setSearch] = useState("");
-  const searchedBalances = useSearch([...allBalances], search, searchFields);
-  const sortedBalances = useMemo(() => {
-    const searchedBalancesSliced = [...searchedBalances];
-    if (sortMode === "asc") {
-      return searchedBalancesSliced.sort((a, b) => -sortByPrice(a, b));
-    } else if (sortMode === "desc") {
-      return searchedBalancesSliced.sort(sortByPrice);
-    } else {
-      return searchedBalancesSliced;
-    }
-  }, [searchedBalances, sortMode]);
-
   const disabledTokenMap =
     uiConfigStore.manageViewAssetTokenConfig.getViewAssetTokenMapByVaultId(
       keyRingStore.selectedKeyInfo?.id ?? ""
     );
+  const [search, setSearch] = useState("");
+  const searchedBalances = useSearch([...allBalances], search, searchFields);
+  const sortedBalances = useMemo(() => {
+    const searchedBalancesSliced = [...searchedBalances];
+    const sortByVisiblePrice = (a: ViewToken, b: ViewToken) => {
+      const getPrice = (viewToken: ViewToken) => {
+        if (
+          isUsdAggregationShadowedByVisiblePrimaryAsset(
+            chainStore,
+            disabledTokenMap,
+            viewToken.chainInfo.chainId,
+            viewToken.token.currency.coinMinimalDenom
+          )
+        ) {
+          return undefined;
+        }
+        return viewToken.price ?? priceStore.calculatePrice(viewToken.token);
+      };
+
+      return sortByPrice(
+        { token: a.token, price: getPrice(a) },
+        { token: b.token, price: getPrice(b) }
+      );
+    };
+
+    if (sortMode === "asc") {
+      return searchedBalancesSliced.sort((a, b) => -sortByVisiblePrice(a, b));
+    } else if (sortMode === "desc") {
+      return searchedBalancesSliced.sort(sortByVisiblePrice);
+    } else {
+      return searchedBalancesSliced;
+    }
+  }, [chainStore, disabledTokenMap, priceStore, searchedBalances, sortMode]);
 
   const handleDisableToken = async (
     chainId: string,
@@ -234,6 +260,7 @@ export const ManageViewAssetTokenListPage: FunctionComponent = observer(() => {
                 }}
                 key={`${viewToken.chainInfo.chainId}-${viewToken.token.currency.coinMinimalDenom}`}
                 viewToken={viewToken}
+                hideUsdAggregationShadowPrice
                 right={
                   <XAxis>
                     <Gutter size="0.5rem" />

--- a/apps/extension/src/pages/setting/index.tsx
+++ b/apps/extension/src/pages/setting/index.tsx
@@ -37,6 +37,7 @@ import { useIntl } from "react-intl";
 import { HeaderLayout } from "../../layouts/header";
 import { BackButton } from "../../layouts/header/components";
 import { useGetIcnsName } from "../../hooks/use-get-icns-name";
+import { isUsdAggregationShadowedByVisiblePrimaryAsset } from "../../utils/is-usd-aggregation-shadowed-by-visible-primary-asset";
 
 export const SettingPage: FunctionComponent = observer(() => {
   const navigate = useNavigate();
@@ -437,8 +438,14 @@ const TopSection: FunctionComponent<{
     onClick?: () => void;
   }[];
 }> = observer(({ items }) => {
-  const { accountStore, keyRingStore, uiConfigStore, hugeQueriesStore } =
-    useStore();
+  const {
+    accountStore,
+    chainStore,
+    keyRingStore,
+    priceStore,
+    uiConfigStore,
+    hugeQueriesStore,
+  } = useStore();
 
   const navigate = useNavigate();
   const theme = useTheme();
@@ -461,19 +468,37 @@ const TopSection: FunctionComponent<{
         ChainIdHelper.parse(bal.chainInfo.chainId).identifier
       );
 
+      if (disabledCoinSet?.has(bal.token.currency.coinMinimalDenom)) {
+        continue;
+      }
+
       if (
-        bal.price &&
-        !disabledCoinSet?.has(bal.token.currency.coinMinimalDenom)
+        isUsdAggregationShadowedByVisiblePrimaryAsset(
+          chainStore,
+          disabledViewAssetTokenMap,
+          bal.chainInfo.chainId,
+          bal.token.currency.coinMinimalDenom
+        )
       ) {
+        continue;
+      }
+
+      const price = bal.price ?? priceStore.calculatePrice(bal.token);
+      if (price) {
         if (!result) {
-          result = bal.price;
+          result = price;
         } else {
-          result = result.add(bal.price);
+          result = result.add(price);
         }
       }
     }
     return result;
-  }, [hugeQueriesStore.allKnownBalances, disabledViewAssetTokenMap]);
+  }, [
+    chainStore,
+    hugeQueriesStore.allKnownBalances,
+    disabledViewAssetTokenMap,
+    priceStore,
+  ]);
 
   const stakedTotalPrice = useMemo(() => {
     let result: PricePretty | undefined;

--- a/apps/extension/src/stores/chain/index.tsx
+++ b/apps/extension/src/stores/chain/index.tsx
@@ -44,6 +44,7 @@ import {
 import { BACKGROUND_PORT, MessageRequester } from "@keplr-wallet/router";
 import { KVStore, toGenerator } from "@keplr-wallet/common";
 import { ChainIdHelper } from "@keplr-wallet/cosmos";
+import { USD_AGGREGATION_SHADOWED_BY } from "../../config";
 
 export type RequiredCurrencyTokenScan = Omit<
   TokenScan,
@@ -372,6 +373,24 @@ export class ChainStore extends BaseChainStore {
   isEnabledChain(chainId: string): boolean {
     const chainIdentifier = ChainIdHelper.parse(chainId).identifier;
     return this.enabledChainIdentifiesMap.get(chainIdentifier) === true;
+  }
+
+  getUsdAggregationShadowPrimaryAsset(
+    chainId: string,
+    coinMinimalDenom: string
+  ): { chainId: string; coinMinimalDenom: string } | undefined {
+    const rule = USD_AGGREGATION_SHADOWED_BY[chainId];
+    if (!rule) return;
+    if (!rule.denoms.has(coinMinimalDenom)) return;
+    if (!this.isEnabledChain(rule.primary.chainId)) return;
+    return rule.primary;
+  }
+
+  isUsdAggregationShadowed(chainId: string, coinMinimalDenom: string): boolean {
+    return !!this.getUsdAggregationShadowPrimaryAsset(
+      chainId,
+      coinMinimalDenom
+    );
   }
 
   @computed

--- a/apps/extension/src/stores/huge-queries/index.ts
+++ b/apps/extension/src/stores/huge-queries/index.ts
@@ -145,6 +145,22 @@ export class HugeQueriesStore {
       );
   }
 
+  protected calculateViewTokenPrice(
+    modularChainInfo: IModularChainInfoImpl,
+    balance: CoinPretty
+  ): PricePretty | undefined {
+    if (
+      this.chainStore.isUsdAggregationShadowed(
+        modularChainInfo.chainId,
+        balance.currency.coinMinimalDenom
+      )
+    ) {
+      return undefined;
+    }
+    if (!balance.currency.coinGeckoId) return undefined;
+    return this.priceStore.calculatePrice(balance);
+  }
+
   @action
   protected updateBalances() {
     const keysUsed = new Map<string, boolean>();
@@ -223,9 +239,7 @@ export class HugeQueriesStore {
               this.balanceBinarySort.pushAndSort(key, {
                 chainInfo: modularChainInfo,
                 token: balance,
-                price: currency.coinGeckoId
-                  ? this.priceStore.calculatePrice(balance)
-                  : undefined,
+                price: this.calculateViewTokenPrice(modularChainInfo, balance),
                 isFetching: queryBalance.stakable.isFetching,
                 error: queryBalance.stakable.error,
               });
@@ -265,9 +279,10 @@ export class HugeQueriesStore {
                 this.balanceBinarySort.pushAndSort(key, {
                   chainInfo: modularChainInfo,
                   token: balance.balance,
-                  price: currency.coinGeckoId
-                    ? this.priceStore.calculatePrice(balance.balance)
-                    : undefined,
+                  price: this.calculateViewTokenPrice(
+                    modularChainInfo,
+                    balance.balance
+                  ),
                   isFetching: balance.isFetching,
                   error: balance.error,
                 });
@@ -320,9 +335,10 @@ export class HugeQueriesStore {
               this.balanceBinarySort.pushAndSort(key, {
                 chainInfo: modularChainInfo,
                 token: balance.balance,
-                price: currency.coinGeckoId
-                  ? this.priceStore.calculatePrice(balance.balance)
-                  : undefined,
+                price: this.calculateViewTokenPrice(
+                  modularChainInfo,
+                  balance.balance
+                ),
                 isFetching: balance.isFetching,
                 error: balance.error,
               });
@@ -376,9 +392,10 @@ export class HugeQueriesStore {
             this.balanceBinarySort.pushAndSort(key, {
               chainInfo: modularChainInfo,
               token: queryBalance.balance,
-              price: currency.coinGeckoId
-                ? this.priceStore.calculatePrice(queryBalance.balance)
-                : undefined,
+              price: this.calculateViewTokenPrice(
+                modularChainInfo,
+                queryBalance.balance
+              ),
               isFetching: queryBalance.isFetching,
               error: queryBalance.error,
             });
@@ -416,9 +433,10 @@ export class HugeQueriesStore {
           this.balanceBinarySort.pushAndSort(key, {
             chainInfo: modularChainInfo,
             token: queryBalance.balance,
-            price: currency.coinGeckoId
-              ? this.priceStore.calculatePrice(queryBalance.balance)
-              : undefined,
+            price: this.calculateViewTokenPrice(
+              modularChainInfo,
+              queryBalance.balance
+            ),
             isFetching: queryBalance.isFetching,
             error: queryBalance.error,
           });
@@ -518,9 +536,7 @@ export class HugeQueriesStore {
             tokensByChainId.get(chainIdentifier)!.push({
               chainInfo: modularChainInfo,
               token: balance,
-              price: currency.coinGeckoId
-                ? this.priceStore.calculatePrice(balance)
-                : undefined,
+              price: this.calculateViewTokenPrice(modularChainInfo, balance),
               isFetching: queryBalance.stakable.isFetching,
               error: queryBalance.stakable.error,
             });
@@ -552,9 +568,10 @@ export class HugeQueriesStore {
               tokensByChainId.get(chainIdentifier)!.push({
                 chainInfo: modularChainInfo,
                 token: balance.balance,
-                price: currency.coinGeckoId
-                  ? this.priceStore.calculatePrice(balance.balance)
-                  : undefined,
+                price: this.calculateViewTokenPrice(
+                  modularChainInfo,
+                  balance.balance
+                ),
                 isFetching: balance.isFetching,
                 error: balance.error,
               });
@@ -610,9 +627,10 @@ export class HugeQueriesStore {
             tokensByChainId.get(chainIdentifier)!.push({
               chainInfo: modularChainInfo,
               token: balance.balance,
-              price: currency.coinGeckoId
-                ? this.priceStore.calculatePrice(balance.balance)
-                : undefined,
+              price: this.calculateViewTokenPrice(
+                modularChainInfo,
+                balance.balance
+              ),
               isFetching: balance.isFetching,
               error: balance.error,
             });
@@ -655,9 +673,10 @@ export class HugeQueriesStore {
           tokensByChainId.get(chainIdentifier)!.push({
             chainInfo: modularChainInfo,
             token: queryBalance.balance,
-            price: currency.coinGeckoId
-              ? this.priceStore.calculatePrice(queryBalance.balance)
-              : undefined,
+            price: this.calculateViewTokenPrice(
+              modularChainInfo,
+              queryBalance.balance
+            ),
             isFetching: queryBalance.isFetching,
             error: queryBalance.error,
           });
@@ -679,7 +698,10 @@ export class HugeQueriesStore {
             tokensByChainId.get(chainIdentifier)!.push({
               chainInfo: modularChainInfo,
               token: balance.balance,
-              price: this.priceStore.calculatePrice(balance.balance),
+              price: this.calculateViewTokenPrice(
+                modularChainInfo,
+                balance.balance
+              ),
               isFetching: balance.isFetching,
               error: balance.error,
             });
@@ -713,7 +735,10 @@ export class HugeQueriesStore {
                 tokensByChainId.get(chainIdentifier)!.push({
                   chainInfo: linkedChain,
                   token: balance.balance,
-                  price: this.priceStore.calculatePrice(balance.balance),
+                  price: this.calculateViewTokenPrice(
+                    linkedChain,
+                    balance.balance
+                  ),
                   isFetching: balance.isFetching,
                   error: balance.error,
                 });

--- a/apps/extension/src/utils/is-usd-aggregation-shadowed-by-visible-primary-asset.ts
+++ b/apps/extension/src/utils/is-usd-aggregation-shadowed-by-visible-primary-asset.ts
@@ -1,0 +1,21 @@
+import { ChainIdHelper } from "@keplr-wallet/cosmos";
+
+import type { ChainStore } from "../stores/chain";
+
+export function isUsdAggregationShadowedByVisiblePrimaryAsset(
+  chainStore: ChainStore,
+  disabledViewAssetTokenMap: ReadonlyMap<string, ReadonlySet<string>>,
+  chainId: string,
+  coinMinimalDenom: string
+): boolean {
+  const primaryAsset = chainStore.getUsdAggregationShadowPrimaryAsset(
+    chainId,
+    coinMinimalDenom
+  );
+  if (!primaryAsset) return false;
+
+  const disabledPrimaryCoinSet = disabledViewAssetTokenMap.get(
+    ChainIdHelper.parse(primaryAsset.chainId).identifier
+  );
+  return !disabledPrimaryCoinSet?.has(primaryAsset.coinMinimalDenom);
+}


### PR DESCRIPTION
## Summary

Injective exposes the same assets via both `injective-1` (Cosmos) and `eip155:1776` (EVM) through cosmos/evm module. When both chains are enabled, balances are double-counted in USD totals.

This PR skips USD pricing for `eip155:1776` tokens when `injective-1` is enabled. Asset list, send, swap, and other UX unchanged.

## Approach

- `USD_AGGREGATION_SHADOWED_BY` pair map in config
- `ChainStore.isUsdAggregationShadowed(chainId)` returns true only when the primary cosmos chain is enabled
- `huge-queries.calculateViewTokenPrice` helper applies the gate at ViewToken creation
- Token row components read `viewToken.price` instead of calling `priceStore` directly
- Token group `totalBalance` excludes shadowed chain amounts

## Test plan

- [ ] Both chains enabled: portfolio total counts INJ once
- [ ] Cosmos only / EVM only: normal totals
- [ ] Toggle cosmos off: EVM price reappears immediately
- [ ] INJ row groups cosmos + EVM into one entry
- [ ] Expanded group: cosmos row shows USD, EVM row blank
- [ ] manage-chains sort: EVM row sinks to USD 0 when shadowed
- [ ] No regression on EVM send/swap

## Notes

- Token detail balance USD not gated (market info, low frequency)
- Mobile app: separate follow-up