### PR TITLE
fix(send): strip requiredErc20Approvals before bridge sendEthereumTx

### DIFF
--- a/apps/extension/src/pages/send/amount/index.tsx
+++ b/apps/extension/src/pages/send/amount/index.tsx
@@ -1450,6 +1450,15 @@ export const SendAmountPage: FunctionComponent = observer(() => {
                     hasApprovalTxWhenBridge = true;
                   }
 
+                  // requiredErc20Approvals는 caller-side 메타데이터이므로
+                  // ethers serialize에 도달하기 전에 제거해야 한다. 별도 erc20
+                  // approval tx를 먼저 보내는 분기 (아래 onFulfill)에는 이미
+                  // strip이 있지만, approval이 불필요한 경우 (allowance 충분)
+                  // tx가 빈 배열을 메타데이터로 가진 채 그대로 spread 되면
+                  // ethers v5가 invalid object key 에러를 던진다.
+                  delete (tx as UnsignedEVMTransactionWithErc20Approvals)
+                    .requiredErc20Approvals;
+
                   await ethereumAccount.sendEthereumTx(
                     sender,
                     {

--- a/packages/stores-eth/src/account/base.ts
+++ b/packages/stores-eth/src/account/base.ts
@@ -601,14 +601,22 @@ export class EthereumAccountBase {
         EthSignType.TRANSACTION
       );
 
+      // requiredErc20Approvals는 swap path가 메타데이터로 주입하는 비표준 키.
+      // ethers serialize()는 unknown key에 대해 invalid object key 에러를 던지므로
+      // signEthereumTx와 동일하게 직렬화 직전에 제거한다.
+      const { requiredErc20Approvals: _, ...txToSerialize } =
+        unsignedTx as UnsignedTransaction & {
+          requiredErc20Approvals?: unknown;
+        };
+
       const isEIP1559 =
-        !!unsignedTx.maxFeePerGas || !!unsignedTx.maxPriorityFeePerGas;
+        !!txToSerialize.maxFeePerGas || !!txToSerialize.maxPriorityFeePerGas;
       if (isEIP1559) {
-        unsignedTx.type = TransactionTypes.eip1559;
+        txToSerialize.type = TransactionTypes.eip1559;
       }
 
       const signedTx = Buffer.from(
-        serialize(unsignedTx, signature).replace("0x", ""),
+        serialize(txToSerialize, signature).replace("0x", ""),
         "hex"
       );
 

--- a/packages/stores-eth/src/account/base.ts
+++ b/packages/stores-eth/src/account/base.ts
@@ -601,22 +601,14 @@ export class EthereumAccountBase {
         EthSignType.TRANSACTION
       );
 
-      // requiredErc20Approvals는 swap path가 메타데이터로 주입하는 비표준 키.
-      // ethers serialize()는 unknown key에 대해 invalid object key 에러를 던지므로
-      // signEthereumTx와 동일하게 직렬화 직전에 제거한다.
-      const { requiredErc20Approvals: _, ...txToSerialize } =
-        unsignedTx as UnsignedTransaction & {
-          requiredErc20Approvals?: unknown;
-        };
-
       const isEIP1559 =
-        !!txToSerialize.maxFeePerGas || !!txToSerialize.maxPriorityFeePerGas;
+        !!unsignedTx.maxFeePerGas || !!unsignedTx.maxPriorityFeePerGas;
       if (isEIP1559) {
-        txToSerialize.type = TransactionTypes.eip1559;
+        unsignedTx.type = TransactionTypes.eip1559;
       }
 
       const signedTx = Buffer.from(
-        serialize(txToSerialize, signature).replace("0x", ""),
+        serialize(unsignedTx, signature).replace("0x", ""),
         "hex"
       );
 


### PR DESCRIPTION
## Summary

Bridge mode (send page → "다른 체인으로 보내기")에서 ERC20 allowance가 이미 충분한 사용자가 broadcast 단계에서 `invalid object key - requiredErc20Approvals` 에러로 실패하는 케이스 수정.

## Cause

`amountConfig.getTx()`는 EVM 응답에 `requiredErc20Approvals`를 메타데이터로 부착 (`apps/hooks-internal/src/ibc-swap/amount.ts:601`). bridge 흐름의 첫 번째 `sendEthereumTx` (line 1453)는 `...(erc20ApprovalTx ?? tx)`로 spread하는데, allowance 충분 → Skip이 빈 배열 반환 → `erc20ApprovalTx`가 `undefined` → `tx` fallback에서 빈 배열 메타데이터가 그대로 spread → ethers v5 serialize 실패.

후속 `sendEthereumTx` (line 1597, onFulfill 안)는 line 1565의 `delete tx.requiredErc20Approvals`로 이미 안전. 같은 strip을 첫 번째 호출 직전에 동일하게 적용.

## Found via

7-day Amplitude `swap_tx_failed`:
- BSC → injective: 2
- (none) → (none): 2

모두 same-asset cross-chain bridge에서 발생 (swap이 아님).

## Test plan

- [ ] 이미 approve된 BSC ERC20을 Injective로 bridge — 정상 broadcast 확인
- [ ] 처음 approve가 필요한 토큰을 bridge — 기존 approval flow regression 없음
- [ ] Amplitude live event tail에서 `requiredErc20Approvals` error 사라짐 확인