### PR TITLE
feat(injective): merge eip155:1776 into injective-1 (ethermint)

### DIFF
--- a/apps/extension/src/config.ts
+++ b/apps/extension/src/config.ts
@@ -873,6 +873,11 @@ export const EmbedChainInfos: (ChainInfo | ModularChainInfo)[] = [
   {
     rpc: "https://rpc-injective.keplr.app",
     rest: "https://lcd-injective.keplr.app",
+    evm: {
+      chainId: 1776,
+      rpc: "https://sentry.evm-rpc.injective.network",
+      websocket: "wss://sentry.evm-ws.injective.network",
+    },
     chainId: "injective-1",
     chainName: "Injective",
     stakeCurrency: {

--- a/apps/extension/src/pages/main/hooks/use-get-addresses-copy-address.ts
+++ b/apps/extension/src/pages/main/hooks/use-get-addresses-copy-address.ts
@@ -129,10 +129,6 @@ export const useGetAddressesOnCopyAddress = (search: string) => {
             return undefined;
           }
 
-          if (modularChainInfo.chainId.startsWith("injective")) {
-            return undefined;
-          }
-
           return accountInfo.hasEthereumHexAddress
             ? accountInfo.ethereumHexAddress
             : undefined;

--- a/apps/extension/src/pages/send/amount/index.tsx
+++ b/apps/extension/src/pages/send/amount/index.tsx
@@ -548,9 +548,7 @@ export const SendAmountPage: FunctionComponent = observer(() => {
     10,
     isEvmTx,
     {
-      allowHexAddressToBech32Address:
-        destModularChainInfo.type === "ethermint" &&
-        !modularChainInfo.chainId.startsWith("injective"),
+      allowHexAddressToBech32Address: destModularChainInfo.type === "ethermint",
       allowHexAddressOnly: destModularChainInfo.type === "evm",
       icns: ICNSInfo,
       ens: ENSInfo,
@@ -591,10 +589,7 @@ export const SendAmountPage: FunctionComponent = observer(() => {
     isEvmTx,
     {
       allowHexAddressToBech32Address:
-        chainType !== "evm" &&
-        chainType !== "ethermint" &&
-        !isEvmTx &&
-        !modularChainInfo.chainId.startsWith("injective"),
+        chainType !== "evm" && chainType !== "ethermint" && !isEvmTx,
       allowHexAddressOnly: isEvmTx,
       icns: ICNSInfo,
       ens: ENSInfo,

--- a/apps/extension/src/pages/setting/contacts/add/index.tsx
+++ b/apps/extension/src/pages/setting/contacts/add/index.tsx
@@ -64,8 +64,7 @@ export const SettingContactsAdd: FunctionComponent = observer(() => {
       chainStore.hasModularChain(chainId) &&
       chainStore.getModularChain(chainId).type !== "starknet" &&
       chainStore.getModularChain(chainId).type !== "bitcoin" &&
-      chainStore.getModularChain(chainId).type !== "evm" &&
-      !chainId.startsWith("injective"),
+      chainStore.getModularChain(chainId).type !== "evm",
     icns: uiConfigStore.icnsInfo,
     ens: ENSInfo,
   });

--- a/packages/background/src/chains/service.ts
+++ b/packages/background/src/chains/service.ts
@@ -283,6 +283,31 @@ export class ChainsService {
       });
     }
 
+    // injective-1 entry now embeds the EVM side (chainId 1776) as an
+    // ethermint chain, so the standalone `eip155:1776` suggestion is no
+    // longer needed and would only cause asset double-counting.
+    // Drop it once; onChainRemoved propagates cleanup to enabled chains,
+    // ERC20 tokens, and dApp permissions.
+    {
+      const done = await this.kvStore.get<boolean>(
+        "migration/remove-injective-evm"
+      );
+      if (!done) {
+        const targetIdentifier = ChainIdHelper.parse("eip155:1776").identifier;
+        const target = this.suggestedChainInfos.find(
+          (c) => ChainIdHelper.parse(c.chainId).identifier === targetIdentifier
+        );
+        if (target) {
+          try {
+            this.removeSuggestedChainInfo(target.chainId);
+          } catch (e) {
+            console.warn("Failed to remove eip155:1776 during migration:", e);
+          }
+        }
+        await this.kvStore.set("migration/remove-injective-evm", true);
+      }
+    }
+
     runIfOnlyAppStart("analytics/test-cointypes", async () => {
       const coinTypes = new Map<number, boolean>();
       const chainInfos = this.getChainInfos();


### PR DESCRIPTION
## Summary

Unify the duplicated Injective Cosmos chain (`injective-1`) and Injective EVM chain (`eip155:1776`) into a single ethermint entry, so EVM dApps connect via the existing `injective-1` chain id and assets stop being double-counted.

- **`feat(injective): embed EVM chain info into injective-1`** — Add `evm: { chainId: 1776, rpc, websocket }` to the `injective-1` entry in `apps/extension/src/config.ts`, converting it to a `type: "ethermint"` ModularChainInfo. Also drop obsolete `chainId.startsWith("injective")` UI guards (deposit modal address listing, send recipient hex→bech32 conversion, contacts add) that dated to when `injective-1` was cosmos-only and only incidentally surfaced coinType-60 hex addresses. Backend `chainIsInjective` guards (signing, fee handling, ledger) are intentionally left as-is — they're for Injective's cosmos tx shape, unrelated to EVM-side UI exposure.
- **`feat(chains): one-time migration to drop legacy eip155:1776 suggestion`** — `ChainsService.init()` runs a one-time migration (key: `migration/remove-injective-evm`) that removes the standalone `eip155:1776` suggested chain if present. `removeSuggestedChainInfo` already propagates cleanup to vault-enabled chains, ERC20 tokens, and dApp permissions, so no extra wiring needed. Fresh profiles or users without the chain are no-ops.

## Out of scope (follow-up)

The EVM-side ERC20 currencies (wINJ, wETH, USDT) are intentionally not added in this PR. Injective MTS exposes them as `erc20:0x...` denoms on the cosmos bank module, and wiring those through the wallet's balance pipeline (HugeQueries routing, `ObservableQueryCosmosBalanceRegistry`, optionally registry json) needs its own change set. Will land separately.

## Test plan

- [ ] Fresh profile (or `eip155:1776` disabled): connect to a dApp on Injective EVM (Helix / Pumex), `wallet_switchEthereumChain(0x6f0)` should route to `injective-1`
- [ ] Send an EVM tx via dApp (e.g. Pumex swap) and confirm signing + broadcast on `injective-1`
- [ ] Cosmos signing still works: delegate INJ, send IBC transfer
- [ ] Deposit modal for Injective shows both `inj1...` and `0x...` entries (matches other ethermint chains)
- [ ] Send screen: pasting a `0x` recipient on Injective converts to `inj1...`
- [ ] Contacts: saving a `0x` recipient for Injective converts to `inj1...`
- [ ] Existing user with `eip155:1776` enabled: migration auto-removes the suggested chain on next launch (no manual action required)
- [ ] `migration/remove-injective-evm` marker is set after first run; subsequent inits no-op