### PR TITLE
[codex] Hide ERC20 assets from IBC transfer picker

### DIFF
--- a/apps/extension/src/pages/send/select-asset/index.tsx
+++ b/apps/extension/src/pages/send/select-asset/index.tsx
@@ -30,6 +30,7 @@ import { StackIcon } from "../../../components/icon/stack";
 import { useSearch } from "../../../hooks/use-search";
 import { ViewToken } from "../../main";
 import { EmptyView } from "../../../components/empty-view";
+import { canSelectAssetForIBCTransfer } from "./utils";
 
 const Styles = {
   Container: styled(Stack)<{ isNobleEarn: boolean }>`
@@ -106,12 +107,10 @@ export const SendSelectAssetPage: FunctionComponent = observer(() => {
   const _filteredTokens = useMemo(() => {
     if (paramIsIBCTransfer) {
       return searchedTokens.filter((token) => {
-        const u = token.chainInfo.unwrapped;
-        if (u.type !== "cosmos" && u.type !== "ethermint") {
-          return false;
-        }
-
-        return u.cosmos.features?.includes("ibc-transfer") ?? false;
+        return canSelectAssetForIBCTransfer(
+          token.chainInfo,
+          token.token.currency.coinMinimalDenom
+        );
       });
     }
 

--- a/apps/extension/src/pages/send/select-asset/utils.spec.ts
+++ b/apps/extension/src/pages/send/select-asset/utils.spec.ts
@@ -1,0 +1,60 @@
+import { canSelectAssetForIBCTransfer } from "./utils";
+
+const makeChainInfo = (type: string, features?: string[]) => ({
+  unwrapped: {
+    type,
+    cosmos: {
+      features,
+    },
+  },
+});
+
+describe("canSelectAssetForIBCTransfer", () => {
+  test("allows native denoms on IBC-enabled Cosmos chains", () => {
+    expect(
+      canSelectAssetForIBCTransfer(
+        makeChainInfo("cosmos", ["ibc-transfer"]),
+        "uatom"
+      )
+    ).toBe(true);
+  });
+
+  test("allows IBC voucher denoms because they are bank denoms", () => {
+    expect(
+      canSelectAssetForIBCTransfer(
+        makeChainInfo("cosmos", ["ibc-transfer"]),
+        "ibc/1234567890ABCDEF"
+      )
+    ).toBe(true);
+  });
+
+  test("allows native denoms on IBC-enabled Ethermint chains", () => {
+    expect(
+      canSelectAssetForIBCTransfer(
+        makeChainInfo("ethermint", ["ibc-transfer"]),
+        "inj"
+      )
+    ).toBe(true);
+  });
+
+  test("rejects Injective MTS ERC20 bank assets such as native USDC", () => {
+    expect(
+      canSelectAssetForIBCTransfer(
+        makeChainInfo("ethermint", ["ibc-transfer"]),
+        "erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a"
+      )
+    ).toBe(false);
+  });
+
+  test("rejects non-IBC chains and non-Cosmos chain types", () => {
+    expect(canSelectAssetForIBCTransfer(makeChainInfo("cosmos"), "uatom")).toBe(
+      false
+    );
+    expect(
+      canSelectAssetForIBCTransfer(
+        makeChainInfo("evm", ["ibc-transfer"]),
+        "ethereum-native"
+      )
+    ).toBe(false);
+  });
+});

--- a/apps/extension/src/pages/send/select-asset/utils.ts
+++ b/apps/extension/src/pages/send/select-asset/utils.ts
@@ -1,0 +1,26 @@
+import { DenomHelper } from "@keplr-wallet/common";
+
+type IBCTransferSelectableChainInfo = {
+  unwrapped: {
+    type: string;
+    cosmos?: {
+      features?: string[];
+    };
+  };
+};
+
+export function canSelectAssetForIBCTransfer(
+  chainInfo: IBCTransferSelectableChainInfo,
+  coinMinimalDenom: string
+): boolean {
+  const u = chainInfo.unwrapped;
+  if (u.type !== "cosmos" && u.type !== "ethermint") {
+    return false;
+  }
+
+  if (!(u.cosmos?.features?.includes("ibc-transfer") ?? false)) {
+    return false;
+  }
+
+  return new DenomHelper(coinMinimalDenom).type === "native";
+}


### PR DESCRIPTION
## Summary
- Filter Advanced IBC Transfer asset selection through a small utility that requires an IBC-enabled Cosmos/Ethermint chain and a bank/native denom.
- Keep existing native bank denoms and `ibc/...` vouchers selectable, while hiding `erc20:...` assets such as Injective native USDC.
- Add focused tests for Cosmos, Ethermint, IBC voucher, ERC20, and non-IBC cases.

## Why
Injective native USDC is exposed as an MTS ERC20 bank asset (`erc20:0xa00C...`). It can appear in balances, but the generic Advanced IBC Transfer flow only supports native bank denoms and would fail later for ERC20-prefixed assets. The picker should not offer those assets as IBC-transferable.

## Validation
- `yarn workspace @keplr-wallet/extension test src/pages/send/select-asset/utils.spec.ts --runInBand --watchman=false`
- `yarn workspace @keplr-wallet/extension typecheck`
- `npx prettier --check apps/extension/src/pages/send/select-asset/index.tsx apps/extension/src/pages/send/select-asset/utils.ts apps/extension/src/pages/send/select-asset/utils.spec.ts`