### PR TITLE
Fix swap chain name analytics

### DIFF
--- a/apps/extension/src/pages/ibc-swap/hooks/use-swap-analytics.ts
+++ b/apps/extension/src/pages/ibc-swap/hooks/use-swap-analytics.ts
@@ -153,15 +153,11 @@ export const useSwapAnalytics = ({
     });
   });
 
-  const inChainIdentifier = ChainIdHelper.parse(inChainId).identifier;
-  const outChainIdentifier = ChainIdHelper.parse(outChainId).identifier;
+  const inChainIdentifier = formatChainIdentifierForAnalytics(inChainId);
+  const outChainIdentifier = formatChainIdentifierForAnalytics(outChainId);
 
-  const inChainName = chainStore.hasModularChain(inChainId)
-    ? chainStore.getModularChain(inChainId).chainName
-    : undefined;
-  const outChainName = chainStore.hasModularChain(outChainId)
-    ? chainStore.getModularChain(outChainId).chainName
-    : undefined;
+  const inChainName = getChainNameForAnalytics(chainStore, inChainId);
+  const outChainName = getChainNameForAnalytics(chainStore, outChainId);
 
   // source selected
   useEffect(() => {
@@ -465,10 +461,7 @@ function getChainProperties(
   denom: string,
   amount: string
 ): SwapChainAnalytics {
-  const _chainIdentifier = ChainIdHelper.parse(chainId).identifier;
-  const chainIdentifier = Number.isNaN(parseInt(_chainIdentifier, 10))
-    ? _chainIdentifier
-    : `eip155:${_chainIdentifier}`;
+  const chainIdentifier = formatChainIdentifierForAnalytics(chainId);
   const modularChainInfo = chainStore.hasModularChain(chainIdentifier)
     ? chainStore.getModularChain(chainIdentifier)
     : undefined;
@@ -494,4 +487,21 @@ function getChainProperties(
     amountUsd: price ? price.toDec().toString() : undefined,
     amountUsdValue: priceToNumber(price),
   };
+}
+
+function formatChainIdentifierForAnalytics(chainId: string): string {
+  const chainIdentifier = ChainIdHelper.parse(chainId).identifier;
+  return Number.isNaN(parseInt(chainIdentifier, 10))
+    ? chainIdentifier
+    : `eip155:${chainIdentifier}`;
+}
+
+function getChainNameForAnalytics(
+  chainStore: ReturnType<typeof useStore>["chainStore"],
+  chainId: string
+): string {
+  const chainIdentifier = formatChainIdentifierForAnalytics(chainId);
+  return chainStore.hasModularChain(chainIdentifier)
+    ? chainStore.getModularChain(chainIdentifier).chainName
+    : chainId;
 }

--- a/apps/extension/src/pages/ibc-swap/hooks/use-swap-analytics.ts
+++ b/apps/extension/src/pages/ibc-swap/hooks/use-swap-analytics.ts
@@ -491,9 +491,9 @@ function getChainProperties(
 
 function formatChainIdentifierForAnalytics(chainId: string): string {
   const chainIdentifier = ChainIdHelper.parse(chainId).identifier;
-  return Number.isNaN(parseInt(chainIdentifier, 10))
-    ? chainIdentifier
-    : `eip155:${chainIdentifier}`;
+  return /^\d+$/.test(chainIdentifier)
+    ? `eip155:${chainIdentifier}`
+    : chainIdentifier;
 }
 
 function getChainNameForAnalytics(

--- a/apps/extension/src/pages/ibc-swap/index.tsx
+++ b/apps/extension/src/pages/ibc-swap/index.tsx
@@ -2194,9 +2194,9 @@ const SpinnerIcon: FunctionComponent<{
 
 function formatChainIdentifierForAnalytics(chainId: string): string {
   const chainIdentifier = ChainIdHelper.parse(chainId).identifier;
-  return Number.isNaN(parseInt(chainIdentifier, 10))
-    ? chainIdentifier
-    : `eip155:${chainIdentifier}`;
+  return /^\d+$/.test(chainIdentifier)
+    ? `eip155:${chainIdentifier}`
+    : chainIdentifier;
 }
 
 function getChainNameForAnalytics(

--- a/apps/extension/src/pages/ibc-swap/index.tsx
+++ b/apps/extension/src/pages/ibc-swap/index.tsx
@@ -605,10 +605,6 @@ export const IBCSwapPage: FunctionComponent = observer(() => {
         // submit attempt carries the same values (priceStore may refresh
         // between submitted and success otherwise). `provider` is added in
         // the try block once the quote response is read.
-        const formatChainIdentifier = (chainId: string): string => {
-          const id = ChainIdHelper.parse(chainId).identifier;
-          return Number.isNaN(parseInt(id, 10)) ? id : `eip155:${id}`;
-        };
         const inAmountAtSubmit = swapConfigs.amountConfig.amount[0];
         const inAmountUsdPriceAtSubmit = inAmountAtSubmit
           ? priceStore.calculatePrice(inAmountAtSubmit, "usd")
@@ -627,9 +623,11 @@ export const IBCSwapPage: FunctionComponent = observer(() => {
           outAmountEstUsdPriceAtSubmit
         );
         const swapMilestoneBase: Record<string, any> = {
-          in_chain_identifier: formatChainIdentifier(inChainId),
+          in_chain_identifier: formatChainIdentifierForAnalytics(inChainId),
+          in_chain_name: getChainNameForAnalytics(chainStore, inChainId),
           in_coin_denom: inCurrency.coinDenom,
-          out_chain_identifier: formatChainIdentifier(outChainId),
+          out_chain_identifier: formatChainIdentifierForAnalytics(outChainId),
+          out_chain_name: getChainNameForAnalytics(chainStore, outChainId),
           out_coin_denom: outCurrency.coinDenom,
         };
         if (inAmountAtSubmit) {
@@ -2193,6 +2191,23 @@ const SpinnerIcon: FunctionComponent<{
     </SpinnerSvg>
   );
 };
+
+function formatChainIdentifierForAnalytics(chainId: string): string {
+  const chainIdentifier = ChainIdHelper.parse(chainId).identifier;
+  return Number.isNaN(parseInt(chainIdentifier, 10))
+    ? chainIdentifier
+    : `eip155:${chainIdentifier}`;
+}
+
+function getChainNameForAnalytics(
+  chainStore: ReturnType<typeof useStore>["chainStore"],
+  chainId: string
+): string {
+  const chainIdentifier = formatChainIdentifierForAnalytics(chainId);
+  return chainStore.hasModularChain(chainIdentifier)
+    ? chainStore.getModularChain(chainIdentifier).chainName
+    : chainId;
+}
 
 const noop = (..._args: any[]) => {
   // noop


### PR DESCRIPTION
## Summary

- Add direct `in_chain_name` and `out_chain_name` fields to swap tx milestone analytics payloads.
- Normalize swap analytics chain identifiers before chain name lookup so numeric EVM chain IDs resolve through `eip155:*`.
- Keep the existing quote-id aggregation path as a complement instead of the only source for chain names.

## Validation

- `yarn workspace @keplr-wallet/extension typecheck`
- `git diff --check`
- pre-commit `eslint` and `prettier --check`